### PR TITLE
CI: bump actions/checkout + actions/cache to v5 for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -36,7 +36,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Cache SPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .build


### PR DESCRIPTION
## Summary

Both `v4` versions of these official actions run on Node 20. GitHub forces Node 24 default on **2026-06-02** and removes Node 20 entirely on **2026-09-16**. `v5` of each is Node 24 native and has been in wide use since mid-2025 — mechanical bump on our end, the upgrade path the ecosystem has settled on.

Changes:
- `.github/workflows/release.yml` — `actions/checkout@v4` → `@v5`
- `.github/workflows/test.yml` — `actions/checkout@v4` → `@v5`, `actions/cache@v4` → `@v5`

## Out of scope

- `maxim-lobanov/setup-xcode@v1` — community action, lower leverage to chase ahead of a real failure. If it stops working under Node 24, the runner will surface it loudly and we'll bump then.
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` — the "test the future runner today" lever. Cleaner to upgrade the actions themselves.

## Test plan

- [ ] CI run on this PR confirms `actions/checkout@v5` + `actions/cache@v5` succeed on `macos-14`. The deprecation warning for those two actions should disappear from the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)