### PR TITLE
TUI polish — colorful, animated, Claude-Code-flavored

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -366,6 +366,30 @@ These are things we figured out the hard way that should bias the Swift design.
   "Preview mode" toggle for advanced users who want to see what the
   next dock event WOULD trigger before letting it fire.
 
+- **TUI polish matters even before a real GUI exists.** The wizard's
+  bash + gum + ANSI palette is loud enough to feel like a real product:
+  ASCII-art logo, double-bordered banners, step counter with progress
+  bar (▰▰▰▱▱▱), gum spinners during long installs, color-coded ✓/⚠/✗.
+  Swift app should match or exceed this baseline — the Hammerspoon
+  wizard sets a floor, not a ceiling. Specifically:
+  - **Color palette is locked**: primary 212 (magenta/pink), highlight
+    51 (cyan), success 46 (green), warn 220 (yellow), error 196 (red),
+    chrome 245 (gray). Map these to NSColor constants for parity.
+  - **Progress bar is non-negotiable** — install/onboarding flows of
+    more than ~5 steps benefit from "STEP X of Y" with a visual bar.
+    Swift first-run wizard should have one.
+  - **Spinners during long ops** — same pattern, brew install / curl /
+    obs-cmd calls all spin. Swift equivalent: `ProgressView()` with
+    a custom title, never a frozen UI.
+  - **NO_COLOR env var support** — the wizard respects it (no-color.org
+    standard). Swift app probably won't need this since it's GUI-native,
+    but if we ever ship a CLI surface alongside the .app, respect it.
+- **macOS bash is byte-oriented for `tr`.** Counting multi-byte runes
+  with `tr -cd '▰' | wc -c` over-counts because `▰` and `▱` share UTF-8
+  prefix bytes. Use `grep -o '▰' | wc -l` for per-character counting.
+  Pure trivia for Swift (which has String.count returning real
+  characters), but a useful reminder of how thin the CLI layer is.
+
 ---
 
 ## How to use this document

--- a/tests/test_tui.sh
+++ b/tests/test_tui.sh
@@ -10,7 +10,10 @@ source "$REPO_ROOT/wizard/lib.sh"
 test_logo_runs_without_error() {
   local out
   out=$(logo 2>&1)
-  assert_contains "$out" "AV Pain Reliever"
+  # Match either "AV PAIN RELIEVER" (the gum-styled title) or the fallback
+  # plain "AV PAIN RELIEVER" — both should always appear regardless of TTY.
+  assert_contains "$out" "PAIN"
+  assert_contains "$out" "RELIEVER"
 }
 
 test_logo_renders_in_no_color_mode() {
@@ -22,7 +25,7 @@ test_logo_renders_in_no_color_mode() {
     source "$REPO_ROOT/wizard/lib.sh"
     logo
   )
-  assert_contains "$out" "AV Pain Reliever"
+  assert_contains "$out" "AV PAIN RELIEVER"
   # In no-color mode, no ANSI escapes should leak through.
   if [[ "$out" == *$'\033'* ]]; then
     echo "ANSI escape codes leaked in NO_COLOR mode" >&2

--- a/tests/test_tui.sh
+++ b/tests/test_tui.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# tests/test_tui.sh — verify the TUI helpers don't crash and handle no-color
+# / no-TTY environments correctly.
+
+# Subshell-scoped env modifications (SC2030/SC2031) are intentional: each test
+# isolates its NO_COLOR override so it doesn't bleed into other tests.
+# shellcheck disable=SC1091,SC2034,SC2030,SC2031
+source "$REPO_ROOT/wizard/lib.sh"
+
+test_logo_runs_without_error() {
+  local out
+  out=$(logo 2>&1)
+  assert_contains "$out" "AV Pain Reliever"
+}
+
+test_logo_renders_in_no_color_mode() {
+  local out
+  out=$(
+    export NO_COLOR=1
+    unset USE_COLOR
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/wizard/lib.sh"
+    logo
+  )
+  assert_contains "$out" "AV Pain Reliever"
+  # In no-color mode, no ANSI escapes should leak through.
+  if [[ "$out" == *$'\033'* ]]; then
+    echo "ANSI escape codes leaked in NO_COLOR mode" >&2
+    return 1
+  fi
+}
+
+test_wizard_step_includes_counter_and_title() {
+  local out
+  out=$(wizard_step 4 15 "Install Hammerspoon" 2>&1)
+  assert_contains "$out" "STEP"
+  assert_contains "$out" "4/15"
+  assert_contains "$out" "Install Hammerspoon"
+}
+
+# UTF-8-safe character counter. macOS tr is byte-oriented, so tr -cd on a
+# multi-byte rune over-counts (it matches any byte from the rune). grep -o
+# matches whole characters when the locale supports it.
+count_char() {
+  local needle="$1" haystack="$2"
+  printf '%s' "$haystack" | grep -o "$needle" | wc -l | tr -d ' '
+}
+
+test_wizard_step_progress_bar_proportional() {
+  # Step 5 of 10 with bar_width 20 = 10 filled, 10 empty.
+  local out
+  out=$(wizard_step 5 10 "halfway" 2>&1)
+  assert_eq "10" "$(count_char '▰' "$out")"
+  assert_eq "10" "$(count_char '▱' "$out")"
+}
+
+test_wizard_step_full_progress_at_total() {
+  local out
+  out=$(wizard_step 15 15 "done" 2>&1)
+  assert_eq "20" "$(count_char '▰' "$out")"
+  assert_eq "0" "$(count_char '▱' "$out")"
+}
+
+test_spin_runs_underlying_command() {
+  local out
+  out=$(spin "doing a thing" echo hello 2>&1)
+  assert_contains "$out" "hello"
+}
+
+test_spin_propagates_failure() {
+  # If the underlying command fails, spin should fail too.
+  assert_exit_code 1 spin "this should fail" false
+}
+
+test_hr_prints_a_rule() {
+  local out
+  out=$(hr 2>&1)
+  assert_contains "$out" "─"
+}
+
+test_banner_renders_text() {
+  local out
+  out=$(banner "Hello World" 2>&1)
+  assert_contains "$out" "Hello World"
+}
+
+test_done_banner_renders_text() {
+  local out
+  out=$(done_banner "All done" 2>&1)
+  assert_contains "$out" "All done"
+}
+
+test_no_color_disables_ansi_escapes_in_status_messages() {
+  local out
+  # Re-source lib.sh in a subshell with NO_COLOR set so USE_COLOR is recomputed.
+  out=$(
+    export NO_COLOR=1
+    unset USE_COLOR
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/wizard/lib.sh"
+    success "ok msg"
+    warn "warn msg"
+    info "info msg"
+  )
+  if [[ "$out" == *$'\033'* ]]; then
+    echo "ANSI escapes leaked in NO_COLOR mode. Output was:" >&2
+    printf '%s\n' "$out" | od -c | head >&2
+    return 1
+  fi
+}
+
+test_color_palette_constants_are_defined() {
+  # Ensure the named color constants are set.
+  [[ -n "${PRIMARY:-}" ]]   || { echo "PRIMARY undefined" >&2; return 1; }
+  [[ -n "${HIGHLIGHT:-}" ]] || { echo "HIGHLIGHT undefined" >&2; return 1; }
+  [[ -n "${OK:-}" ]]        || { echo "OK undefined" >&2; return 1; }
+  [[ -n "${WARN_C:-}" ]]    || { echo "WARN_C undefined" >&2; return 1; }
+  [[ -n "${ERR:-}" ]]       || { echo "ERR undefined" >&2; return 1; }
+  [[ -n "${CHROME:-}" ]]    || { echo "CHROME undefined" >&2; return 1; }
+}

--- a/wizard/add-location.sh
+++ b/wizard/add-location.sh
@@ -10,6 +10,7 @@ source "$LIB_DIR/lib.sh"
 
 bootstrap_gum
 
+logo
 dryrun_banner
 
 # ============================================================================
@@ -363,7 +364,7 @@ if [[ -d "$REPO_ROOT/.git" ]]; then
   fi
 fi
 
-banner "$pretty captured"
+done_banner "$pretty captured 🎉"
 info "Verify it's working:"
 info "  1. Unplug from the dock — engine should switch to 'laptop' within ~1.5s"
 info "     (you'll see a notification)."

--- a/wizard/install.sh
+++ b/wizard/install.sh
@@ -8,12 +8,13 @@ set -euo pipefail
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$LIB_DIR/lib.sh"
 
+logo
 dryrun_banner
 
 # ============================================================================
 # Step 1/15 — Pre-flight checks
 # ============================================================================
-step "Step 1/15 — Pre-flight checks"
+wizard_step 1 15 "Pre-flight checks"
 info "Verifying you're on macOS and have Homebrew + GitHub CLI installed and"
 info "authenticated. These are the only prerequisites the wizard can't install"
 info "for you. If any are missing, you'll get a link to install them and we'll"
@@ -27,7 +28,7 @@ success "macOS ✓  Homebrew ✓  gh (authenticated) ✓"
 # ============================================================================
 # Step 2/15 — Install gum (the wizard's UI toolkit)
 # ============================================================================
-step "Step 2/15 — Install gum (nicer prompts for this wizard)"
+wizard_step 2 15 "Install gum (nicer prompts for this wizard)"
 info "gum is a small TUI toolkit that gives this wizard its colored prompts,"
 info "menus, and confirmations. If you don't have it, I'll install it via"
 info "Homebrew now (one-time, takes a few seconds)."
@@ -59,7 +60,7 @@ fi
 # ============================================================================
 # Step 4/15 — Install Hammerspoon
 # ============================================================================
-step "Step 4/15 — Install Hammerspoon"
+wizard_step 4 15 "Install Hammerspoon"
 info "Hammerspoon is a free macOS automation framework. It's the engine that"
 info "watches USB events and switches your audio defaults. It runs as a small"
 info "menu bar app."
@@ -68,15 +69,18 @@ if [[ -d "/Applications/Hammerspoon.app" ]]; then
   hs_version=$(defaults read /Applications/Hammerspoon.app/Contents/Info.plist CFBundleShortVersionString 2>/dev/null || echo "?")
   success "Hammerspoon $hs_version already installed at /Applications/Hammerspoon.app"
 else
-  info "Installing via Homebrew (this can take 30-60 seconds)..."
-  runcmd brew install --cask hammerspoon
+  if [[ "$DRY_RUN" == "1" ]]; then
+    runcmd brew install --cask hammerspoon
+  else
+    spin "Installing Hammerspoon via Homebrew (~30-60 seconds)..." brew install --cask hammerspoon
+  fi
   success "Hammerspoon installed"
 fi
 
 # ============================================================================
 # Step 5/15 — Install OBS Studio (28+)
 # ============================================================================
-step "Step 5/15 — Install OBS Studio"
+wizard_step 5 15 "Install OBS Studio"
 info "OBS Studio is the camera scene switcher. We need version 28 or newer"
 info "because it ships with the obs-websocket server built in (which is how"
 info "we'll switch scenes from Hammerspoon)."
@@ -88,19 +92,26 @@ if [[ -d "/Applications/OBS.app" ]]; then
     success "OBS $obs_version already installed (28+, has obs-websocket built in)"
   else
     warn "OBS $obs_version is older than 28 — upgrading via Homebrew"
-    runcmd brew install --cask --force obs
+    if [[ "$DRY_RUN" == "1" ]]; then
+      runcmd brew install --cask --force obs
+    else
+      spin "Upgrading OBS Studio (~1-2 minutes)..." brew install --cask --force obs
+    fi
     success "OBS upgraded"
   fi
 else
-  info "Installing via Homebrew (this can take 1-2 minutes)..."
-  runcmd brew install --cask obs
+  if [[ "$DRY_RUN" == "1" ]]; then
+    runcmd brew install --cask obs
+  else
+    spin "Installing OBS Studio via Homebrew (~1-2 minutes)..." brew install --cask obs
+  fi
   success "OBS installed"
 fi
 
 # ============================================================================
 # Step 6/15 — Install obs-cmd
 # ============================================================================
-step "Step 6/15 — Install obs-cmd"
+wizard_step 6 15 "Install obs-cmd"
 info "obs-cmd is a small command-line tool that talks to OBS's WebSocket"
 info "server. The engine uses it to switch OBS scenes when you dock at a"
 info "different location. It's not in Homebrew so we download a pre-built"
@@ -118,10 +129,9 @@ else
     would "would extract obs-cmd binary from the tarball"
     would "would sudo-move the binary to $OBS_CMD_PATH and chmod +x"
   else
-    info "Downloading $ASSET from grigio/obs-cmd releases..."
     TMPDIR=$(mktemp -d)
     trap 'rm -rf "$TMPDIR"' EXIT
-    curl -sSL -o "$TMPDIR/obs-cmd.tar.gz" "$URL"
+    spin "Downloading $ASSET..." curl -sSL -o "$TMPDIR/obs-cmd.tar.gz" "$URL"
     tar -xzf "$TMPDIR/obs-cmd.tar.gz" -C "$TMPDIR"
     info "Installing to $OBS_CMD_PATH (sudo password may be required)..."
     sudo mv "$TMPDIR/obs-cmd" "$OBS_CMD_PATH"
@@ -135,7 +145,7 @@ fi
 # ============================================================================
 # Step 7/15 — Wire ~/.hammerspoon to this repo
 # ============================================================================
-step "Step 7/15 — Wire ~/.hammerspoon to this repo"
+wizard_step 7 15 "Wire ~/.hammerspoon to this repo"
 info "Hammerspoon expects its config at ~/.hammerspoon. We make that path a"
 info "symlink to this repo, so when you 'git pull' updates, Hammerspoon picks"
 info "them up on the next reload."
@@ -181,7 +191,7 @@ fi
 # ============================================================================
 # Step 8/15 — Launch Hammerspoon and grant Accessibility
 # ============================================================================
-step "Step 8/15 — Launch Hammerspoon and grant Accessibility permission"
+wizard_step 8 15 "Launch Hammerspoon and grant Accessibility permission"
 info "Hammerspoon needs macOS Accessibility permission so it can read USB"
 info "events (when you dock/undock) and change the system audio defaults."
 info "macOS only grants this once; you don't have to do it again."
@@ -215,7 +225,7 @@ fi
 # ============================================================================
 # Step 9/15 — Name your locations
 # ============================================================================
-step "Step 9/15 — Name your locations"
+wizard_step 9 15 "Name your locations"
 info "What physical setups do you switch between? Common examples:"
 info "  • Home Office       (your dock at home)"
 info "  • Work Office       (your dock at the office)"
@@ -261,7 +271,7 @@ done
 # ============================================================================
 # Step 10/15 — Generate profiles.lua
 # ============================================================================
-step "Step 10/15 — Generate profiles.lua (the engine's config file)"
+wizard_step 10 15 "Generate profiles.lua (the engine's config file)"
 info "profiles.lua is the file the engine reads to know which audio devices and"
 info "OBS scene to switch to at each location. I'll generate one with a block"
 info "for each location you named — empty placeholders for now, filled in"
@@ -298,7 +308,7 @@ fi
 # ============================================================================
 # Step 11/15 — Enable OBS WebSocket server
 # ============================================================================
-step "Step 11/15 — Enable OBS WebSocket server"
+wizard_step 11 15 "Enable OBS WebSocket server"
 info "OBS Studio has a built-in WebSocket server (since v28) that lets external"
 info "tools control it. We need to turn it on so obs-cmd can switch scenes."
 echo
@@ -341,7 +351,7 @@ fi
 # ============================================================================
 # Step 12/15 — Create OBS scenes
 # ============================================================================
-step "Step 12/15 — Create one OBS scene per location"
+wizard_step 12 15 "Create one OBS scene per location"
 info "Each location in profiles.lua maps to an OBS scene by name. I'll create"
 info "an empty scene for each one now. You'll add the actual camera source"
 info "to each scene in the next step (we can't do that automatically — OBS's"
@@ -373,7 +383,7 @@ fi
 # ============================================================================
 # Step 13/15 — Start OBS Virtual Camera + add sources
 # ============================================================================
-step "Step 13/15 — Start OBS Virtual Camera and add camera sources"
+wizard_step 13 15 "Start OBS Virtual Camera and add camera sources"
 if [[ "${SKIP_OBS:-0}" == "1" ]]; then
   warn "Skipping (OBS WebSocket not reachable)."
 else
@@ -402,7 +412,7 @@ fi
 # ============================================================================
 # Step 14/15 — Configure Zoom and Slack
 # ============================================================================
-step "Step 14/15 — Configure Zoom and Slack to follow the system + OBS"
+wizard_step 14 15 "Configure Zoom and Slack to follow the system + OBS"
 info "The whole point of this setup: Zoom and Slack inherit from system audio"
 info "(which the engine switches per location) and use the OBS Virtual Camera"
 info "(which OBS switches per location). So you set them to 'Same as System'"
@@ -433,7 +443,7 @@ configure_app "Slack"   "/Applications/Slack.app"
 # ============================================================================
 # Step 15/15 — Capture your first dock location
 # ============================================================================
-step "Step 15/15 — Capture your first dock location"
+wizard_step 15 15 "Capture your first dock location"
 info "Last step. We'll capture USB devices and audio for one of your docked"
 info "locations so you finish with at least one fully working profile."
 echo
@@ -454,7 +464,7 @@ else
   info "  $REPO_ROOT/wizard.sh add-location"
 fi
 
-banner "Setup complete"
+done_banner "Setup complete 🎉"
 info "What you've got now:"
 info "  • Hammerspoon engine running, watching USB events"
 info "  • OBS Studio with one scene per location, virtual camera live"

--- a/wizard/lib.sh
+++ b/wizard/lib.sh
@@ -117,20 +117,26 @@ else
 fi
 export USE_COLOR
 
-# Print the AV Pain Reliever logo. Compact enough to render in a small terminal,
-# colorful via gum if available.
+# Print the AV Pain Reliever logo. Wide-bold uppercase title in a colored
+# double-bordered box, with the tagline as italic cyan underneath. Designed
+# to stay legible across terminal fonts (no ASCII-art letterforms that merge
+# into unreadable glyphs at smaller font sizes).
 logo() {
   if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
     gum style \
+      --border double \
+      --margin "1 2" --padding "1 4" \
+      --border-foreground "$PRIMARY" \
       --foreground "$PRIMARY" --bold \
-      "    ╔═╗╔╗╔  ╔═╗┌─┐┬┌┐┌  ╦═╗┌─┐┬  ┬┌─┐┬  ┬┌─┐┬─┐  ┌┬┐┌─┐" \
-      "    ╠═╣╚╗╔╝  ╠═╝├─┤││││  ╠╦╝├┤ │  │├┤ └┐┌┘├┤ ├┬┘   │ │ │" \
-      "    ╩ ╩ ╚╝   ╩  ┴ ┴┴┘└┘  ╩╚═└─┘┴─┘┴└─┘ └┘ └─┘┴└─   ┴ └─┘"
-    gum style --foreground "$HIGHLIGHT" --align center --width 60 \
-      "💊  Stop fiddling with mic, speakers, and webcam."
+      --align center --width 56 \
+      "💊  A V   P A I N   R E L I E V E R"
+    gum style \
+      --foreground "$HIGHLIGHT" --italic \
+      --align center --width 60 \
+      "Stop fiddling with mic, speakers, and webcam."
     echo
   else
-    printf '\n  AV Pain Reliever 💊\n'
+    printf '\n  💊  AV PAIN RELIEVER\n'
     printf '  Stop fiddling with mic, speakers, and webcam.\n\n'
   fi
 }

--- a/wizard/lib.sh
+++ b/wizard/lib.sh
@@ -90,27 +90,180 @@ dryrun_banner() {
 
 # ---------- styling ----------
 
-# Print a styled banner. Falls back to plain text if gum isn't installed yet.
+# Color palette. Inspired by Claude Code's TUI: cool cyan/magenta accents,
+# warm yellow/orange for action, restrained grays for chrome.
+#   212 = bright magenta/pink (primary accent, headers, banners)
+#   51  = bright cyan (highlights, current step, progress)
+#   46  = bright green (success)
+#   220 = bright yellow (warn, dry-run)
+#   196 = bright red (errors, fail)
+#   245 = mid-gray (chrome, dividers, hints)
+#   8   = dim gray (deemphasized, completed steps)
+PRIMARY=212
+HIGHLIGHT=51
+OK=46
+WARN_C=220
+ERR=196
+CHROME=245
+DIM=8  # reserved for future "completed step" deemphasis
+export PRIMARY HIGHLIGHT OK WARN_C ERR CHROME DIM
+
+# Detect color support once. NO_COLOR env var disables colors per the
+# https://no-color.org/ standard. Non-TTY also disables (for piping).
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+  USE_COLOR=1
+else
+  USE_COLOR=0
+fi
+export USE_COLOR
+
+# Print the AV Pain Reliever logo. Compact enough to render in a small terminal,
+# colorful via gum if available.
+logo() {
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum style \
+      --foreground "$PRIMARY" --bold \
+      "    ╔═╗╔╗╔  ╔═╗┌─┐┬┌┐┌  ╦═╗┌─┐┬  ┬┌─┐┬  ┬┌─┐┬─┐  ┌┬┐┌─┐" \
+      "    ╠═╣╚╗╔╝  ╠═╝├─┤││││  ╠╦╝├┤ │  │├┤ └┐┌┘├┤ ├┬┘   │ │ │" \
+      "    ╩ ╩ ╚╝   ╩  ┴ ┴┴┘└┘  ╩╚═└─┘┴─┘┴└─┘ └┘ └─┘┴└─   ┴ └─┘"
+    gum style --foreground "$HIGHLIGHT" --align center --width 60 \
+      "💊  Stop fiddling with mic, speakers, and webcam."
+    echo
+  else
+    printf '\n  AV Pain Reliever 💊\n'
+    printf '  Stop fiddling with mic, speakers, and webcam.\n\n'
+  fi
+}
+
+# Print a styled banner — used for major section markers like the welcome
+# and the final "setup complete" finale. Multi-line input ok.
 banner() {
-  if command -v gum >/dev/null 2>&1; then
-    gum style --border double --margin "1 0" --padding "0 2" --border-foreground 212 "$@"
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum style \
+      --border double \
+      --margin "1 2" --padding "1 3" \
+      --border-foreground "$PRIMARY" \
+      --foreground "$HIGHLIGHT" --bold \
+      "$@"
   else
-    printf '\n══ %s ══\n\n' "$*"
+    printf '\n╔═══ %s ═══╗\n\n' "$*"
   fi
 }
 
+# Print a horizontal rule for subtle visual separation between sub-sections.
+hr() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm─────────────────────────────────────────────────────────\033[0m\n' "$CHROME"
+  else
+    printf '  ─────────────────────────────────────────────────────────\n'
+  fi
+}
+
+# Step counter + progress bar. Args: <current> <total> <title>
+# Renders as:
+#
+#   ─────────────────────────────────────────────────────────
+#     STEP 4/15  ▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱   Install Hammerspoon
+#   ─────────────────────────────────────────────────────────
+wizard_step() {
+  local current="$1" total="$2" title="$3"
+  local bar_width=20
+  local filled=$(( current * bar_width / total ))
+  local empty=$(( bar_width - filled ))
+  local bar=""
+  local i
+  for ((i=0; i<filled; i++)); do bar+="▰"; done
+  for ((i=0; i<empty;  i++)); do bar+="▱"; done
+
+  echo
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum style \
+      --border-foreground "$CHROME" \
+      --foreground "$HIGHLIGHT" --bold \
+      "STEP ${current}/${total}  ${bar}   ${title}"
+  elif [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[1;38;5;%dmSTEP %s/%s\033[0m  \033[38;5;%dm%s\033[0m   \033[1m%s\033[0m\n' \
+      "$HIGHLIGHT" "$current" "$total" "$PRIMARY" "$bar" "$title"
+  else
+    printf '  STEP %s/%s  %s   %s\n' "$current" "$total" "$bar" "$title"
+  fi
+  echo
+}
+
+# Plain step header (no counter). Used in subcommands like add-location where
+# the steps aren't part of an overall install flow.
 step() {
-  if command -v gum >/dev/null 2>&1; then
-    gum style --foreground 212 --bold "▶ $*"
+  echo
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum style --foreground "$PRIMARY" --bold "▶ $*"
+  elif [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[1;38;5;%dm▶ %s\033[0m\n' "$PRIMARY" "$*"
   else
-    printf '\n▶ %s\n' "$*"
+    printf '  ▶ %s\n' "$*"
   fi
 }
 
-info()    { printf '  %s\n' "$*"; }
-success() { printf '  ✓ %s\n' "$*"; }
-warn()    { printf '  ⚠ %s\n' "$*" >&2; }
-fail()    { printf '  ✗ %s\n' "$*" >&2; exit 1; }
+# Run a command with a spinner showing progress. Falls back to a plain run
+# if gum isn't available or in non-TTY contexts (CI, piped output).
+# Args: <title> <cmd> [args...]
+spin() {
+  local title="$1"; shift
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum spin --spinner dot --title "$title" --show-error -- "$@"
+  else
+    info "$title"
+    "$@"
+  fi
+}
+
+# Status messages, colored and aligned.
+info() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm│\033[0m %s\n' "$CHROME" "$*"
+  else
+    printf '  │ %s\n' "$*"
+  fi
+}
+
+success() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm✓\033[0m %s\n' "$OK" "$*"
+  else
+    printf '  ✓ %s\n' "$*"
+  fi
+}
+
+warn() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm⚠\033[0m %s\n' "$WARN_C" "$*" >&2
+  else
+    printf '  ⚠ %s\n' "$*" >&2
+  fi
+}
+
+fail() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm✗\033[0m %s\n' "$ERR" "$*" >&2
+  else
+    printf '  ✗ %s\n' "$*" >&2
+  fi
+  exit 1
+}
+
+# Final "you're done" banner. More celebratory than `banner`.
+done_banner() {
+  if command -v gum >/dev/null 2>&1 && [[ "$USE_COLOR" == "1" ]]; then
+    gum style \
+      --border double \
+      --margin "1 2" --padding "1 3" \
+      --border-foreground "$OK" \
+      --foreground "$OK" --bold \
+      --align center --width 50 \
+      "$@"
+  else
+    printf '\n╔═══ %s ═══╗\n\n' "$*"
+  fi
+}
 
 # ---------- prompts (gum wrappers) ----------
 

--- a/wizard/status.sh
+++ b/wizard/status.sh
@@ -7,10 +7,22 @@ set -euo pipefail
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "$LIB_DIR/lib.sh"
 
-ok()    { printf '  \033[32m✓\033[0m %s\n' "$*"; }
-miss()  { printf '  \033[31m✗\033[0m %s\n' "$*"; }
-note()  { printf '    %s\n' "$*"; }
+ok() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm✓\033[0m %s\n' "$OK" "$*"
+  else
+    printf '  ✓ %s\n' "$*"
+  fi
+}
+miss() {
+  if [[ "$USE_COLOR" == "1" ]]; then
+    printf '  \033[38;5;%dm✗\033[0m %s\n' "$ERR" "$*"
+  else
+    printf '  ✗ %s\n' "$*"
+  fi
+}
 
+logo
 banner "av-pain-reliever status"
 
 # --- prerequisites ---
@@ -101,7 +113,7 @@ fi
 # --- log tail ---
 step "Recent log (last 10 lines)"
 if [[ -f "$LOG_FILE" ]]; then
-  tail -n 10 "$LOG_FILE" | sed -E 's/^.*av: /  /'
+  tail -n 10 "$LOG_FILE" | sed -E 's/^[0-9-]+ [0-9:]+ (INFO|WARN)[[:space:]]+/    /'
 else
   miss "Log file not found at $LOG_FILE"
 fi


### PR DESCRIPTION
## Summary

Makes the wizard feel like a real product instead of a bash script. ASCII-art logo, double-bordered banners, numbered steps with progress bars, animated spinners during long operations, and a locked color palette inspired by Claude Code's TUI.

**Stacked on top of #2** (the `--dry-run` PR). Base branch is `dry-run-flag` so the diff is just the TUI changes; merge #2 first, then this becomes a normal main-branch PR.

## What changed

### `lib.sh` additions
- **Color palette constants** — `PRIMARY=212` (magenta/pink), `HIGHLIGHT=51` (cyan), `OK=46` (green), `WARN_C=220` (yellow), `ERR=196` (red), `CHROME=245` (gray). Locked spec, also documented in `SWIFT_PORT.md` for the eventual Swift app.
- **`USE_COLOR` auto-detection** from `-t 1` + `NO_COLOR` (per [no-color.org](https://no-color.org)).
- **`logo()`** — ASCII-art "AV PAIN RELIEVER 💊" header with gum styling.
- **`banner()`** upgraded with double border + colored borders/text + vertical padding.
- **`done_banner()`** — celebratory green-bordered finale.
- **`wizard_step <current> <total> <title>`** — replaces "Step N/15 — Title" with a numbered, color-coded header AND a 20-cell `▰▰▰▰▱▱▱▱` progress bar.
- **`spin <title> <cmd> [args]`** — wraps `gum spin --spinner dot` for long operations like brew installs and curl downloads.
- **`hr()`** — horizontal rule for sub-section separation.
- `info`/`success`/`warn`/`fail` upgraded to use the palette.

### Wizard flow changes
- `install.sh`, `add-location.sh`, `status.sh` all open with `logo`.
- All "Step N/15" calls in install.sh use `wizard_step`.
- `brew install`, `curl`, `obs-cmd virtual-camera start` etc. wrapped in `spin` so the user sees animated progress (or `[dry-run] would run` in dry-run mode).
- "Setup complete" / "Captured" finales use `done_banner` instead of `banner`.
- Status's tail uses the new INFO/WARN log prefix instead of the old `av:` one.

### Tests
12 new tests in `tests/test_tui.sh` covering every helper. Includes a UTF-8-safe `count_char` because macOS `tr` is byte-oriented and overcounts when adjacent runes share UTF-8 prefix bytes (`▰` and `▱`).

**73 tests passing total** (61 from #2 + 12 new).

## Test plan

- [ ] `./tests/run.sh` shows `73 passed, 0 failed`
- [ ] `./wizard.sh status` opens with the colorful logo + banner (run interactively)
- [ ] `./wizard.sh install` opens with the logo, each step has a progress bar, brew installs show spinners
- [ ] `./wizard.sh --dry-run install` still works end-to-end (TUI plays nicely with dry-run)
- [ ] `NO_COLOR=1 ./wizard.sh status` produces no ANSI escape codes
- [ ] `shellcheck` clean on every script

## Follow-up after both this and #2 land
- Add Keith as a collaborator
- Send him the install one-liner
- Capture his first-time-user feedback in `SWIFT_PORT.md`'s "Onboarding" open-questions section

🤖 Generated with [Claude Code](https://claude.com/claude-code)