### PR TITLE
About + Welcome refresh: confetti, Check for Updates, personalised greeting

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2204,6 +2204,41 @@ files.
 
 ---
 
+## About dialog refresh (2026-05-03)
+
+Stripped the "fiddling" framing out of the About dialog and rebuilt
+it around the four things that actually matter at the About moment:
+app icon, app name, version, an update affordance, and the existing
+"Show welcome again" link.
+
+What got cut:
+
+- `Theme.Copy.tagline` ("Stop fiddling with mic, speakers, and webcam.")
+- The italic "Made to stop the fiddling." line.
+- The two-line description block ("Lives quietly in your menu bar / Watches your USB ports / Picks the right defaults.").
+- The intervening Divider.
+
+What got added:
+
+- A bordered `Check for Updates` button wired to the existing
+  `delegate.checkForUpdates()` Sparkle pass-through, so the same
+  update path Advanced → Check for Updates… uses is now reachable
+  from About too.
+- A one-shot SwiftUI confetti burst overlaid on the dialog. Hand-
+  rolled, no SPM dep — 36 particles (Circle / Capsule / `pills.fill`
+  brand-glyph wink) with random color, size, drift, spin, and fall
+  duration, each animated by a single per-particle `@State` flipped
+  on appear. The whole overlay unmounts after 2.6 s via `.task` +
+  `showConfetti = false` so nothing keeps ticking once the burst
+  finishes. Palette uses system colors (`.accentColor`, `.yellow`,
+  `.pink`, `.green`, `.blue`, `.orange`) so it inherits the user's
+  macOS accent and stays plain-native.
+
+Frame shrunk 360 × 460 → 360 × 340. `Theme.Copy.tagline` is still
+defined; it just isn't used by the About dialog anymore.
+
+---
+
 ## How to use this document
 
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us

--- a/Sources/AVPainRelieverApp/AboutView.swift
+++ b/Sources/AVPainRelieverApp/AboutView.swift
@@ -3,74 +3,168 @@ import SwiftUI
 let aboutWindowID = "about-window"
 
 /// About scene shown via the menu item and the standard ⌘? path.
-/// Replaces `NSApp.orderFrontStandardAboutPanel` so the brand can sit
-/// on the hero — pill icon in magenta, app name in big magenta type,
-/// cyan tagline, version + a single warm "made to stop the fiddling"
-/// line. Personality lives in the copy, not the chrome.
+/// Replaces `NSApp.orderFrontStandardAboutPanel`. Layout is deliberately
+/// minimal: app icon, name, version, an update button, and the existing
+/// "Show welcome again" link. The only piece of personality is a one-shot
+/// confetti burst on appear — fits the plain-native aesthetic without
+/// pulling in a particle library.
 struct AboutView: View {
     @ObservedObject var delegate: AppDelegate
     @Environment(\.dismissWindow) private var dismissWindow
     @State private var pulse = false
+    @State private var showConfetti = true
 
     var body: some View {
-        VStack(spacing: 18) {
-            // Generated app icon — same artwork the OS uses.
-            // SwiftUI's Image(nsImage:) downscales cleanly from the
-            // 1024-square master.
-            Image(nsImage: AppIcon.image)
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 96, height: 96)
-                .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
-                .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
-                .scaleEffect(pulse ? 1.03 : 1.0)
-                .animation(
-                    .easeInOut(duration: 1.8).repeatForever(autoreverses: true),
-                    value: pulse
-                )
-                .onAppear { pulse = true }
+        ZStack {
+            VStack(spacing: 20) {
+                // Generated app icon — same artwork the OS uses.
+                // SwiftUI's Image(nsImage:) downscales cleanly from the
+                // 1024-square master.
+                Image(nsImage: AppIcon.image)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: 96, height: 96)
+                    .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                    .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
+                    .scaleEffect(pulse ? 1.03 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 1.8).repeatForever(autoreverses: true),
+                        value: pulse
+                    )
+                    .onAppear { pulse = true }
 
-            VStack(spacing: 6) {
-                Text(Theme.Copy.appName)
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                Text(Theme.Copy.tagline)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                VStack(spacing: 4) {
+                    Text(Theme.Copy.appName)
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                    Text(VersionInfo.short)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Check for Updates") {
+                    delegate.checkForUpdates()
+                }
+                .controlSize(.large)
+
+                Button("Show welcome again") {
+                    delegate.showWelcomeAgain()
+                    dismissWindow(id: aboutWindowID)
+                }
+                .buttonStyle(.link)
+                .font(.caption)
             }
+            .padding(.vertical, 28)
+            .padding(.horizontal, 28)
+            .frame(width: 360, height: 340)
 
-            VStack(spacing: 4) {
-                Text(VersionInfo.short)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text("Made to stop the fiddling.")
-                    .font(.caption.italic())
-                    .foregroundStyle(.secondary)
+            if showConfetti {
+                ConfettiBurst()
+                    .allowsHitTesting(false)
+                    .task {
+                        // Outlast the longest particle (~2.5s) so every
+                        // piece falls off the bottom before the layer
+                        // unmounts. After this, the ZStack collapses and
+                        // no animations keep ticking in the background.
+                        try? await Task.sleep(for: .seconds(2.6))
+                        showConfetti = false
+                    }
             }
-
-            Divider()
-                .padding(.horizontal, 40)
-
-            VStack(spacing: 4) {
-                Text("Lives quietly in your menu bar.")
-                Text("Watches your USB ports. Picks the right defaults.")
-            }
-            .font(.callout)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 24)
-
-            Button("Show welcome again") {
-                delegate.showWelcomeAgain()
-                dismissWindow(id: aboutWindowID)
-            }
-            .buttonStyle(.link)
-            .font(.caption)
         }
-        .padding(.vertical, 28)
-        .padding(.horizontal, 28)
-        .frame(width: 360, height: 460)
         .background(.background)
         .dialogWindowChrome()
         .centeredOnScreen()
+    }
+}
+
+// MARK: - Confetti
+
+/// One-shot confetti overlay. Generates a fixed batch of particles on
+/// init and lets each one animate itself from above the frame to below.
+/// No TimelineView, no DisplayLink — every particle has a single
+/// `.animation` driven by a per-particle `@State` flipped on appear.
+private struct ConfettiBurst: View {
+    private let particles: [ConfettiParticle.Spec] = (0..<36).map { _ in .random() }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                ForEach(particles) { spec in
+                    ConfettiParticle(spec: spec, containerSize: geo.size)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+    }
+}
+
+private struct ConfettiParticle: View {
+    let spec: Spec
+    let containerSize: CGSize
+    @State private var animate = false
+
+    var body: some View {
+        spec.shapeView
+            .frame(
+                width: spec.size,
+                height: spec.shape == .capsule ? spec.size * 2.2 : spec.size
+            )
+            .foregroundStyle(spec.color)
+            .rotationEffect(.degrees(animate ? spec.spin : 0))
+            .position(x: spec.startX * max(containerSize.width, 1), y: 0)
+            .offset(
+                x: animate ? spec.driftX : 0,
+                y: animate ? containerSize.height + 80 : -40
+            )
+            .animation(
+                .easeOut(duration: spec.duration),
+                value: animate
+            )
+            .onAppear { animate = true }
+    }
+
+    enum Shape: Equatable {
+        case circle, capsule, pill
+    }
+
+    struct Spec: Identifiable {
+        let id = UUID()
+        let startX: CGFloat       // 0...1, multiplied by container width
+        let driftX: CGFloat       // horizontal drift in points
+        let spin: Double          // total degrees over the fall
+        let duration: Double      // seconds
+        let size: CGFloat         // base dimension in points
+        let color: Color
+        let shape: Shape
+
+        @ViewBuilder
+        var shapeView: some View {
+            switch shape {
+            case .circle:
+                Circle()
+            case .capsule:
+                Capsule()
+            case .pill:
+                // Wink to the brand glyph — a few of the falling pieces
+                // are the same `pills.fill` symbol the menu bar wears.
+                Image(systemName: "pills.fill")
+                    .resizable()
+            }
+        }
+
+        static func random() -> Spec {
+            // System palette so the burst inherits the user's macOS
+            // accent color and stays plain-native.
+            let palette: [Color] = [.accentColor, .yellow, .pink, .green, .blue, .orange]
+            let shapes: [Shape] = [.circle, .capsule, .pill]
+            return Spec(
+                startX: .random(in: 0.05...0.95),
+                driftX: .random(in: -40...40),
+                spin: .random(in: -540...540),
+                duration: .random(in: 1.8...2.5),
+                size: .random(in: 7...11),
+                color: palette.randomElement() ?? .accentColor,
+                shape: shapes.randomElement() ?? .circle
+            )
+        }
     }
 }

--- a/Sources/AVPainRelieverApp/AboutView.swift
+++ b/Sources/AVPainRelieverApp/AboutView.swift
@@ -61,11 +61,12 @@ struct AboutView: View {
                 ConfettiBurst()
                     .allowsHitTesting(false)
                     .task {
-                        // Outlast the longest particle (~2.5s) so every
-                        // piece falls off the bottom before the layer
-                        // unmounts. After this, the ZStack collapses and
-                        // no animations keep ticking in the background.
-                        try? await Task.sleep(for: .seconds(2.6))
+                        // Outlast the longest particle trajectory
+                        // (max riseDuration + fallDuration ≈ 2.4s)
+                        // so every piece arcs back down before the
+                        // layer unmounts. After this, the ZStack
+                        // collapses and no animations keep ticking.
+                        try? await Task.sleep(for: .seconds(3.2))
                         showConfetti = false
                     }
             }
@@ -76,95 +77,3 @@ struct AboutView: View {
     }
 }
 
-// MARK: - Confetti
-
-/// One-shot confetti overlay. Generates a fixed batch of particles on
-/// init and lets each one animate itself from above the frame to below.
-/// No TimelineView, no DisplayLink — every particle has a single
-/// `.animation` driven by a per-particle `@State` flipped on appear.
-private struct ConfettiBurst: View {
-    private let particles: [ConfettiParticle.Spec] = (0..<36).map { _ in .random() }
-
-    var body: some View {
-        GeometryReader { geo in
-            ZStack {
-                ForEach(particles) { spec in
-                    ConfettiParticle(spec: spec, containerSize: geo.size)
-                }
-            }
-            .frame(width: geo.size.width, height: geo.size.height)
-        }
-    }
-}
-
-private struct ConfettiParticle: View {
-    let spec: Spec
-    let containerSize: CGSize
-    @State private var animate = false
-
-    var body: some View {
-        spec.shapeView
-            .frame(
-                width: spec.size,
-                height: spec.shape == .capsule ? spec.size * 2.2 : spec.size
-            )
-            .foregroundStyle(spec.color)
-            .rotationEffect(.degrees(animate ? spec.spin : 0))
-            .position(x: spec.startX * max(containerSize.width, 1), y: 0)
-            .offset(
-                x: animate ? spec.driftX : 0,
-                y: animate ? containerSize.height + 80 : -40
-            )
-            .animation(
-                .easeOut(duration: spec.duration),
-                value: animate
-            )
-            .onAppear { animate = true }
-    }
-
-    enum Shape: Equatable {
-        case circle, capsule, pill
-    }
-
-    struct Spec: Identifiable {
-        let id = UUID()
-        let startX: CGFloat       // 0...1, multiplied by container width
-        let driftX: CGFloat       // horizontal drift in points
-        let spin: Double          // total degrees over the fall
-        let duration: Double      // seconds
-        let size: CGFloat         // base dimension in points
-        let color: Color
-        let shape: Shape
-
-        @ViewBuilder
-        var shapeView: some View {
-            switch shape {
-            case .circle:
-                Circle()
-            case .capsule:
-                Capsule()
-            case .pill:
-                // Wink to the brand glyph — a few of the falling pieces
-                // are the same `pills.fill` symbol the menu bar wears.
-                Image(systemName: "pills.fill")
-                    .resizable()
-            }
-        }
-
-        static func random() -> Spec {
-            // System palette so the burst inherits the user's macOS
-            // accent color and stays plain-native.
-            let palette: [Color] = [.accentColor, .yellow, .pink, .green, .blue, .orange]
-            let shapes: [Shape] = [.circle, .capsule, .pill]
-            return Spec(
-                startX: .random(in: 0.05...0.95),
-                driftX: .random(in: -40...40),
-                spin: .random(in: -540...540),
-                duration: .random(in: 1.8...2.5),
-                size: .random(in: 7...11),
-                color: palette.randomElement() ?? .accentColor,
-                shape: shapes.randomElement() ?? .circle
-            )
-        }
-    }
-}

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -45,7 +45,7 @@ struct AVPainRelieverApp: SwiftUI.App {
         }
 
         Window("About AV Pain Reliever", id: aboutWindowID) {
-            AboutView(delegate: appDelegate)
+            AboutWindowContent(delegate: appDelegate)
         }
         .windowResizability(.contentSize)
 
@@ -117,6 +117,11 @@ private struct WelcomeWindowContent: View {
                 dismissWindow(id: welcomeWindowID)
             }
         )
+        // Mirrors the AboutWindowContent pattern: the open-token forces
+        // SwiftUI to tear down + rebuild WelcomeView every time the
+        // window is re-shown, resetting the confetti `@State` so the
+        // burst plays fresh on each open.
+        .id(delegate.welcomeOpenToken)
     }
 }
 
@@ -249,6 +254,9 @@ private struct MenuContentView: View {
         Divider()
 
         Button {
+            // Bump the About scene's open-token before showing it so
+            // the view tree rebuilds and the confetti burst replays.
+            delegate.willOpenAbout()
             openWindow(id: aboutWindowID)
             NSApp.activate(ignoringOtherApps: true)
         } label: {
@@ -376,6 +384,22 @@ private struct MenuContentView: View {
         return label
     }
 
+}
+
+/// Wrapper view inside the About Window scene. Mirrors the wizard
+/// pattern below: takes the AppDelegate as `@ObservedObject` so the
+/// Scene-level `.id(token)` actually picks up new tokens. Reading
+/// `appDelegate.aboutOpenToken` directly inside the Scene body does
+/// NOT work — `@NSApplicationDelegateAdaptor` at the App level
+/// doesn't make the Scene re-evaluate on `@Published` changes; only
+/// a View with `@ObservedObject` does.
+private struct AboutWindowContent: View {
+    @ObservedObject var delegate: AppDelegate
+
+    var body: some View {
+        AboutView(delegate: delegate)
+            .id(delegate.aboutOpenToken)
+    }
 }
 
 /// Wrapper view inside the Add-Profile Window scene. Watches the

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -101,6 +101,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// open (empty Name field on Edit, or vice versa).
     @Published var wizardOpenToken: UUID = UUID()
 
+    /// Bumped every time the About window is about to open. The About
+    /// scene applies this as a SwiftUI `.id`, forcing the view tree to
+    /// rebuild — which resets the confetti `@State` so the burst plays
+    /// fresh on every open instead of just the first.
+    @Published var aboutOpenToken: UUID = UUID()
+
+    /// Same trick for the Welcome window. Bumped wherever
+    /// `shouldShowWelcome` is flipped to true (first-launch + the
+    /// "Show welcome again" link from About) so the welcome view tree
+    /// rebuilds and the confetti burst replays on every open.
+    @Published var welcomeOpenToken: UUID = UUID()
+
     private var cancellables: Set<AnyCancellable> = []
 
     override init() {
@@ -206,6 +218,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // Defer to the next runloop turn so SwiftUI's window graph is
         // ready to receive the openWindow request.
         DispatchQueue.main.async { [weak self] in
+            self?.welcomeOpenToken = UUID()
             self?.shouldShowWelcome = true
             NSApp.activate(ignoringOtherApps: true)
         }
@@ -226,6 +239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // Toggling false→true is what `WelcomeOpener` watches for.
         shouldShowWelcome = false
         DispatchQueue.main.async { [weak self] in
+            self?.welcomeOpenToken = UUID()
             self?.shouldShowWelcome = true
             NSApp.activate(ignoringOtherApps: true)
         }
@@ -402,6 +416,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     func beginAddingProfile() {
         profileBeingEdited = nil
         wizardOpenToken = UUID()
+    }
+
+    /// Bump the About-scene token so SwiftUI rebuilds the view tree
+    /// next time the window is shown. Call immediately before
+    /// `openWindow(id: aboutWindowID)`.
+    func willOpenAbout() {
+        aboutOpenToken = UUID()
     }
 
     /// Confirm + delete a profile. Shown as a modal alert so the user

--- a/Sources/AVPainRelieverApp/ConfettiBurst.swift
+++ b/Sources/AVPainRelieverApp/ConfettiBurst.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// One-shot party-popper confetti. Every particle launches from a
+/// single point at the bottom-centre of the container, arcs up + outward
+/// in a wide cone, and falls back down. Each particle drives its own
+/// `KeyframeAnimator` (macOS 14+) so the rise → apex → fall trajectory
+/// gets two distinct timing segments (fast launch, slower return) that
+/// a single linear `.animation` can't express.
+///
+/// Sized via the surrounding layout — drop it into a ZStack overlay
+/// and let it expand to fill. Used by both the About and Welcome
+/// scenes; the burst plays once on appear and the parent unmounts the
+/// overlay after the longest trajectory finishes so nothing keeps
+/// ticking in the background.
+struct ConfettiBurst: View {
+    private let particles: [ConfettiParticle.Spec] = (0..<90).map { _ in .random() }
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                ForEach(particles) { spec in
+                    ConfettiParticle(spec: spec, containerSize: geo.size)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+    }
+}
+
+private struct ConfettiParticle: View {
+    let spec: Spec
+    let containerSize: CGSize
+    @State private var fire = false
+
+    var body: some View {
+        KeyframeAnimator(initialValue: Values(), trigger: fire) { values in
+            spec.shapeView
+                .frame(
+                    width: spec.size,
+                    height: spec.shape == .capsule ? spec.size * 2.2 : spec.size
+                )
+                .foregroundStyle(spec.color)
+                .rotationEffect(.degrees(values.rotation))
+                .offset(x: values.offsetX, y: values.offsetY)
+                .opacity(values.opacity)
+                .position(
+                    // Single launch point: bottom-centre of the container,
+                    // just under any visible buttons. Every particle starts
+                    // here and fans outward — that's what makes it read
+                    // as a burst rather than snowfall.
+                    x: containerSize.width / 2,
+                    y: containerSize.height - 40
+                )
+        } keyframes: { _ in
+            // Vertical trajectory: rise to apex (negative y in SwiftUI),
+            // then fall well past the launch point. CubicKeyframe gives
+            // smooth Catmull-Rom interpolation between segments — feels
+            // ballistic without us computing physics.
+            KeyframeTrack(\.offsetY) {
+                CubicKeyframe(-spec.peakRise, duration: spec.riseDuration)
+                CubicKeyframe(spec.fallTarget, duration: spec.fallDuration)
+            }
+            // Horizontal trajectory: travel to the apex's x, then a
+            // small extra drift on the way down (wind / tumble feel).
+            KeyframeTrack(\.offsetX) {
+                CubicKeyframe(spec.peakDX, duration: spec.riseDuration)
+                CubicKeyframe(spec.peakDX + spec.driftDX, duration: spec.fallDuration)
+            }
+            // Continuous spin across the whole flight.
+            KeyframeTrack(\.rotation) {
+                LinearKeyframe(spec.spin, duration: spec.riseDuration + spec.fallDuration)
+            }
+            // Fade out only in the last 30 % of the fall so particles
+            // are clearly visible through the apex and most of the
+            // descent, then disappear before the overlay unmounts.
+            KeyframeTrack(\.opacity) {
+                LinearKeyframe(1.0, duration: spec.riseDuration + spec.fallDuration * 0.7)
+                LinearKeyframe(0.0, duration: spec.fallDuration * 0.3)
+            }
+        }
+        .onAppear { fire.toggle() }
+    }
+
+    /// Animatable bag of values. KeyframeAnimator interpolates each
+    /// stored property along its KeyframeTrack and hands a fully-
+    /// interpolated `Values` to the content closure on every frame.
+    struct Values {
+        var offsetX: CGFloat = 0
+        var offsetY: CGFloat = 0
+        var rotation: Double = 0
+        var opacity: Double = 1
+    }
+
+    enum Shape: Equatable {
+        case circle, capsule, pill
+    }
+
+    struct Spec: Identifiable {
+        let id = UUID()
+        let peakDX: CGFloat       // x offset at apex (signed)
+        let peakRise: CGFloat     // positive number; subtracted from y at apex
+        let driftDX: CGFloat      // extra x drift on the way down
+        let fallTarget: CGFloat   // final y offset (positive → below origin)
+        let riseDuration: Double
+        let fallDuration: Double
+        let spin: Double
+        let size: CGFloat
+        let color: Color
+        let shape: Shape
+
+        @ViewBuilder
+        var shapeView: some View {
+            switch shape {
+            case .circle:
+                Circle()
+            case .capsule:
+                Capsule()
+            case .pill:
+                // Wink to the brand glyph — a few of the launched pieces
+                // are the same `pills.fill` symbol the menu bar wears.
+                Image(systemName: "pills.fill")
+                    .resizable()
+            }
+        }
+
+        static func random() -> Spec {
+            // System palette so the burst inherits the user's macOS
+            // accent color and stays plain-native.
+            let palette: [Color] = [.accentColor, .yellow, .pink, .green, .blue, .orange]
+            let shapes: [Shape] = [.circle, .capsule, .pill]
+            // Launch angle in standard math radians where 0 = right and
+            // -π/2 = straight up. Range -150°…-30° is a 120° upward
+            // cone — wide enough to look chaotic, narrow enough that
+            // every particle visibly clears the buttons.
+            let angle = Double.random(in: -.pi * 5/6 ... -.pi * 1/6)
+            // Big power range — the strongest particles arc well past
+            // the dialog's edges and clip at the window bounds. That
+            // clipping is the price for keeping the confetti inside
+            // the existing Window scene; rendering truly outside the
+            // window requires a borderless transparent host window,
+            // which is a separate change.
+            let power = Double.random(in: 200...420)
+            let peakDX = CGFloat(cos(angle) * power)
+            // sin(angle) is negative across the upward cone; flip to a
+            // positive rise so the trajectory keyframe can subtract it
+            // from y (SwiftUI y-down).
+            let peakRise = CGFloat(-sin(angle) * power)
+            return Spec(
+                peakDX: peakDX,
+                peakRise: peakRise,
+                driftDX: CGFloat.random(in: -40...40),
+                fallTarget: CGFloat.random(in: 360...560),
+                riseDuration: Double.random(in: 0.5...0.85),
+                fallDuration: Double.random(in: 1.4...2.2),
+                spin: Double.random(in: -900...900),
+                size: CGFloat.random(in: 8...14),
+                color: palette.randomElement() ?? .accentColor,
+                shape: shapes.randomElement() ?? .circle
+            )
+        }
+    }
+}

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -42,9 +42,9 @@ enum Theme {
     }
 
     enum Copy {
-        /// Tagline shown in About + first-run welcome. Keep voice warm,
+        /// Tagline shown under the welcome greeting. Keep voice warm,
         /// not corporate; the user-facing personality lives here.
-        static let tagline = "Stop fiddling with mic, speakers, and webcam."
+        static let tagline = "Your audio and camera, dialed in automatically."
         static let appName = "AV Pain Reliever"
     }
 }

--- a/Sources/AVPainRelieverApp/WelcomeView.swift
+++ b/Sources/AVPainRelieverApp/WelcomeView.swift
@@ -10,75 +10,78 @@ let welcomeWindowID = "welcome-window"
 struct WelcomeView: View {
     let onAddProfile: () -> Void
     let onSkip: () -> Void
+    @State private var showConfetti = true
 
     var body: some View {
-        VStack(spacing: 24) {
-            Image(nsImage: AppIcon.image)
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 104, height: 104)
-                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-                .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
+        ZStack {
+            VStack(spacing: 24) {
+                Image(nsImage: AppIcon.image)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: 104, height: 104)
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                    .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
 
-            VStack(spacing: 8) {
-                Text("Welcome to \(Theme.Copy.appName)")
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                    .multilineTextAlignment(.center)
-                Text(Theme.Copy.tagline)
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            VStack(alignment: .leading, spacing: 12) {
-                bullet(symbol: "cable.connector",
-                       text: "Plug in your dock, microphone, or webcam.")
-                bullet(symbol: "wand.and.stars",
-                       text: "AV Pain Reliever notices and switches your audio + camera defaults — automatically.")
-                bullet(symbol: "sparkles",
-                       text: "No tinkering with System Settings before every meeting.")
-            }
-            .padding(.horizontal, 18)
-
-            Spacer(minLength: 0)
-
-            VStack(spacing: 10) {
-                Button(action: onAddProfile) {
-                    Text("Add Your First Location")
-                        .frame(minWidth: 220)
-                        .padding(.vertical, 4)
+                VStack(spacing: 8) {
+                    Text(Self.greetingTitle)
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                        .multilineTextAlignment(.center)
+                    Text(Theme.Copy.tagline)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
 
-                Button("Skip — I'll set up later", action: onSkip)
-                    .buttonStyle(.borderless)
-                    .keyboardShortcut(.cancelAction)
+                Spacer(minLength: 0)
+
+                VStack(spacing: 10) {
+                    Button(action: onAddProfile) {
+                        Text("Add Your First Location")
+                            .frame(minWidth: 220)
+                            .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
+
+                    Button("Skip — I'll set up later", action: onSkip)
+                        .buttonStyle(.borderless)
+                        .keyboardShortcut(.cancelAction)
+                }
+            }
+            .padding(.vertical, 32)
+            .padding(.horizontal, 28)
+            .frame(width: 480, height: 540)
+
+            if showConfetti {
+                ConfettiBurst()
+                    .allowsHitTesting(false)
+                    .task {
+                        // Outlast the longest particle trajectory so
+                        // every piece arcs back down before the layer
+                        // unmounts. After this, the ZStack collapses
+                        // and no animations keep ticking.
+                        try? await Task.sleep(for: .seconds(3.2))
+                        showConfetti = false
+                    }
             }
         }
-        .padding(.vertical, 32)
-        .padding(.horizontal, 28)
-        .frame(width: 480, height: 540)
         .background(.background)
         .dialogWindowChrome()
         .centeredOnScreen()
     }
 
-    /// Three bullet rows below the tagline. Each pairs an SF Symbol
-    /// with one short sentence — easier to scan than a single dense
-    /// paragraph and gives the user a sense of the product shape on
-    /// first read.
-    private func bullet(symbol: String, text: String) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: symbol)
-                .font(.body.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 24, alignment: .center)
-            Text(text)
-                .font(.callout)
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
+    /// Personalised welcome title. Uses the macOS account holder's
+    /// first name when available so first launch reads as a hello to
+    /// the human at the keyboard, not the product. `NSFullUserName()`
+    /// is set by macOS at account creation and almost always non-empty,
+    /// but the fallback covers headless / unusual setups.
+    private static var greetingTitle: String {
+        let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        let firstName = full.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? ""
+        if firstName.isEmpty {
+            return "Welcome to \(Theme.Copy.appName)"
         }
+        return "Welcome, \(firstName)."
     }
 }


### PR DESCRIPTION
## Summary

### About dialog
- Refocuses on what actually matters there: app icon, name, version, an update affordance, and the existing "Show welcome again" link.
- Drops the "Stop fiddling…" tagline, the italic "Made to stop the fiddling." line, and the descriptive "Lives quietly in your menu bar…" block.
- Adds a bordered **Check for Updates** button wired to the existing `delegate.checkForUpdates()` Sparkle pass-through.
- Frame shrinks 360×460 → 360×340.

### Welcome dialog
- Personalised greeting via `NSFullUserName()` — "Welcome, Eric." with a fallback to "Welcome to AV Pain Reliever" when the name is empty.
- `Theme.Copy.tagline` updated to "Your audio and camera, dialed in automatically." (was "Stop fiddling with mic, speakers, and webcam.").
- Three feature bullets removed; the unused `bullet(symbol:text:)` helper went with them.

### Confetti (shared by About + Welcome)
- Hand-rolled SwiftUI, no SPM dep. 90 particles (Circle / Capsule / `pills.fill` brand-glyph wink) with random color/size/drift/spin/duration.
- Party-popper trajectory via macOS 14+ `KeyframeAnimator`: launch from a single point at the bottom-centre, arc up + outward in a 120° upward cone (power 200–420 pts), Catmull-Rom interpolation through apex, fall with extra horizontal drift. Total flight ≤ ~3 s; the overlay unmounts after 3.2 s so nothing keeps ticking in the background.
- Extracted from `AboutView.swift` into `ConfettiBurst.swift` so both dialogs can use it.

### Replay-on-open plumbing
- `aboutOpenToken` + `welcomeOpenToken` on `AppDelegate`. New `AboutWindowContent` wrapper observes the delegate as `@ObservedObject` and stamps `.id(token)` on its child view (the Scene-level `@NSApplicationDelegateAdaptor` doesn't trigger Scene re-evaluation on `@Published` changes — same lesson the wizard learned).
- About token bumped from a new `willOpenAbout()` called from the menu's About button. Welcome token bumped wherever `shouldShowWelcome` flips to true (first-launch + the "Show welcome again" link).

## Test plan

- [x] `swift build` clean.
- [x] About: open → confetti plays once, falls off, layer goes quiet. Layout: icon → name → version → Check for Updates → Show welcome again. Close + reopen → confetti replays.
- [x] Show welcome again → About dismisses, Welcome opens. Confetti plays. Greeting reads "Welcome, [name]." Tagline is the new one. No bullets.
- [x] Reopen Welcome multiple times → confetti replays each time.
- [ ] Bundled-build verification of "Check for Updates" → defers to the shipped `.app` (Sparkle controller is gated to bundled builds with a real `SUPublicEDKey`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)