### PR TITLE
Update window: front-most, titled, with release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,10 +138,56 @@ jobs:
           ditto -c -k --sequesterRsrc --keepParent \
               dist/AVPainReliever.app dist/AVPainReliever.app.zip
 
+      - name: Create or update draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Two flows are supported:
+          #   1. Curated notes: maintainer pre-creates the release as a
+          #      draft with --notes "..." BEFORE pushing the tag. We
+          #      detect the existing release and just attach the asset.
+          #   2. Auto notes: no prior release exists. We create a draft
+          #      with --generate-notes (commit-list fallback). The
+          #      maintainer can edit the body in the draft before
+          #      publishing; the post-publish workflow will refresh the
+          #      appcast description.
+          if gh release view "$VERSION_TAG" >/dev/null 2>&1; then
+              gh release upload "$VERSION_TAG" dist/AVPainReliever.app.zip --clobber
+          else
+              gh release create "$VERSION_TAG" \
+                  dist/AVPainReliever.app.zip \
+                  --draft \
+                  --generate-notes \
+                  --title "$VERSION_TAG"
+          fi
+
+      - name: Render release notes to HTML
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BODY="$(gh release view "$VERSION_TAG" --json body --jq .body 2>/dev/null || true)"
+          if [[ -z "$BODY" ]]; then
+              echo "::notice::Release body is empty; appcast item will not include a description"
+              echo "RELEASE_NOTES_HTML=" >> "$GITHUB_ENV"
+              exit 0
+          fi
+          # GitHub's /markdown API renders GFM exactly like the release
+          # page does, so the appcast HTML matches what the user sees on
+          # the release page.
+          HTML="$(gh api -X POST /markdown -f text="$BODY" -f mode=gfm)"
+          {
+              echo "RELEASE_NOTES_HTML<<APPCAST_EOF"
+              echo "$HTML"
+              echo "APPCAST_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Sign appcast item
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           VERSION: ${{ env.VERSION_NUM }}
+          RELEASE_NOTES_HTML: ${{ env.RELEASE_NOTES_HTML }}
         run: |
           set -euo pipefail
           if [[ -z "${SPARKLE_PRIVATE_KEY:-}" ]]; then
@@ -152,17 +198,6 @@ jobs:
           ITEM_FILE="$RUNNER_TEMP/appcast-item.xml"
           scripts/sign-appcast.sh dist/AVPainReliever.app.zip > "$ITEM_FILE"
           echo "APPCAST_ITEM_FILE=$ITEM_FILE" >> "$GITHUB_ENV"
-
-      - name: Create draft GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh release create "$VERSION_TAG" \
-              dist/AVPainReliever.app.zip \
-              --draft \
-              --generate-notes \
-              --title "$VERSION_TAG"
 
       - name: Append item to appcast.xml on main
         env:

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import Sparkle
 import OSLog
 
@@ -73,12 +74,43 @@ final class Updater {
         self.controller = controller
         let feedDescription = controller.updater.feedURL?.absoluteString ?? "nil"
         Self.logger.info("Sparkle updater started; feed=\(feedDescription, privacy: .public)")
+        installWindowTitleObserver()
     }
 
-    /// User-initiated update check (menu item action). Sparkle shows
-    /// its own progress + "you're up to date" UI — nothing for us
-    /// to render.
+    /// Sparkle's update alert XIB doesn't set a window title, so its
+    /// windows render with a blank title bar. We can't override the
+    /// XIB without forking Sparkle, but we can name the window at
+    /// runtime: when any window keys, check whether its window
+    /// controller (or the window itself) is one of Sparkle's
+    /// `SU…` / `SPU…` classes and, if so, give it a title.
+    /// Heuristic but cheap; a Sparkle internal class rename would
+    /// silently drop the title back to blank — acceptable downside.
+    private func installWindowTitleObserver() {
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { notification in
+            guard let window = notification.object as? NSWindow else { return }
+            guard window.title.isEmpty else { return }
+            let controllerClass = window.windowController.map { NSStringFromClass(type(of: $0)) } ?? ""
+            let windowClass = NSStringFromClass(type(of: window))
+            let looksLikeSparkle =
+                controllerClass.hasPrefix("SU") || controllerClass.hasPrefix("SPU") ||
+                windowClass.hasPrefix("SU") || windowClass.hasPrefix("SPU")
+            if looksLikeSparkle {
+                window.title = "Software Update"
+            }
+        }
+    }
+
+    /// User-initiated update check (menu item action). Activate first
+    /// so AV Pain Reliever is the frontmost app when Sparkle's window
+    /// appears after the feed fetch — without this, an LSUIElement
+    /// build's update window can land behind whatever app you've
+    /// switched to while the network call was in flight.
     func checkForUpdates() {
+        NSApp.activate(ignoringOtherApps: true)
         controller.checkForUpdates(nil)
     }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -105,18 +105,34 @@ from your working directory.
 1. Bump the version. There's no version source file — the `git tag` is
    the version. Verify `Resources/Info.plist` doesn't have anything
    stale.
-2. Tag and push:
+2. **(Recommended)** Pre-create the GitHub release as a draft with
+   curated release notes — these become the "What's New" panel in
+   Sparkle's update window:
    ```sh
-   git tag v0.1.0
-   git push origin v0.1.0
+   gh release create v0.1.11 --draft --notes "$(cat <<'EOF'
+   ## What's new
+   - Confetti when you open About
+   - Personalised welcome greeting
+   - Update window comes to the front when checking
+   EOF
+   )"
    ```
-3. Watch the run: `gh run watch` (or in the browser).
-4. Once the workflow completes:
+   If you skip this step, the workflow falls back to
+   `--generate-notes` (a "What's Changed" commit list).
+3. Tag and push:
+   ```sh
+   git tag v0.1.11
+   git push origin v0.1.11
+   ```
+4. Watch the run: `gh run watch` (or in the browser).
+5. Once the workflow completes:
    - The release is in **draft** state — review and publish it
      manually via the Releases page.
    - `appcast.xml` on `main` has a new `<item>` referencing the
-     release asset. Existing v0.0.x installs see the update on their
-     next Sparkle check (or via Advanced → Check for Updates…).
+     release asset. Existing installs see the update on their next
+     Sparkle check (or via Advanced → Check for Updates…), and the
+     update window shows the release notes panel sourced from your
+     GitHub release body.
 
 ### First-tag checklist
 

--- a/scripts/sign-appcast.sh
+++ b/scripts/sign-appcast.sh
@@ -10,6 +10,11 @@
 # Or, when working from your login keychain (no env var):
 #   VERSION=0.1.0 scripts/sign-appcast.sh dist/AVPainReliever.app.zip
 #
+# Optional inputs:
+#   - $RELEASE_NOTES_HTML  Pre-rendered HTML embedded as the item's
+#                          <description>. Sparkle uses this to populate
+#                          its "What's New" panel.
+#
 # Outputs to stdout:
 #   - The full <item> block (URL placeholder included; replace before
 #     committing to appcast.xml).
@@ -54,10 +59,22 @@ ZIP_NAME="$(basename "$ZIP")"
 PUBDATE="$(LC_TIME=en_US.UTF-8 TZ=UTC date '+%a, %d %b %Y %H:%M:%S +0000')"
 ASSET_URL="https://github.com/superic/av-pain-reliever/releases/download/v$VERSION/$ZIP_NAME"
 
+# Optional: $RELEASE_NOTES_HTML is rendered HTML for the <description>
+# field. When set, Sparkle expands its update window with a "What's
+# New" panel. CDATA-wrapping keeps the HTML's `<` / `>` characters
+# legal inside the appcast XML.
+DESCRIPTION_BLOCK=""
+if [[ -n "${RELEASE_NOTES_HTML:-}" ]]; then
+    DESCRIPTION_BLOCK="            <description><![CDATA[
+${RELEASE_NOTES_HTML}
+]]></description>
+"
+fi
+
 cat <<XML
         <item>
             <title>Version $VERSION</title>
-            <pubDate>$PUBDATE</pubDate>
+${DESCRIPTION_BLOCK}            <pubDate>$PUBDATE</pubDate>
             <sparkle:version>$VERSION</sparkle:version>
             <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
## Summary

Three pieces of polish for Sparkle's update flow.

### Runtime fixes in `Updater.swift`

- **Front-most**: `NSApp.activate(ignoringOtherApps: true)` before `controller.checkForUpdates(nil)`. Fixes the LSUIElement-build issue where Sparkle's update window appears behind whichever app the user switched to while the feed was loading. Verified locally with a `VERSION=0.1.9` dev build against the `v0.1.10` appcast item.
- **Window title**: a `windowDidBecomeKey` observer that matches Sparkle's `SU…` / `SPU…` controller/window classes and renames the title bar to **"Software Update"**. Sparkle's `SUUpdateAlert` XIB ships with no title; we can't fork the XIB without forking Sparkle, so this is the cheapest reliable workaround.

### Release-notes pipeline

- **`scripts/sign-appcast.sh`** accepts `$RELEASE_NOTES_HTML` and embeds it as `<description><![CDATA[...]]></description>`. Sparkle expands its update window with a "What's New" panel.
- **`.github/workflows/release.yml`** reorders the steps so the draft release exists before the appcast is signed; fetches the body via `gh release view`, renders it to HTML via `gh api -X POST /markdown` (GFM mode), and passes the HTML to the signer. Both flows supported:
  - **Curated**: pre-create the draft with `gh release create vX.Y.Z --draft --notes "..."` before pushing the tag — the workflow uses your notes.
  - **Auto fallback**: just push the tag — the workflow creates a draft with `--generate-notes` and uses the commit list.
- **`docs/RELEASING.md`** documents the optional pre-create step.

## Test plan

- [x] `swift build` clean.
- [x] `make-app.sh` local build → About → Check for Updates → window comes to the front; title bar reads "Software Update".
- [ ] Release-notes panel: only verifiable in production. The first release built through this pipeline (v0.1.11) will be the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)