### PR TITLE
Add --dry-run flag to the wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ This downloads the repo into a folder called `av-pain-reliever` in your home dir
 
 You don't need to read any further unless you want to know exactly what to expect.
 
+### Want to see what would happen first?
+
+Add `--dry-run` to preview the install without actually doing anything. Nothing is downloaded, nothing is installed, no files are written. You'll still see every prompt and every step header — every "would do X" line tells you exactly what a real run would do at that point.
+
+```sh
+~/av-pain-reliever/wizard.sh --dry-run
+```
+
+You can also dry-run any other subcommand, like `add-location`:
+
+```sh
+~/av-pain-reliever/wizard.sh --dry-run add-location
+```
+
+Use this if you want to walk through the flow once before committing to it, or if you want to show a colleague what the install will look like on their Mac.
+
 ---
 
 ## What the wizard does (a walkthrough)

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -346,6 +346,25 @@ These are things we figured out the hard way that should bias the Swift design.
   go to Tools → WebSocket Server Settings, tick Enable, untick Auth, click
   OK" is better than "configure OBS websocket". Swift's first-run wizard
   should follow the same pattern.
+- **Dry-run is a valuable affordance, not a power-user feature.** The
+  Hammerspoon wizard now ships with `--dry-run` that walks the user
+  through the entire install flow, showing every command/install that
+  would have happened, without actually doing any of it. Useful for:
+  (a) previewing before committing to changes, (b) showing a colleague
+  what their install will look like, (c) demoing the app. Implementation:
+  every side-effect call goes through a `runcmd` or `runstep` wrapper
+  that checks a `DRY_RUN` env var. Read-only commands (pgrep, defaults
+  read, command -v) always run. Confirms always run (they're asking the
+  user, not doing work).
+  *Implication for Swift:* the first-run UI should have a "preview only"
+  toggle that walks through every screen without writing anything to
+  `~/Library/Application Support/AVPainReliever/` or running `obs-cmd`.
+  Same wrapper pattern: every side-effect operation in
+  `ProfileApplier`/`ConfigLoader`/`OBSController` checks an injected
+  `dryRun: Bool`. Probably easiest as a property on the dependency
+  injection container. The status bar UI could even have a permanent
+  "Preview mode" toggle for advanced users who want to see what the
+  next dock event WOULD trigger before letting it fire.
 
 ---
 

--- a/tests/test_dry_run.sh
+++ b/tests/test_dry_run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/test_dry_run.sh — verify the --dry-run flag plumbing.
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/wizard/lib.sh"
+
+WIZARD="$REPO_ROOT/wizard.sh"
+
+test_runcmd_executes_when_dry_run_off() {
+  DRY_RUN=0
+  local out
+  out=$(runcmd echo hello 2>&1)
+  assert_eq "hello" "$out"
+}
+
+test_runcmd_skips_when_dry_run_on() {
+  DRY_RUN=1
+  local out
+  out=$(runcmd touch /tmp/should-not-exist-$$ 2>&1)
+  if [[ -e "/tmp/should-not-exist-$$" ]]; then
+    rm -f "/tmp/should-not-exist-$$"
+    echo "touch happened despite DRY_RUN=1" >&2
+    return 1
+  fi
+  assert_contains "$out" "[dry-run]"
+  assert_contains "$out" "would run"
+}
+
+test_runstep_uses_description_when_dry_run_on() {
+  DRY_RUN=1
+  local out
+  out=$(runstep "regenerate the kitchen sink" echo this-should-not-print 2>&1)
+  assert_contains "$out" "[dry-run]"
+  assert_contains "$out" "regenerate the kitchen sink"
+  if [[ "$out" == *this-should-not-print* ]]; then
+    echo "underlying command ran despite DRY_RUN=1" >&2
+    return 1
+  fi
+}
+
+test_runstep_runs_underlying_command_when_dry_run_off() {
+  DRY_RUN=0
+  local out
+  out=$(runstep "fake description" echo real-output 2>&1)
+  assert_eq "real-output" "$out"
+}
+
+test_dryrun_banner_silent_when_off() {
+  DRY_RUN=0
+  local out
+  out=$(dryrun_banner 2>&1)
+  assert_eq "" "$out"
+}
+
+test_dryrun_banner_shown_when_on() {
+  DRY_RUN=1
+  local out
+  out=$(dryrun_banner 2>&1)
+  assert_contains "$out" "DRY-RUN MODE"
+}
+
+test_wizard_dispatcher_parses_dry_run_long_flag() {
+  # Use the help subcommand because it doesn't actually do anything; we just
+  # need to know the dispatcher accepted the flag without erroring.
+  assert_exit_code 0 "$WIZARD" --dry-run help
+}
+
+test_wizard_dispatcher_parses_dry_run_short_flag() {
+  assert_exit_code 0 "$WIZARD" -n help
+}
+
+test_wizard_help_mentions_dry_run() {
+  local out
+  out=$("$WIZARD" help 2>&1)
+  assert_contains "$out" "--dry-run"
+}
+
+test_wizard_status_runs_normally_with_dry_run_flag() {
+  # Status is read-only so dry-run is a no-op for it, but the flag should
+  # parse cleanly and not break anything.
+  assert_exit_code 0 "$WIZARD" --dry-run status
+}
+
+test_dry_run_default_is_zero() {
+  unset DRY_RUN
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/wizard/lib.sh"
+  assert_eq "0" "$DRY_RUN"
+}
+
+test_dry_run_respects_existing_env() {
+  export DRY_RUN=1
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/wizard/lib.sh"
+  assert_eq "1" "$DRY_RUN"
+  unset DRY_RUN
+}

--- a/wizard.sh
+++ b/wizard.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
 # wizard.sh — entry point for the av-pain-reliever onboarding wizard.
 # Usage:
-#   ./wizard.sh                  # full first-time install (default)
-#   ./wizard.sh install          # same as above
-#   ./wizard.sh add-location     # capture USB / audio for one new location
-#   ./wizard.sh status           # diagnostic: what's installed, what's running
+#   ./wizard.sh                        # full first-time install (default)
+#   ./wizard.sh install                # same as above
+#   ./wizard.sh add-location           # capture USB / audio for one new location
+#   ./wizard.sh status                 # diagnostic: what's installed, what's running
+#
+# Flags:
+#   --dry-run, -n   Show what would happen without doing it. Prompts still
+#                   appear so you can walk through the flow; nothing is
+#                   installed, nothing written, no commands run.
 
 # shellcheck disable=SC1091
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# Parse flags out of $@ before dispatching to the subcommand.
+DRY_RUN=0
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n)
+      DRY_RUN=1
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+export DRY_RUN
+set -- "${positional[@]:-}"
+
 source "$SCRIPT_DIR/wizard/lib.sh"
 
 cmd="${1:-install}"
@@ -30,12 +52,25 @@ case "$cmd" in
 av-pain-reliever wizard
 
 Usage:
-  $0                  Run the full first-time install (default).
-  $0 install          Same as above.
-  $0 add-location     Capture USB devices and audio for one new location.
-                      Run this while docked at the location you're capturing.
-  $0 status           Show what's installed, what's running, and the recent log.
-  $0 help             Show this message.
+  $0 [--dry-run] [command]
+
+Commands:
+  install          Run the full first-time install (default).
+  add-location     Capture USB devices and audio for one new location.
+                   Run this while docked at the location you're capturing.
+  status           Show what's installed, what's running, and the recent log.
+  help             Show this message.
+
+Flags:
+  --dry-run, -n    Walk through the flow without doing any actual work.
+                   Useful for previewing what install or add-location will do
+                   on your machine before committing to the changes.
+
+Examples:
+  $0                            # run the full install
+  $0 --dry-run install          # preview the install without doing it
+  $0 -n add-location            # preview a location capture
+  $0 status                     # diagnostic snapshot
 EOF
     ;;
   *)

--- a/wizard/add-location.sh
+++ b/wizard/add-location.sh
@@ -10,6 +10,8 @@ source "$LIB_DIR/lib.sh"
 
 bootstrap_gum
 
+dryrun_banner
+
 # ============================================================================
 # Step 1 — Pick which location to capture
 # ============================================================================
@@ -52,6 +54,9 @@ if [[ "$picked" == "+ Add a brand new location" ]]; then
   pretty=$(to_pretty "$slug")
   if grep -q "WIZARD_PROFILE_${slug}_BEGIN" "$PROFILES_FILE"; then
     info "Location '$pretty' already exists in profiles.lua. Reusing it."
+  elif [[ "$DRY_RUN" == "1" ]]; then
+    would "would append a new placeholder block for '$pretty' to profiles.lua"
+    would "would create matching OBS scene '$pretty' (if OBS reachable)"
   else
     tmpfile=$(mktemp)
     awk -v slug="$slug" -v pretty="$pretty" '
@@ -102,9 +107,10 @@ if ! grep -q "WIZARD_PROFILE_${slug}_BEGIN" "$PROFILES_FILE"; then
       [[ -n "$_s" ]] && all_pretty+=("$(to_pretty "$_s")")
     done < <(grep -oE '\["[^"]+"\] = \{' "$PROFILES_FILE" | sed -E 's/^\["//; s/"\] = \{$//')
     backup="$PROFILES_FILE.backup-$(date +%Y%m%d-%H%M%S)"
-    cp "$PROFILES_FILE" "$backup"
+    runcmd cp "$PROFILES_FILE" "$backup"
     info "Backed up to $backup"
-    "$LIB_DIR/_generate-profiles.sh" "${all_pretty[@]}"
+    runstep "would regenerate profiles.lua (locations: ${all_pretty[*]})" \
+      "$LIB_DIR/_generate-profiles.sh" "${all_pretty[@]}"
     success "profiles.lua migrated to wizard format"
   else
     fail "Can't update profile without anchor markers. Aborting."
@@ -136,8 +142,14 @@ info "I'm asking the engine to enumerate all currently-attached USB devices"
 info "and audio devices, and write the list to its log file. We'll read the"
 info "list from there in the next step."
 echo
-hammerspoon_reload_with_fallback
-sleep 2
+if [[ "$DRY_RUN" == "1" ]]; then
+  would "would reload Hammerspoon to refresh the device snapshot in the log"
+  info "(In dry-run mode I'll use the most recent existing snapshot from the log,"
+  info " if there is one, so you can still see what the picker would look like.)"
+else
+  hammerspoon_reload_with_fallback
+  sleep 2
+fi
 
 # ============================================================================
 # Step 4 — Parse the snapshot
@@ -260,14 +272,23 @@ trap 'rm -f "$fp_block"' EXIT
   done
 } > "$fp_block"
 
-"$LIB_DIR/_update-profile.sh" "$slug" "$audio_in" "$audio_out" "$fp_block" "$PROFILES_FILE"
+if [[ "$DRY_RUN" == "1" ]]; then
+  would "would update profiles.lua block for '$slug' with:"
+  while IFS= read -r fpline; do
+    would "    $fpline"
+  done < "$fp_block"
+  would "    audioInput  = \"$audio_in\""
+  would "    audioOutput = \"$audio_out\""
+else
+  "$LIB_DIR/_update-profile.sh" "$slug" "$audio_in" "$audio_out" "$fp_block" "$PROFILES_FILE"
+fi
 rm -f "$fp_block"
 trap - EXIT
 
 success "profiles.lua updated"
 
-# Quick syntax check.
-if command -v luac >/dev/null 2>&1; then
+# Quick syntax check (skipped in dry-run since nothing was written).
+if [[ "$DRY_RUN" != "1" ]] && command -v luac >/dev/null 2>&1; then
   if ! luac -p "$PROFILES_FILE" 2>/dev/null; then
     fail "profiles.lua has a syntax error after the edit. Restore from backup."
   fi
@@ -282,8 +303,12 @@ step "Step 10 — Apply the new profile"
 info "Reloading Hammerspoon so the engine picks up the new profile and"
 info "re-evaluates which one matches your current state."
 echo
-hammerspoon_reload_with_fallback
-sleep 2
+if [[ "$DRY_RUN" == "1" ]]; then
+  would "would reload Hammerspoon to apply the new profile"
+else
+  hammerspoon_reload_with_fallback
+  sleep 2
+fi
 
 # ============================================================================
 # Step 11 — Show what happened
@@ -316,7 +341,11 @@ if [[ -d "$REPO_ROOT/.git" ]]; then
   info "and you can sync them to a different Mac."
   echo
   if confirm "Commit and push profiles.lua now?"; then
-    if git -C "$REPO_ROOT" diff --quiet --exit-code -- profiles.lua; then
+    if [[ "$DRY_RUN" == "1" ]]; then
+      would "would 'git add profiles.lua'"
+      would "would 'git commit -m \"Add/update $pretty profile via wizard\"'"
+      would "would 'git push' (if a remote is configured)"
+    elif git -C "$REPO_ROOT" diff --quiet --exit-code -- profiles.lua; then
       info "No actual changes to commit (file already matched git's copy)."
     else
       git -C "$REPO_ROOT" add profiles.lua

--- a/wizard/install.sh
+++ b/wizard/install.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$LIB_DIR/lib.sh"
 
+dryrun_banner
+
 # ============================================================================
 # Step 1/15 — Pre-flight checks
 # ============================================================================
@@ -67,7 +69,7 @@ if [[ -d "/Applications/Hammerspoon.app" ]]; then
   success "Hammerspoon $hs_version already installed at /Applications/Hammerspoon.app"
 else
   info "Installing via Homebrew (this can take 30-60 seconds)..."
-  brew install --cask hammerspoon
+  runcmd brew install --cask hammerspoon
   success "Hammerspoon installed"
 fi
 
@@ -86,12 +88,12 @@ if [[ -d "/Applications/OBS.app" ]]; then
     success "OBS $obs_version already installed (28+, has obs-websocket built in)"
   else
     warn "OBS $obs_version is older than 28 — upgrading via Homebrew"
-    brew install --cask --force obs
+    runcmd brew install --cask --force obs
     success "OBS upgraded"
   fi
 else
   info "Installing via Homebrew (this can take 1-2 minutes)..."
-  brew install --cask obs
+  runcmd brew install --cask obs
   success "OBS installed"
 fi
 
@@ -111,17 +113,23 @@ if [[ -x "$OBS_CMD_PATH" ]]; then
 else
   ASSET=$(obs_cmd_asset)
   URL="https://github.com/grigio/obs-cmd/releases/latest/download/$ASSET"
-  info "Downloading $ASSET from grigio/obs-cmd releases..."
-  TMPDIR=$(mktemp -d)
-  trap 'rm -rf "$TMPDIR"' EXIT
-  curl -sSL -o "$TMPDIR/obs-cmd.tar.gz" "$URL"
-  tar -xzf "$TMPDIR/obs-cmd.tar.gz" -C "$TMPDIR"
-  info "Installing to $OBS_CMD_PATH (sudo password may be required)..."
-  sudo mv "$TMPDIR/obs-cmd" "$OBS_CMD_PATH"
-  sudo chmod +x "$OBS_CMD_PATH"
-  trap - EXIT
-  rm -rf "$TMPDIR"
-  success "obs-cmd installed: $($OBS_CMD_PATH --version)"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "would download $URL"
+    would "would extract obs-cmd binary from the tarball"
+    would "would sudo-move the binary to $OBS_CMD_PATH and chmod +x"
+  else
+    info "Downloading $ASSET from grigio/obs-cmd releases..."
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+    curl -sSL -o "$TMPDIR/obs-cmd.tar.gz" "$URL"
+    tar -xzf "$TMPDIR/obs-cmd.tar.gz" -C "$TMPDIR"
+    info "Installing to $OBS_CMD_PATH (sudo password may be required)..."
+    sudo mv "$TMPDIR/obs-cmd" "$OBS_CMD_PATH"
+    sudo chmod +x "$OBS_CMD_PATH"
+    trap - EXIT
+    rm -rf "$TMPDIR"
+    success "obs-cmd installed: $($OBS_CMD_PATH --version)"
+  fi
 fi
 
 # ============================================================================
@@ -141,8 +149,8 @@ if [[ -L "$HAMMERSPOON_DIR" ]]; then
     info "If you replace it, the existing link will be moved to a backup, not deleted."
     if confirm "Replace it with a link to this repo?"; then
       backup="$HAMMERSPOON_DIR.backup-$(date +%Y%m%d-%H%M%S)"
-      mv "$HAMMERSPOON_DIR" "$backup"
-      ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
+      runcmd mv "$HAMMERSPOON_DIR" "$backup"
+      runcmd ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
       success "Old link backed up to $backup"
       success "~/.hammerspoon -> $REPO_ROOT"
     else
@@ -158,15 +166,15 @@ elif [[ -e "$HAMMERSPOON_DIR" ]]; then
   info "Nothing is deleted; you can restore it later by removing the new symlink"
   info "and renaming the backup back to ~/.hammerspoon."
   if confirm "Move existing ~/.hammerspoon to backup and create the symlink?"; then
-    mv "$HAMMERSPOON_DIR" "$backup"
-    ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
+    runcmd mv "$HAMMERSPOON_DIR" "$backup"
+    runcmd ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
     success "Existing config backed up to $backup"
     success "~/.hammerspoon -> $REPO_ROOT"
   else
     fail "Can't proceed without ~/.hammerspoon pointing at this repo. Aborting."
   fi
 else
-  ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
+  runcmd ln -s "$REPO_ROOT" "$HAMMERSPOON_DIR"
   success "~/.hammerspoon -> $REPO_ROOT (created fresh)"
 fi
 
@@ -182,16 +190,20 @@ if pgrep -x Hammerspoon >/dev/null 2>&1; then
   success "Hammerspoon is already running"
 else
   info "Launching Hammerspoon..."
-  open -a Hammerspoon
-  sleep 2
+  runcmd open -a Hammerspoon
+  [[ "$DRY_RUN" != "1" ]] && sleep 2
 fi
 echo
 info "I'll open the System Settings → Privacy & Security → Accessibility pane"
 info "for you. Find Hammerspoon in the list and toggle the switch ON."
 info "(You'll be prompted for your Mac password — that's normal.)"
 echo
-open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" >/dev/null 2>&1 || true
-sleep 1
+if [[ "$DRY_RUN" == "1" ]]; then
+  would 'would open System Settings → Privacy & Security → Accessibility pane'
+else
+  open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" >/dev/null 2>&1 || true
+  sleep 1
+fi
 if confirm "Done — Hammerspoon is toggled ON in Accessibility?"; then
   success "Accessibility permission granted"
 else
@@ -261,21 +273,27 @@ if grep -q '^-- WIZARD_PROFILE_' "$PROFILES_FILE" 2>/dev/null; then
   if ! confirm "Overwrite anyway?"; then
     info "Keeping existing profiles.lua. Skipping generation."
   else
-    "$LIB_DIR/_generate-profiles.sh" "${locations[@]}"
+    runstep "would generate profiles.lua with ${#locations[@]} location(s): ${locations[*]}" \
+      "$LIB_DIR/_generate-profiles.sh" "${locations[@]}"
     success "profiles.lua regenerated with ${#locations[@]} location(s)"
   fi
 else
   if [[ -f "$PROFILES_FILE" ]]; then
     backup="$PROFILES_FILE.backup-$(date +%Y%m%d-%H%M%S)"
-    cp "$PROFILES_FILE" "$backup"
+    runcmd cp "$PROFILES_FILE" "$backup"
     info "Backed up existing profiles.lua to $backup"
   fi
-  "$LIB_DIR/_generate-profiles.sh" "${locations[@]}"
+  runstep "would generate profiles.lua with ${#locations[@]} location(s): ${locations[*]}" \
+    "$LIB_DIR/_generate-profiles.sh" "${locations[@]}"
   success "profiles.lua written with ${#locations[@]} location(s)"
 fi
 echo
 info "Asking Hammerspoon to reload its config so the new profiles are live..."
-hammerspoon_reload_with_fallback
+if [[ "$DRY_RUN" == "1" ]]; then
+  would "would reload Hammerspoon (osascript reload)"
+else
+  hammerspoon_reload_with_fallback
+fi
 
 # ============================================================================
 # Step 11/15 — Enable OBS WebSocket server
@@ -286,11 +304,14 @@ info "tools control it. We need to turn it on so obs-cmd can switch scenes."
 echo
 if ! pgrep -x OBS >/dev/null 2>&1; then
   info "Launching OBS (give it a few seconds to start)..."
-  open -a OBS
-  sleep 4
+  runcmd open -a OBS
+  [[ "$DRY_RUN" != "1" ]] && sleep 4
 fi
 if obs-cmd info >/dev/null 2>&1; then
   success "OBS WebSocket already enabled and reachable on localhost:4455"
+elif [[ "$DRY_RUN" == "1" ]]; then
+  would "would prompt you to enable OBS WebSocket server in Tools → WebSocket Server Settings"
+  would "would verify connection with: obs-cmd info"
 else
   echo
   info "Click into the OBS window. Then in the OBS menu bar at the top:"
@@ -328,6 +349,11 @@ info "API doesn't let us enumerate your physical cameras)."
 echo
 if [[ "${SKIP_OBS:-0}" == "1" ]]; then
   warn "Skipping (OBS WebSocket not reachable)."
+elif [[ "$DRY_RUN" == "1" ]]; then
+  for loc in "${locations[@]}"; do
+    pretty=$(to_pretty "$(to_slug "$loc")")
+    would "would create OBS scene '$pretty' (skipped if it already exists)"
+  done
 else
   existing_scenes=$(obs-cmd scene list 2>/dev/null || echo "")
   for loc in "${locations[@]}"; do
@@ -355,7 +381,7 @@ else
   info "will see as your camera. It persists across OBS launches; you only"
   info "need to do this once."
   echo
-  obs-cmd virtual-camera start >/dev/null 2>&1 || true
+  runcmd obs-cmd virtual-camera start
   success "Virtual camera started"
   echo
   info "Now add a camera source to each scene (one-time, ~30 seconds per scene):"
@@ -389,7 +415,7 @@ configure_app() {
     return
   fi
   info "Opening $app for you to configure..."
-  open -a "$app" >/dev/null 2>&1 || true
+  runcmd open -a "$app"
   echo
   info "In $app's settings:"
   info "  • Microphone → Same as System"
@@ -416,7 +442,13 @@ info "locations RIGHT NOW with everything plugged in (dock, monitor, mic,"
 info "speakers, anything else that's part of that setup)."
 echo
 if confirm "Are you docked at a location and ready to capture it now?"; then
-  "$LIB_DIR/add-location.sh"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "would launch the add-location subcommand to capture this dock setup"
+    info "(In a real run, this is where you'd pick USB devices, microphone,"
+    info " and speaker for your current location.)"
+  else
+    "$LIB_DIR/add-location.sh"
+  fi
 else
   info "No problem. Whenever you're ready, run:"
   info "  $REPO_ROOT/wizard.sh add-location"

--- a/wizard/lib.sh
+++ b/wizard/lib.sh
@@ -9,7 +9,84 @@ HAMMERSPOON_DIR="${HAMMERSPOON_DIR:-$HOME/.hammerspoon}"
 PROFILES_FILE="${PROFILES_FILE:-$REPO_ROOT/profiles.lua}"
 LOG_FILE="${LOG_FILE:-$HAMMERSPOON_DIR/logs/av-pain-reliever.log}"
 
-export LIB_DIR REPO_ROOT HAMMERSPOON_DIR PROFILES_FILE LOG_FILE
+# DRY_RUN=1 means "show what you would do, don't actually do it." Set by the
+# --dry-run flag parsed in wizard.sh. Default off.
+DRY_RUN="${DRY_RUN:-0}"
+
+export LIB_DIR REPO_ROOT HAMMERSPOON_DIR PROFILES_FILE LOG_FILE DRY_RUN
+
+# ---------- dry-run helpers ----------
+
+# Print a "would do X" line, color-coded yellow so it stands out.
+would() {
+  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    printf '  \033[33m[dry-run]\033[0m %s\n' "$*"
+  else
+    printf '  [dry-run] %s\n' "$*"
+  fi
+}
+
+# runcmd <cmd> [args...]
+# In normal mode: runs the command. In dry-run mode: prints what it would
+# have run, returns 0. Use this for commands that have side effects.
+runcmd() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "would run: $*"
+    return 0
+  fi
+  "$@"
+}
+
+# runstep <description> <cmd> [args...]
+# Like runcmd but with a human-readable description for dry-run output.
+# Use when the underlying command is opaque (like a long sudo invocation
+# or a script call) and the user benefits from a clearer summary.
+runstep() {
+  local desc="$1"; shift
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "$desc"
+    return 0
+  fi
+  "$@"
+}
+
+# write_file <path> [content_via_stdin]
+# In normal mode: writes stdin to <path>. In dry-run mode: prints what would
+# have been written and a preview of the first few lines.
+write_file_dryrun_aware() {
+  local path="$1"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "would write file: $path"
+    local content
+    content=$(cat)
+    local line_count
+    line_count=$(printf '%s' "$content" | wc -l | tr -d ' ')
+    would "  (${line_count} lines; first 5 below)"
+    printf '%s\n' "$content" | head -5 | sed 's/^/    │ /' | while IFS= read -r line; do
+      if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+        printf '  \033[33m[dry-run]\033[0m %s\n' "$line"
+      else
+        printf '  [dry-run] %s\n' "$line"
+      fi
+    done
+    return 0
+  fi
+  cat > "$path"
+}
+
+# Bail-out helper: emit a one-line dry-run banner if active.
+dryrun_banner() {
+  [[ "$DRY_RUN" == "1" ]] || return 0
+  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    printf '\n  \033[1;33m━━━ DRY-RUN MODE ━━━\033[0m\n'
+    printf '  \033[33mNo files will be written, no commands run, no apps installed.\n'
+    printf '  Prompts still appear so you can walk through the flow.\033[0m\n\n'
+  else
+    printf '\n  ━━━ DRY-RUN MODE ━━━\n'
+    printf '  No files will be written, no commands run, no apps installed.\n'
+    printf '  Prompts still appear so you can walk through the flow.\n\n'
+  fi
+}
 
 # ---------- styling ----------
 
@@ -124,6 +201,12 @@ require_gh() {
 bootstrap_gum() {
   if command -v gum >/dev/null 2>&1; then return 0; fi
   step "Installing gum (one-time, gives this wizard a nicer UI)"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    would "would 'brew install gum'"
+    info "(gum isn't installed yet, so dry-run prompts will use plain bash"
+    info " fallbacks instead of gum's colored UI for this run.)"
+    return 0
+  fi
   brew install gum >/dev/null
   command -v gum >/dev/null 2>&1 || fail "gum install failed"
   success "gum installed"


### PR DESCRIPTION
## Summary

Adds a \`--dry-run\` flag (also \`-n\`) to the wizard. Lets you preview what \`install\` or \`add-location\` would do without actually doing it.

\`\`\`sh
~/av-pain-reliever/wizard.sh --dry-run install
~/av-pain-reliever/wizard.sh -n add-location
\`\`\`

You'll see a yellow \`━━━ DRY-RUN MODE ━━━\` banner at the top, then walk through every step. Side-effect lines show up as \`[dry-run] would do X\` instead of running. Read-only checks (is OBS running? is Hammerspoon installed?) still execute. Prompts still appear so you can walk through the flow exactly as a real user would.

## What changed

- \`wizard.sh\` parses \`--dry-run\` / \`-n\` out of \`\$@\` before dispatching to a subcommand. Sets \`DRY_RUN=1\` env var.
- \`wizard/lib.sh\` adds three helpers:
  - \`runcmd <args>\` — runs the command normally OR prints \`[dry-run] would run: ...\`
  - \`runstep <desc> <args>\` — same but with a human-readable description (used when the underlying command is opaque, like a sudo move or a script call)
  - \`dryrun_banner\` — prints the yellow banner at the top of every dry-run flow
- \`install.sh\` and \`add-location.sh\` wrap every side-effect call (brew install, curl, sudo mv, ln -s, cp, open -a, osascript reload, obs-cmd scene create, etc.) with the helpers
- \`bootstrap_gum\` is dry-run aware: prints what it would do, falls through to plain bash prompts for the rest of the run if gum isn't installed
- README adds a "Want to see what would happen first?" section right after the install command

## What stays untouched in dry-run mode

- Read-only commands (\`pgrep\`, \`defaults read\`, \`command -v\`, \`obs-cmd info\`, \`obs-cmd scene list\`) — they don't change state
- Prompts (\`gum confirm\` / \`choose\` / \`input\`) — they're asking the user, not doing work

## Test plan

- [ ] \`./tests/run.sh\` shows \`61 passed, 0 failed\`
- [ ] \`./wizard.sh help\` mentions \`--dry-run\`
- [ ] \`./wizard.sh --dry-run install\` walks through every step without actually installing or modifying anything
- [ ] \`./wizard.sh -n add-location\` works the same way
- [ ] \`./wizard.sh --dry-run status\` runs cleanly (status is read-only, dry-run is a no-op)
- [ ] \`shellcheck\` clean on all wizard scripts and the new \`tests/test_dry_run.sh\`

## Follow-up

The TUI polish PR (spinners, progress bar, more colorful banners) is next. The dry-run flag will make it easier to preview those visual changes safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)