### PR TITLE
Menu bar: opt-in to show active profile icon

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2172,6 +2172,38 @@ To make a recurrence less likely:
 
 ---
 
+## Menu bar profile-icon toggle (2026-05-03)
+
+Added an opt-in setting that swaps the menu bar's `pills.fill` glyph
+for the active profile's SF Symbol. Default off so the product's
+brand glyph stays the out-of-the-box look; users who want the menu
+bar to track location flip the toggle in Settings → General →
+Behavior ("Show current profile icon in the menu bar").
+
+Implementation reused existing pieces end-to-end:
+
+- `SettingsStore` — new `showProfileIconInMenuBar` Bool with the
+  same `@Published`/`didSet`/UserDefaults pattern as the other
+  toggles. Default decoded with `(object(forKey:) as? Bool) ?? false`
+  so "never set" stays distinct from "explicitly off".
+- `AppDelegate` — one-line passthrough mirror so `MenuLabelView`
+  re-renders via the existing `objectWillChange` republish.
+- `MenuLabelView` — new private `menuBarIcon` computed var routes
+  through `ProfileIcon.effectiveSymbol(for:override:)`, the same
+  resolver the "Switch to" submenu and Profiles list already use.
+  Falls back to `Theme.Symbol.appIcon` when the toggle is off, when
+  no active profile is known yet (fresh launch pre-evaluation), or
+  when the active slug isn't found in `availableProfiles`.
+- The unknown-location branch is intentionally untouched — when the
+  user is at a new dock there's no active profile to represent, so
+  the `questionmark.circle` + "New location" treatment stays the
+  right signal regardless of toggle state.
+
+No new types, no new files. Total diff: ~25 net lines across four
+files.
+
+---
+
 ## How to use this document
 
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -135,11 +135,27 @@ private struct MenuLabelView: View {
             Image(systemName: "questionmark.circle")
             Text("New location")
         } else {
-            Image(systemName: Theme.Symbol.appIcon)
+            Image(systemName: menuBarIcon)
             if delegate.showProfileNameInMenuBar {
                 Text(delegate.currentProfileTitle)
             }
         }
+    }
+
+    /// Resolved SF Symbol for the menu bar. Defaults to the product's
+    /// `pills.fill` brand glyph; when the user opts in via Settings →
+    /// General and an active profile is known, swaps in that profile's
+    /// effective icon (user override → slug auto-mapper → fallback pin),
+    /// matching what the "Switch to" submenu and Profiles list render.
+    private var menuBarIcon: String {
+        guard
+            delegate.showProfileIconInMenuBar,
+            let slug = delegate.activeProfileSlug,
+            let profile = delegate.availableProfiles.first(where: { $0.name == slug })
+        else {
+            return Theme.Symbol.appIcon
+        }
+        return ProfileIcon.effectiveSymbol(for: slug, override: profile.icon)
     }
 }
 

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -469,6 +469,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// Mirror of `settings.showProfileNameInMenuBar` for the same reason.
     var showProfileNameInMenuBar: Bool { settings.showProfileNameInMenuBar }
 
+    /// Mirror of `settings.showProfileIconInMenuBar` for the same reason.
+    var showProfileIconInMenuBar: Bool { settings.showProfileIconInMenuBar }
+
     /// Profile-config discovery in priority order. Mirrors what the
     /// eventual first-run wizard will codify, but for now lets a
     /// developer or migrating Phase 1 user run the app immediately:

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -14,6 +14,7 @@ final class SettingsStore: ObservableObject {
         static let notificationsEnabled = "notificationsEnabled"
         static let debounceInterval = "debounceInterval"
         static let showProfileNameInMenuBar = "showProfileNameInMenuBar"
+        static let showProfileIconInMenuBar = "showProfileIconInMenuBar"
         static let profileSwitchCount = "profileSwitchCount"
         static let suppressedWelcome = "suppressedWelcome"
         static let launchAtLogin = "launchAtLogin"
@@ -39,6 +40,15 @@ final class SettingsStore: ObservableObject {
     /// minimal status item.
     @Published var showProfileNameInMenuBar: Bool {
         didSet { defaults.set(showProfileNameInMenuBar, forKey: Key.showProfileNameInMenuBar) }
+    }
+
+    /// Swap the menu bar's `pills.fill` glyph for the active profile's
+    /// SF Symbol (resolved through `ProfileIcon.effectiveSymbol`).
+    /// Default off — the pill icon is the product's identity at a
+    /// glance, so opting in is what users do when they want the menu
+    /// bar to track location instead.
+    @Published var showProfileIconInMenuBar: Bool {
+        didSet { defaults.set(showProfileIconInMenuBar, forKey: Key.showProfileIconInMenuBar) }
     }
 
     /// Lifetime count of profile applications. Drives the easter-egg
@@ -76,6 +86,7 @@ final class SettingsStore: ObservableObject {
         self.notificationsEnabled = (defaults.object(forKey: Key.notificationsEnabled) as? Bool) ?? true
         self.debounceInterval = (defaults.object(forKey: Key.debounceInterval) as? Double) ?? 1.5
         self.showProfileNameInMenuBar = (defaults.object(forKey: Key.showProfileNameInMenuBar) as? Bool) ?? true
+        self.showProfileIconInMenuBar = (defaults.object(forKey: Key.showProfileIconInMenuBar) as? Bool) ?? false
         self.profileSwitchCount = (defaults.object(forKey: Key.profileSwitchCount) as? Int) ?? 0
         self.suppressedWelcome = (defaults.object(forKey: Key.suppressedWelcome) as? Bool) ?? false
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool) ?? false

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -53,6 +53,7 @@ private struct GeneralSettingsTab: View {
                 Toggle("Launch at login", isOn: $settings.launchAtLogin)
                 Toggle("Send notifications when profiles change", isOn: $settings.notificationsEnabled)
                 Toggle("Show current profile in the menu bar", isOn: $settings.showProfileNameInMenuBar)
+                Toggle("Show current profile icon in the menu bar", isOn: $settings.showProfileIconInMenuBar)
             } header: {
                 Label("Behavior", systemImage: "wand.and.stars")
             }


### PR DESCRIPTION
## Summary

- New "Show current profile icon in the menu bar" toggle in Settings → General → Behavior, **off by default** so the `pills.fill` brand glyph stays the out-of-the-box look.
- When on, the menu bar icon tracks the active profile via `ProfileIcon.effectiveSymbol(for:override:)` — the same resolver the "Switch to" submenu and Profiles list already use, so a `home-office` profile lands on `house.fill`, `laptop` on `laptopcomputer`, user-overridden picks win, etc.
- Implementation reuses every existing pattern: `SettingsStore` `@Published` + `didSet`/UserDefaults persistence, `AppDelegate` passthrough mirror, `MenuLabelView` consuming through `@ObservedObject delegate`. No new types, no new files.

## Test plan

- [x] `swift build` — clean.
- [x] Local hands-on: toggle off → `pills.fill`; toggle on → active profile's icon; profile switch updates the menu bar icon live; quit + relaunch persists the toggle; unknown-location branch still shows `questionmark.circle` + "New location" with the toggle on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)