### PR TITLE
feature/virtual-camera: M1 — Camera Extension scaffold

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,17 @@ jobs:
               echo "APPCAST_ITEM_FILE=" >> "$GITHUB_ENV"
               exit 0
           fi
+          # v0.2.x+ ships through the experimental Sparkle channel —
+          # only installs that have allowlisted "experimental" (via
+          # the Settings → General → Updates → Receive experimental
+          # updates toggle) see these items as available upgrades.
+          # v0.1.x stays on the empty/stable channel so every install
+          # picks them up automatically.
+          case "$VERSION_TAG" in
+              v0.0.0-*|v0.1.*) export CHANNEL= ;;
+              *) export CHANNEL=experimental ;;
+          esac
+          echo "Appcast channel: ${CHANNEL:-<stable>}"
           ITEM_FILE="$RUNNER_TEMP/appcast-item.xml"
           scripts/sign-appcast.sh dist/AVPainReliever.app.zip > "$ITEM_FILE"
           echo "APPCAST_ITEM_FILE=$ITEM_FILE" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@
 #
 # Trigger: push of a tag matching v*.*.* (e.g. v0.1.0). Steps:
 #   1. Build a universal-binary, Developer-ID-signed, hardened-runtime
-#      AVPainReliever.app via scripts/make-app.sh.
+#      AVPainReliever.app via the right build script for the tag:
+#        - v0.0.0-* / v0.1.* → scripts/make-app.sh (no virtual camera)
+#        - v0.2.* and later  → scripts/make-app-with-virtual-camera.sh
+#          (includes embedded CMIO Camera Extension)
 #   2. Notarize via notarytool (--wait), then staple the ticket.
 #   3. EdDSA-sign the .app.zip with Sparkle's sign_update.
 #   4. Create a draft GitHub Release with auto-generated notes and the
@@ -11,13 +14,17 @@
 #      installs see the update.
 #
 # Required GitHub Secrets — see docs/RELEASING.md for setup instructions:
-#   MACOS_CERTIFICATE          base64 of the Developer ID Application .p12
-#   MACOS_CERTIFICATE_PASSWORD .p12 password
-#   MACOS_KEYCHAIN_PASSWORD    random — for the temp keychain Actions creates
-#   APPLE_ID                   developer Apple ID email
-#   APPLE_ID_PASSWORD          app-specific password for notarytool
-#   APPLE_TEAM_ID              10-char Team ID
-#   SPARKLE_PRIVATE_KEY        EdDSA private key from generate_keys -x (raw, base64-decoded contents)
+#   MACOS_CERTIFICATE             base64 of the Developer ID Application .p12
+#   MACOS_CERTIFICATE_PASSWORD    .p12 password
+#   MACOS_KEYCHAIN_PASSWORD       random — for the temp keychain Actions creates
+#   MACOS_PROVISIONING_PROFILE    base64 of AVPainReliever.provisionprofile
+#                                 (only needed for v0.2.x+ — the system
+#                                 extension activation requires it; v0.1.x
+#                                 builds never see this step)
+#   APPLE_ID                      developer Apple ID email
+#   APPLE_ID_PASSWORD             app-specific password for notarytool
+#   APPLE_TEAM_ID                 10-char Team ID
+#   SPARKLE_PRIVATE_KEY           EdDSA private key from generate_keys -x (raw, base64-decoded contents)
 #
 # Each step that depends on a secret early-exits with a warning when
 # the secret is empty. That makes a v0.0.0-dryrun tag possible without
@@ -54,6 +61,43 @@ jobs:
 
       - name: Compute version number
         run: echo "VERSION_NUM=${VERSION_TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Pick build script for this tag
+        # v0.1.x stays on the no-virtual-camera build to keep the
+        # existing release line shipping unblocked while v0.2.x is
+        # built from feature/virtual-camera. Anything matching v0.2.*
+        # or later (including v1.x) gets the virtual-camera build.
+        run: |
+          set -euo pipefail
+          case "$VERSION_TAG" in
+              v0.0.0-*|v0.1.*)
+                  BUILD_SCRIPT=scripts/make-app.sh
+                  ;;
+              *)
+                  BUILD_SCRIPT=scripts/make-app-with-virtual-camera.sh
+                  ;;
+          esac
+          echo "BUILD_SCRIPT=$BUILD_SCRIPT" >> "$GITHUB_ENV"
+          echo "Selected build script: $BUILD_SCRIPT"
+
+      - name: Decode provisioning profile
+        # Only required for builds that embed the Camera Extension.
+        # Skipped silently for v0.1.x tags (the no-virtual-camera path)
+        # so its release pipeline stays a no-op for this step.
+        env:
+          PROFILE_BASE64: ${{ secrets.MACOS_PROVISIONING_PROFILE }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_SCRIPT" != "scripts/make-app-with-virtual-camera.sh" ]]; then
+              echo "Skipping — v0.1.x build doesn't embed an extension"
+              exit 0
+          fi
+          if [[ -z "${PROFILE_BASE64:-}" ]]; then
+              echo "::warning::MACOS_PROVISIONING_PROFILE secret is empty — signed v0.2.x+ build will fail without it"
+              exit 0
+          fi
+          echo -n "$PROFILE_BASE64" | base64 --decode -o Resources/AVPainReliever.provisionprofile
+          echo "Wrote Resources/AVPainReliever.provisionprofile ($(stat -f%z Resources/AVPainReliever.provisionprofile) bytes)"
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -109,8 +153,11 @@ jobs:
         run: |
           set -euo pipefail
           # MAC_CERT_NAME is set by the keychain step when secrets
-          # were available; otherwise unset → make-app.sh ad-hoc signs.
-          scripts/make-app.sh
+          # were available; otherwise unset → script ad-hoc signs.
+          # BUILD_SCRIPT was picked by the earlier step based on the
+          # tag prefix (v0.1.x → make-app.sh, v0.2.x+ →
+          # make-app-with-virtual-camera.sh).
+          "$BUILD_SCRIPT"
 
       - name: Notarize and staple
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ dist/
 # developer.apple.com, and contain the team ID + cert hashes —
 # never commit. Each developer drops their own at this path.
 Resources/*.provisionprofile
+
+# Signing certs — installed in the Keychain, not the repo.
+# .cer is the public cert (not sensitive) but still doesn't belong
+# in source control; .p12 carries the private key and *must* never
+# be committed.
+*.cer
+*.p12

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ prototypes/hammerspoon/logs/
 
 # Distribution output — produced by scripts/make-app.sh; never commit.
 dist/
+
+# Provisioning profiles. Team-specific, regenerable from
+# developer.apple.com, and contain the team ID + cert hashes —
+# never commit. Each developer drops their own at this path.
+Resources/*.provisionprofile

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,15 @@ let package = Package(
     products: [
         .library(name: "AVPainReliever", targets: ["AVPainReliever"]),
         .executable(name: "AVPainRelieverApp", targets: ["AVPainRelieverApp"]),
+        // V2 virtual-camera Camera Extension. Built only when the
+        // make-app-with-virtual-camera.sh release script asks for it
+        // — the default `make-app.sh` (v0.1.x) doesn't embed it. See
+        // SWIFT_PORT.md "V2 plan: native virtual camera" for the
+        // architecture rationale.
+        .executable(
+            name: "AVPainRelieverCameraExtension",
+            targets: ["AVPainRelieverCameraExtension"]
+        ),
     ],
     dependencies: [
         // TOML parser. Foundation has JSON/plist but no TOML; locked
@@ -64,6 +73,14 @@ let package = Package(
         .testTarget(
             name: "AVPainRelieverAppTests",
             dependencies: ["AVPainRelieverApp"]
+        ),
+        // Camera Extension binary. Imports CoreMediaIO directly; no
+        // dependency on AVPainReliever or AVPainRelieverApp — the
+        // extension runs in its own process with a clean boundary.
+        // The compiled binary is wrapped in a .systemextension bundle
+        // by scripts/make-app-with-virtual-camera.sh.
+        .executableTarget(
+            name: "AVPainRelieverCameraExtension"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ When you carry a MacBook between locations — your home office, a work desk, a 
 
 Configure your video apps (Zoom, Slack, Teams) once to follow the system, and after that the right setup is active the moment you plug in. Unplug and it returns to your laptop's built-in mic and speakers.
 
+Some apps — Zoom, Slack, Teams — keep their own camera selection that ignores the system default. For those, AV Pain Reliever can also act as a **virtual camera** that always streams whatever camera the active profile names. See *Virtual camera* below.
+
 The app lives in your menu bar — no Dock icon, no windows in your way.
 
 ---
@@ -56,6 +58,23 @@ Click the menu bar icon for:
 - **Add Profile…** — capture the dock you're at right now (⌘N).
 - **Settings…** — notifications, menu bar appearance, profile management, Launch at Login (⌘,).
 - **About** — version and updates.
+
+---
+
+## Virtual camera (optional)
+
+Zoom, Slack, and Teams remember the camera you pick *inside their own settings* and ignore the system default. So even after AV Pain Reliever changes your system camera, those apps keep using whatever you last chose in their picker.
+
+The virtual camera fixes that. Once turned on, **AV Pain Reliever** appears as a camera in any video app's picker. Pick it once and it then streams whichever real camera the active profile names — built-in, USB capture card, iPhone Continuity Camera, anything you can configure in a profile. When the profile changes, the picture follows.
+
+To enable:
+
+1. Open **Settings… → Camera**.
+2. Toggle **Enable AV Pain Reliever as a virtual camera**.
+3. Approve in **System Settings → General → Login Items & Extensions** when prompted (one-time setup).
+4. In Zoom / Slack / Teams, pick **AV Pain Reliever** as your camera.
+
+To turn it off, flip the toggle back. The "AV Pain Reliever" entry stops showing up in those apps' camera lists.
 
 ---
 

--- a/Resources/AVPainReliever-WithVirtualCamera.entitlements
+++ b/Resources/AVPainReliever-WithVirtualCamera.entitlements
@@ -10,5 +10,7 @@
 	<array>
 		<string>HLH4LEWS9S.group.com.ericwillis.avpainreliever</string>
 	</array>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>

--- a/Resources/AVPainReliever-WithVirtualCamera.entitlements
+++ b/Resources/AVPainReliever-WithVirtualCamera.entitlements
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+	v0.2.0+ host-app entitlements. Adds the system-extension install
+	capability so AVPainRelieverApp can submit OSSystemExtensionRequest
+	to activate the bundled Camera Extension. Requires the
+	`com.apple.developer.system-extension.install` capability on the
+	provisioning profile (granted automatically with the Apple
+	Developer Program; no separate request needed).
+
+	The default v0.1.x release pipeline still uses
+	AVPainReliever.entitlements, which omits this entitlement —
+	those builds don't embed the Camera Extension and have no need
+	to request system-extension installs.
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.developer.system-extension.install</key>
+	<true/>
+</dict>
+</plist>

--- a/Resources/AVPainReliever-WithVirtualCamera.entitlements
+++ b/Resources/AVPainReliever-WithVirtualCamera.entitlements
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-	v0.2.0+ host-app entitlements. Adds the system-extension install
-	capability so AVPainRelieverApp can submit OSSystemExtensionRequest
-	to activate the bundled Camera Extension. Requires the
-	`com.apple.developer.system-extension.install` capability on the
-	provisioning profile (granted automatically with the Apple
-	Developer Program; no separate request needed).
-
-	The default v0.1.x release pipeline still uses
-	AVPainReliever.entitlements, which omits this entitlement —
-	those builds don't embed the Camera Extension and have no need
-	to request system-extension installs.
--->
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
 	<key>com.apple.developer.system-extension.install</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>HLH4LEWS9S.group.com.ericwillis.avpainreliever</string>
+	</array>
 </dict>
 </plist>

--- a/Resources/AVPainRelieverCameraExtension-Info.plist
+++ b/Resources/AVPainRelieverCameraExtension-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>AV Pain Reliever Camera Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>AVPainRelieverCameraExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ericwillis.avpainreliever.CameraExtension</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>AVPainRelieverCameraExtension</string>
+	<key>CFBundlePackageType</key>
+	<string>SYSX</string>
+	<key>CFBundleShortVersionString</key>
+	<string>__MARKETING_VERSION__</string>
+	<key>CFBundleVersion</key>
+	<string>__BUILD_VERSION__</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 Eric Willis. MIT-licensed.</string>
+</dict>
+</plist>

--- a/Resources/AVPainRelieverCameraExtension-Info.plist
+++ b/Resources/AVPainRelieverCameraExtension-Info.plist
@@ -24,5 +24,20 @@
 	<string>14.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Eric Willis. MIT-licensed.</string>
+	<!--
+		`CMIOExtension` dict is the marker that tells `sysextd` this
+		bundle is a Camera Extension (vs DriverKit / NetworkExtension /
+		EndpointSecurity). Without it, activation fails with "does not
+		appear to belong to any extension categories." Mach service
+		name format is "<TEAMID>.<bundle-id>" — substituted at build
+		time by scripts/make-app-with-virtual-camera.sh.
+	-->
+	<key>CMIOExtension</key>
+	<dict>
+		<key>CMIOExtensionMachServiceName</key>
+		<string>__TEAM_ID__.group.com.ericwillis.avpainreliever.CameraExtension</string>
+	</dict>
+	<key>NSSystemExtensionUsageDescription</key>
+	<string>AV Pain Reliever uses a Camera Extension to publish a virtual camera that follows the active profile.</string>
 </dict>
 </plist>

--- a/Resources/AVPainRelieverCameraExtension.entitlements
+++ b/Resources/AVPainRelieverCameraExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/Resources/AVPainRelieverCameraExtension.entitlements
+++ b/Resources/AVPainRelieverCameraExtension.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>HLH4LEWS9S.group.com.ericwillis.avpainreliever</string>
+	</array>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,6 +30,8 @@
 	<string>14.0</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>AV Pain Reliever reads frames from the camera selected by your active profile and forwards them to the AV Pain Reliever virtual camera.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Eric Willis. MIT-licensed.</string>
 	<key>NSSupportsAutomaticTermination</key>

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3191,9 +3191,145 @@ graph does not guarantee the host that activated it can see
 it. Always test the picker from inside the host, not just
 Photo Booth.
 
----
+### Lazy capture, signaled from the extension (2026-05-04)
 
-## How to use this document
+User report: "macOS shows the green camera light on whenever
+AV Pain Reliever is running, even when I'm not in a call.
+OBS doesn't do this."
+
+Root cause: `VirtualCameraActivator.enable()` was opening an
+`AVCaptureSession` on the user's webcam the moment the
+toggle flipped, regardless of whether anything was reading
+the virtual camera. Always-on capture = always-on green
+light. The original M3 design picked this for hold-last-frame
+guarantees during mid-call source swaps, but those guarantees
+only matter while a call is in progress; the rest of the
+time the running session was pure waste.
+
+OBS comparison: OBS gates capture on (a) a scene that uses
+the camera being active AND (b) a downstream consumer
+reading the OBS Virtual Camera output. We had neither gate.
+
+Constraint that shaped the fix (M2 attempt #1, above): the
+Camera Extension itself can't run AVFoundation, so we can't
+move capture into the extension. Capture stays host-side; the
+only knob is *when* the host starts/stops it.
+
+Design:
+
+- Extension exposes a "consumer is active" signal via Darwin
+  notifications (Team-ID-prefixed names so the sandbox lets
+  the extension post). Edge-triggered on `streamingCounter`
+  0↔1 transitions in `CameraExtensionStreamSource.startStream`
+  / `stopStream`.
+- Host (`VirtualCameraActivator`) registers
+  `CFNotificationCenter` Darwin observers as soon as state
+  reaches `.on`, posts a "what's the current state?" ping so
+  the extension re-broadcasts (covers the "host launches with
+  extension already streaming a Zoom call from a previous
+  host instance" case), and routes notifications to
+  `handleConsumerActive` / `handleConsumerInactive`.
+- Active: cancel any pending stop, start the pipeline if not
+  running.
+- Inactive: schedule a 30-s `DispatchSourceTimer` grace.
+  Cancelled if a new consumer joins inside the window.
+  Stops the pipeline on expiry.
+
+Why Darwin notifications and not custom CMIO properties: the
+CMIOExtension framework's bridging from `CMIOExtensionProperty`
+(string-based) to host-visible `CMIOObjectAddPropertyListener`
+(OSType selectors) isn't documented for custom properties.
+Darwin notifications are 1980s-tech, but they work cleanly
+across the sandbox boundary with a Team-ID prefix and are
+edge-triggered for free. The "host launches mid-stream" case
+is solved by a single ping at observer-registration time.
+
+Result:
+
+- Idle (toggle on, no Zoom call): green light off, no
+  capture.
+- Zoom opens our virtual camera: ~300-500 ms warmup, then
+  frames flow.
+- Zoom call ends: capture stays warm 30 s; green light goes
+  off after.
+- Profile-driven mid-call source swap: unchanged — the
+  extension still re-emits the cached frame to cover the
+  source-swap gap.
+
+What we explicitly didn't add: a logo splash for the warmup
+window. AV Pain Reliever's "passive utility" identity says
+the camera should show the user's actual face, not our
+brand, even for half a second.
+
+### Profile camera = source, virtual camera = output (2026-05-04)
+
+User caught a conceptual mismatch the day after the wizard
+fix shipped: the per-profile Camera picker was listing
+"AV Pain Reliever" alongside real cameras. That treated the
+virtual camera as a possible *input source* — which is
+nonsense, since the virtual camera's whole purpose is to be
+the *output* that Zoom/Slack/etc. point at. A profile names
+the *real* camera the virtual camera should route per
+location.
+
+Decision (option #2 of the three we walked through): when the
+virtual camera is the active routing layer, the system-wide
+preferred camera (`AVCaptureDevice.userPreferredCamera`)
+points at the virtual camera, not the real one. Reasoning:
+
+- Users set Zoom/Slack/Teams to "AV Pain Reliever" once,
+  manually. That's the contract.
+- AVFoundation-modern apps (FaceTime, Safari getUserMedia,
+  Photo Booth) honour `userPreferredCamera` automatically.
+  Setting it to the virtual camera makes those apps follow
+  the same routing as Zoom — one coherent system state.
+- System Settings → Cameras → Preferred Camera shows
+  "AV Pain Reliever," which reinforces the model when the
+  user goes looking.
+
+Implementation:
+
+- New `VirtualCameraSourceController.preferredCameraOverride: String?`
+  protocol property (default `nil` so existing impls / tests
+  compile unchanged).
+- `VirtualCameraActivator` returns `"AV Pain Reliever"` when
+  state is `.on`, nil otherwise. During `.activating` /
+  `.needsApproval` / `.requiresRelaunch` / `.failed` we don't
+  redirect — the device might not deliver frames.
+- `ProfileApplier`: when `preferredCameraOverride` is non-nil,
+  `setPreferred` gets the override; `setSource` still gets
+  the profile's literal real-camera name. When nil, both
+  calls get the literal name (legacy V1 behaviour).
+- Wizard filters the virtual camera out of the picker
+  (`AddProfileViewModel.refresh`) and quietly clears any
+  saved profile value that points at it (legacy migration
+  for profiles created during the buggy window). Helper text
+  under the picker now adapts to the toggle state — explains
+  the routing model when the virtual camera is on.
+- `Engine.reapply()` + `ProfileApplier.invalidateLastApplied()`:
+  the same profile name now produces different system-state
+  writes depending on the toggle, so the dedupe key has to be
+  invalidated when the toggle flips. Toggle off ⇒ AppDelegate
+  calls `engine.reapply()` synchronously; toggle on ⇒ the
+  activator's `.on` transition fires a `$state` Combine
+  observer that does the same.
+- `VirtualCameraActivator.disable()`: defensively clears
+  `userPreferredCamera` if it's currently the virtual camera,
+  so AVFoundation-modern apps don't get stuck on a now-dead
+  device while the engine catches up.
+
+Pieces left untouched:
+
+- Menu bar's `currentCameraDisplay` still shows the
+  *profile's* real camera name. Correct under the new
+  model — the profile's intent is "use BRIO at this
+  location," and the menu surfaces that intent.
+- We don't programmatically set `userPreferredCamera` on
+  toggle-on outside of the next profile apply. If the
+  active profile has `camera == nil`, the system pref
+  isn't touched. The user's "set Zoom to AV Pain
+  Reliever once" instruction stays the contract; we don't
+  over-ride to be helpful.
 
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2294,6 +2294,235 @@ for any future caller that wants "the original."
 
 ---
 
+## V2 plan: native virtual camera (CMIO Camera Extension)
+
+**Status:** planning, 2026-05-04. Decisions captured below; no code
+yet. This section is the canonical record for the V2 work — update it
+as the design evolves and as milestones land.
+
+### Why this, why now
+
+Today's app sets `AVCaptureDevice.userPreferredCamera`, which covers
+FaceTime and browsers (Safari/Chrome `getUserMedia`) automatically.
+It does **not** cover Zoom, Slack, or Teams — those apps store their
+own camera selection and ignore the system preference. There is no
+public API to change Zoom's selection from the outside.
+
+The earlier plan was to recommend OBS Virtual Camera as the bridge:
+configure OBS once with a per-scene camera, point Zoom/Slack at "OBS
+Virtual Camera," and let OBS scene-switching handle the rest. That
+plan was retired on 2026-05-04 — OBS is a third-party dependency
+and the project mandate is "self-contained" (no Hammerspoon, no OBS,
+neither in the UI nor in the docs).
+
+The V2 path: ship a native macOS Camera Extension (CoreMedia I/O,
+macOS 13+) bundled inside the app. Zoom/Slack/Teams see "AV Pain
+Reliever" in their picker, the user selects it once, and from then
+on the active profile drives what frames flow through. CMIO Camera
+Extensions are the modern macOS API used by mmhmm, Hand Mirror,
+Detail, Camo, Ecamm Live, and OBS itself (since OBS migrated off the
+deprecated DAL plug-in path in 2022).
+
+### Decisions (settled 2026-05-04)
+
+- **Activation is opt-in.** Default install behaves exactly like
+  v0.1.x — no system-extension prompt, no extra entry in Zoom's
+  picker. Users enable the virtual camera from a Settings toggle,
+  which triggers the system-extension approval flow at that moment.
+  Rationale: most users may already be happy with FaceTime/browser
+  coverage; an opt-in toggle respects that and keeps first-launch
+  identical.
+- **On profile switch, hold last frame.** The virtual camera holds
+  the last good frame from the outgoing source for ~500 ms while
+  the new source initializes, then cuts. Polite to viewers in a
+  live call, no jarring black flash. Exact hold duration is a tuning
+  knob, not a design decision.
+- **macOS 13+ floor for v0.2.0.** This is a modern app; CMIO Camera
+  Extensions need 13+. Users still on macOS 12 stay on the v0.1.x
+  Sparkle channel and miss the feature, which is fine.
+- **Picker name: "AV Pain Reliever".** Short, matches the app name,
+  reads correctly in narrow Zoom/Slack pickers. No "Camera" suffix,
+  no "Virtual" parenthetical.
+- **Source mirrors the active profile.** The virtual camera vends
+  frames from whatever camera the current profile says is the
+  preferred camera. No separate "virtual camera source" config —
+  one less knob, and it matches the user mental model ("Zoom should
+  finally follow my profiles").
+- **Apple entitlement request happens after a working prototype.**
+  Build first on user's machine in `systemextensionsctl developer
+  on` mode, prove the architecture end-to-end, then submit the
+  request. Risk: turnaround is days to weeks, so we may end up with
+  a finished feature waiting on Apple. Acceptable — the existing
+  release line keeps shipping in parallel.
+
+### Architecture
+
+Three pieces, separated by process boundary:
+
+1. **Main app (existing process).** Owns USB watching, profile
+   resolution, settings, the menu-bar UI. Adds a new
+   `VirtualCameraController` protocol with two implementations:
+   - `NoopVirtualCameraController` — does nothing. Used in the
+     default v0.1.x build. Lets the existing release pipeline
+     continue untouched.
+   - `CMIOVirtualCameraController` — talks to the extension via
+     XPC. Sends "switch source camera," "pause," "resume," and
+     receives extension-side status (active client count, errors).
+2. **Camera Extension (`AVPainRelieverCameraExtension.systemextension`).**
+   A `CMIOExtensionProvider` host with one `CMIOExtensionDevice`
+   ("AV Pain Reliever") and one `CMIOExtensionStream`. Owns the
+   real `AVCaptureSession` against the source camera; receives
+   source-camera-change commands from the main app over XPC; vends
+   frames downstream to whichever app currently has the virtual
+   camera open. Handles the hold-last-frame transition internally.
+3. **XPC service.** The pipe between (1) and (2). Trivial protocol:
+   `setSourceCamera(uniqueID:)`, `pause()`, `resume()`,
+   `currentStatus()`. Frames do not flow over XPC — only commands.
+   The extension reads frames directly from AVFoundation; that's
+   the whole point of doing it in-process.
+
+`ProfileApplier` gains one new step: after setting
+`userPreferredCamera`, also tell the `VirtualCameraController` to
+switch its source. With the no-op implementation this is free; with
+the CMIO implementation it forwards over XPC.
+
+The extension does not own any audio. The existing `AudioController`
+path is unchanged — audio still flows through the system default
+device, which Zoom/Slack pick up via "Same as System" as today.
+
+### Branch + build setup
+
+- **Branch:** `feature/virtual-camera`, cut off `main` at whatever
+  commit is current when work starts. Long-lived. `main` continues
+  to ship `v0.1.x` patch releases independently.
+- **Project structure shift:** A `.systemextension` target requires
+  an actual Xcode bundle, which Swift Package Manager can't build
+  alone. Add a thin `AVPainReliever.xcodeproj` alongside `Package.swift`
+  that references the existing SPM packages and adds two targets:
+  the Camera Extension and an XPC service. SPM development for the
+  main app continues unchanged — `swift build`, `swift test`, the
+  current scripts. The Xcode project is only invoked for v0.2.0
+  release builds.
+- **Build configuration:** Two configs — `Release` (existing,
+  no extension embedded, no camera-extension entitlement, ships as
+  v0.1.x) and `ReleaseWithVirtualCamera` (embeds the extension,
+  declares the entitlement, ships as v0.2.0+). The
+  `VirtualCameraController` injection is selected by build setting
+  so the no-op build genuinely doesn't link the CMIO code path.
+- **CI:** Existing GitHub Actions release workflow keeps working as-
+  is for v0.1.x. A second workflow (or a parameter on the existing
+  one) handles v0.2.0+ builds via xcodebuild. Notarization stays the
+  same Developer ID flow; the only delta is the entitled
+  provisioning profile after Apple approves the entitlement.
+
+### Milestones
+
+Rough ordering, not a timeline (this is a side project; whenever
+each lands, it lands):
+
+1. **M1 — Project scaffold.** Add `AVPainReliever.xcodeproj`. Empty
+   Camera Extension target that activates and shows up in Zoom but
+   vends a black frame. `systemextensionsctl developer on` workflow
+   documented. No main-app integration yet. Goal: prove the
+   activation/signing/embedding plumbing works.
+2. **M2 — Frame pipeline.** Extension opens a hardcoded source
+   camera, vends real frames. Verify against Zoom + Slack +
+   FaceTime. No XPC yet, no profile integration. Goal: prove the
+   frame path works at acceptable resolution/framerate.
+3. **M3 — XPC + source switching.** Wire the XPC service. Main app
+   can tell the extension which source camera to use. Hold-last-
+   frame behavior implemented. Goal: prove dynamic switching works
+   without dropping the Zoom call.
+4. **M4 — Profile integration.** `VirtualCameraController` protocol
+   + both implementations. `ProfileApplier` wired up. Settings
+   toggle to install/enable. Goal: end-to-end feature works on
+   user's machine.
+5. **M5 — Apple entitlement request.** Submit with concrete app
+   demo, screenshots, use-case writeup. Wait.
+6. **M6 — Release readiness.** Notarized build with the entitled
+   provisioning profile. Sparkle integration verified for the
+   extension upgrade path (v0.2.0 → v0.2.1 must replace the
+   extension cleanly). README + Settings copy explaining the
+   feature. Tag v0.2.0.
+
+### Deferred / open items
+
+- **Hold-last-frame exact duration.** 500 ms is a starting point;
+  tune in M3 once we can see the actual switch on Zoom.
+- **Behavior when no source camera is available** (profile says
+  camera X, X is unplugged). Black frame? "No camera connected"
+  placeholder image? Hold last frame indefinitely? Decide in M3.
+- **Resolution / format negotiation.** Match source for V2; revisit
+  if Zoom complains about specific formats.
+- **Uninstall flow.** Settings should offer a "Disable virtual
+  camera" that calls `OSSystemExtensionRequest.deactivationRequest`.
+  Design in M4.
+- **Sparkle + extension replacement edge cases.** Specifically the
+  "user has Zoom open with the virtual camera active when v0.2.1
+  installs" case. Investigate in M6.
+- **Entitlement request body.** Draft once M4 lands so we can
+  describe a working feature, not a hypothetical.
+
+### M1 — project scaffold (landed 2026-05-04, awaiting hands-on verification)
+
+Branch: `feature/virtual-camera`. Approach: extend the existing
+SPM + shell-script build pattern rather than introduce an Xcode
+project. A `.systemextension` is just a different bundle wrapper
+around a Swift binary; the existing `make-app.sh` already proves
+hand-rolled bundle assembly works for this project.
+
+What landed:
+
+- `Sources/AVPainRelieverCameraExtension/` — four Swift files:
+  `main.swift` (entry point), `CameraExtensionProvider.swift`
+  (CMIOExtensionProviderSource), `CameraExtensionDevice.swift`
+  (CMIOExtensionDeviceSource — single device, stable UUID),
+  `CameraExtensionStream.swift` (CMIOExtensionStreamSource —
+  vends 1280×720 BGRA black frames at 30 fps via a
+  `DispatchSourceTimer` + `CVPixelBufferPool`).
+- `Package.swift` — added
+  `AVPainRelieverCameraExtension` as an executable target. No
+  dependency on `AVPainReliever` or `AVPainRelieverApp`; clean
+  process boundary from the start.
+- `Resources/AVPainRelieverCameraExtension-Info.plist` — minimal
+  bundle metadata (`CFBundlePackageType = SYSX`, child bundle ID
+  `com.ericwillis.avpainreliever.CameraExtension`).
+- `Resources/AVPainRelieverCameraExtension.entitlements` —
+  sandboxed (`com.apple.security.app-sandbox = true`).
+- `Resources/AVPainReliever-WithVirtualCamera.entitlements` —
+  v0.2.0 host-app entitlements adding
+  `com.apple.developer.system-extension.install`. The default
+  `Resources/AVPainReliever.entitlements` is unchanged so the
+  v0.1.x signing pipeline is byte-for-byte the same.
+- `scripts/make-app-with-virtual-camera.sh` — parallel-track
+  build script. Runs `swift build` for both products, assembles
+  both bundles, embeds the extension at
+  `Contents/Library/SystemExtensions/`, signs inside-out (Sparkle
+  nested → Sparkle.framework → Camera Extension → host app).
+- `Sources/AVPainRelieverApp/VirtualCameraActivator.swift` +
+  `AppDelegate.applicationDidFinishLaunching` hook — env-var-gated
+  (`AVPR_ACTIVATE_VIRTUAL_CAMERA=1`) `OSSystemExtensionRequest`
+  activation. No-op on v0.1.x builds (entitlement absent → request
+  fails harmlessly). M4 will replace this with a real Settings
+  toggle.
+- `docs/VIRTUAL_CAMERA_DEV.md` — local-test recipe:
+  `systemextensionsctl developer on`, build, ditto into
+  `/Applications`, env-var-launch, verify in Zoom, iteration loop,
+  uninstall, common failure modes.
+
+What's deliberately not done: no main-app integration with
+`ProfileApplier`, no source-camera switching, no XPC service yet.
+Those are M2 / M3 / M4. M1's only job is to prove the
+activation/embedding/signing plumbing works.
+
+Verification steps (next): user runs
+`scripts/make-app-with-virtual-camera.sh`, dittos to
+`/Applications`, runs the activation, confirms "AV Pain Reliever"
+appears in Zoom and shows a black frame. Findings fold back into
+this section once we know what works and what didn't.
+
+---
+
 ## How to use this document
 
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3147,6 +3147,50 @@ in parallel for anyone who doesn't need any of this. **Money.**
    the reboot was supposed to clean up. Reboot first, then
    install.
 
+### Wizard camera-picker discovery (2026-05-04)
+
+User report: after activating the virtual camera, "AV Pain
+Reliever" showed up in Photo Booth but not in the Add/Edit
+Profile wizard's camera picker. Three independent gotchas
+overlapping; fix had to address each:
+
+1. **Camera TCC for the host process.** `AVCaptureDevice.DiscoverySession`
+   in a host that's never been granted camera permission
+   silently hides `.external` devices including the host's
+   own embedded Camera Extension. `CameraCaptureSession` only
+   asks when the sink pipeline starts, which leaves the
+   wizard blind on toggle-on-but-never-opened-Add states.
+   Fix: `AppDelegate.applicationDidFinishLaunching` now
+   pre-grants on `.notDetermined` so TCC settles before any
+   wizard opens. Idempotent — `AVCaptureDevice.requestAccess`
+   no-ops once authorized.
+2. **Wizard reads the camera list once, at init.**
+   `AddProfileViewModel.refresh()` runs from the initializer
+   and from the manual Refresh button — nothing observes
+   `VirtualCameraActivator.state`. A wizard opened during
+   `.activating` / `.needsApproval` froze without the virtual
+   camera. Fix: `WizardForm` now `.onReceive`s
+   `delegate.virtualCameraActivator.$state` and triggers
+   `viewModel.refresh()` on `.on`.
+3. **Host process can't always see its own Camera Extension.**
+   Even with TCC and a fresh refresh, AVFoundation's
+   in-process discovery cache stays stale on first
+   activation in some launches. Photo Booth (separate
+   process) sees it; the host doesn't until relaunch.
+   Same family as the existing disable→re-enable
+   `requiresRelaunch` quirk. Fix:
+   `VirtualCameraActivator.scheduleHostVisibilityCheck()`
+   runs ~1.5 s after state flips to `.on`, runs a fresh
+   `DiscoverySession`, looks for the extension by
+   `virtualCameraUID`. If absent, escalates to
+   `.requiresRelaunch` and stops the capture pipeline so
+   the existing Settings "Restart" affordance handles it.
+
+Lesson: a CMIO Camera Extension being live in the OS-level
+graph does not guarantee the host that activated it can see
+it. Always test the picker from inside the host, not just
+Photo Booth.
+
 ---
 
 ## How to use this document

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2459,10 +2459,18 @@ the extension can't capture"):
    and re-emits it at 30 fps when the sink temporarily dries up,
    covering the ~500 ms input-swap window so Zoom doesn't see a
    freeze.
-4. **M4 — Profile integration.** `VirtualCameraController`
-   protocol + both implementations (no-op + CMIO).
-   `ProfileApplier` wired up. Settings toggle to install/enable.
-   Goal: end-to-end feature works on user's machine.
+4. **M4 — Settings UI + opt-in toggle.** SHIPPED 2026-05-04.
+   `SettingsStore.virtualCameraEnabled` (default off).
+   `VirtualCameraActivator` refactored from a static one-shot
+   into a stateful `ObservableObject` with state machine
+   (`.off` / `.activating` / `.needsApproval` / `.on` /
+   `.failed` / `.requiresRelaunch`) and a `relaunch()` action.
+   Camera tab in Settings shows toggle + live status row +
+   contextual button (Open Login Items & Extensions for
+   approval, Restart AV Pain Reliever for the in-session
+   re-enable quirk). `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` kept as a
+   debug override that locks the toggle for the launch and shows
+   a "Debug override" badge.
 5. **M5 — Release readiness review.** No separate Apple entitlement
    request needed (system-extension.install is auto-granted with
    Developer Program); App Group registration was the surprise gate
@@ -2503,9 +2511,25 @@ the extension can't capture"):
   passthrough path) profiles.
 - **Resolution / format negotiation.** Match source for V2; revisit
   if Zoom complains about specific formats.
-- **Uninstall flow.** Settings should offer a "Disable virtual
-  camera" that calls `OSSystemExtensionRequest.deactivationRequest`.
-  Design in M4.
+- **Uninstall flow.** Resolved in M4 (2026-05-04). The Settings
+  toggle calls `OSSystemExtensionRequest.deactivationRequest` on
+  flip-off and tears down the host capture pipeline. Surfaces in
+  System Settings → Login Items & Extensions for true uninstall.
+- **In-session toggle off → on quirk.** Surfaced and partially
+  resolved in M4 (2026-05-04). `OSSystemExtensionRequest.deactivationRequest`
+  doesn't actually stop the running extension process — it
+  queues `[terminated waiting to uninstall on reboot]` while the
+  extension stays alive and visible to AVCapture clients. Toggle
+  back on in the same host process can't get fresh CMIO state for
+  the device (the host's CMIO context already saw the device as
+  "going away") so the pipeline produces a black feed. Detected
+  via the activator's `deactivatedThisSession` flag; toggle-on
+  routes to `.requiresRelaunch` and the Settings UI surfaces a
+  "Restart AV Pain Reliever" button that quits + relaunches the
+  host (fresh process → fresh CMIO context → device found
+  immediately, same path that works on every cold launch). Not
+  pretty, but mac OS doesn't expose a userspace API to tear down
+  an extension and re-attach in the same process.
 - **Sparkle + extension replacement edge cases.** Specifically the
   "user has Zoom open with the virtual camera active when v0.2.1
   installs" case. Investigate in M6.
@@ -2840,6 +2864,64 @@ extension re-emits last cached frame at 30 fps to source
     ▼
 Zoom keeps seeing 30 fps — no freeze, no drop
 ```
+
+### M4 — Settings UI + opt-in toggle (SHIPPED 2026-05-04)
+
+The Camera Extension is now opt-in via a real Settings toggle
+instead of the env-var-only path used in M1–M3. Default off, so
+fresh installs see no system extension activity until the user
+turns it on. The env var (`AVPR_ACTIVATE_VIRTUAL_CAMERA=1`) stays
+as a debug affordance — it forces enable on launch regardless of
+the persisted setting and shows a "Debug override" badge in the
+Settings UI so the user understands why the toggle is greyed out.
+
+Architecture:
+
+- **`SettingsStore.virtualCameraEnabled`** — persisted `Bool`,
+  default false. Same `UserDefaults` pattern as the other
+  toggles. New unit test covers the default + persistence.
+
+- **`VirtualCameraActivator` refactor** — was a static one-shot
+  in M1; now an `ObservableObject` with a state machine:
+
+  ```
+  .off ──enable()──▶ .activating ──didFinishWithResult──▶ .on
+   ▲ ▲                   │
+   │ │                   ├─requestNeedsUserApproval──▶ .needsApproval
+   │ │                   └─didFailWithError──────────▶ .failed
+   │ └────disable()─────┐
+   │                    │
+   ┴────────────────────┘
+       (deactivatedThisSession=true)
+                ↓
+       enable() → .requiresRelaunch
+   ```
+
+  `enable()` and `disable()` are both idempotent and log every
+  transition for debugging. `relaunch()` quits + reopens the
+  host bundle via `/usr/bin/open <path>` so the fresh process
+  picks up the persisted toggle and gets a clean CMIO context.
+
+- **AppDelegate wiring** — owns the activator (was static).
+  Subscribes to `settings.$virtualCameraEnabled` via Combine;
+  toggle changes route through `applyVirtualCameraToggle`. The
+  activator is itself the `VirtualCameraSourceController`
+  plumbed into `ProfileApplier` — silently no-ops when off
+  (returns `.ok` without doing anything), forwards to the
+  running `CameraCaptureSession` when on. No engine rebuild
+  needed on toggle flip.
+
+- **Settings UI — Camera tab** — third tab alongside General
+  and Profiles. Shows the toggle, a live status row (colored
+  dot + label that mirrors the activator state), and a
+  contextual button: "Open Login Items & Extensions" when in
+  `.needsApproval` / `.failed`, "Restart AV Pain Reliever" when
+  in `.requiresRelaunch`. Footer hint adapts to the state
+  (e.g. "Pick 'AV Pain Reliever' in Zoom" when on, "macOS holds
+  the virtual camera in a stale state…" when restart is
+  required). Footer rendered as a `Text` row inside the section
+  body per the project memory's macOS-14 `Form(.grouped)`
+  footer-slot convention.
 
 ### M2 lessons (gotchas the architecture or first attempts hit)
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2463,7 +2463,7 @@ each lands, it lands):
 - **Entitlement request body.** Draft once M4 lands so we can
   describe a working feature, not a hypothetical.
 
-### M1 — project scaffold (landed 2026-05-04, awaiting hands-on verification)
+### M1 — project scaffold (SHIPPED 2026-05-04)
 
 Branch: `feature/virtual-camera`. Approach: extend the existing
 SPM + shell-script build pattern rather than introduce an Xcode
@@ -2517,8 +2517,10 @@ activation/embedding/signing plumbing works.
 
 Verification (2026-05-04, second attempt): activated successfully
 end-to-end. `systemextensionsctl list` reports `[activated enabled]`,
-the extension process is alive under `_cmiodalassistants`, and the
-host app's activation request returns success.
+the extension process is alive under `_cmiodalassistants`, the host
+app's activation request returns success, and "AV Pain Reliever"
+appears in Zoom's camera picker showing the black 1280×720 frame at
+30 fps. M1 success criteria met.
 
 ### M1 lessons (gotchas the original scaffold missed)
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2448,12 +2448,17 @@ the extension can't capture"):
    source stream that AVCapture clients (Zoom, Photo Booth, etc.)
    read. Initial XPC implementation was abandoned — see "Why XPC
    didn't work for the frame pipe" below.
-3. **M3 — Source switching + hold-last-frame.** Host app accepts
-   `setSourceCamera(uniqueID:)` over the XPC service, swaps the
-   `AVCaptureSession`'s source, and pauses the frame feed for
-   ~500 ms while the new source warms up. Extension holds the
-   last frame internally during the pause. Goal: prove dynamic
-   switching works without dropping the Zoom call.
+3. **M3 — Source switching + hold-last-frame.** SHIPPED
+   2026-05-04. Engine layer drives the host's running
+   `AVCaptureSession` directly through a new
+   `VirtualCameraSourceController` adapter — no XPC (M2's
+   architecture pivot eliminated the XPC service entirely). The
+   active profile's `camera` field becomes both the system
+   `userPreferredCamera` (existing behavior) AND the virtual
+   camera's source (new). Extension holds the most recent frame
+   and re-emits it at 30 fps when the sink temporarily dries up,
+   covering the ~500 ms input-swap window so Zoom doesn't see a
+   freeze.
 4. **M4 — Profile integration.** `VirtualCameraController`
    protocol + both implementations (no-op + CMIO).
    `ProfileApplier` wired up. Settings toggle to install/enable.
@@ -2470,11 +2475,32 @@ the extension can't capture"):
 
 ### Deferred / open items
 
-- **Hold-last-frame exact duration.** 500 ms is a starting point;
-  tune in M3 once we can see the actual switch on Zoom.
+- **Hold-last-frame exact duration.** Resolved in M3: there is no
+  fixed duration — the extension repeats the cached frame at 30 fps
+  for as long as the sink stays empty AND a client is watching.
+  Verified on a manual switch from `home-office` → `laptop` on
+  2026-05-04: cold-start gap on first client connect was covered by
+  one held emit before fresh frames took over.
 - **Behavior when no source camera is available** (profile says
-  camera X, X is unplugged). Black frame? "No camera connected"
-  placeholder image? Hold last frame indefinitely? Decide in M3.
+  camera X, X is unplugged). Currently logged as
+  `virtual camera source 'X' not found — skipping`; the running
+  session keeps the previous source and the virtual camera continues
+  to deliver that. No black frame, no placeholder. Revisit if the
+  user reports it as confusing in practice.
+- **Format negotiation for non-FaceTime cameras.** Resolved as
+  part of M3 (2026-05-04). Diagnosis: forced
+  `kCVPixelFormatType_32BGRA` at 1280×720 in the host's
+  `videoSettings` works for FaceTime HD but silently dropped
+  every frame from the user's HDMI to U3 capture card
+  (vendor 0x1e4e / product 0x701f) which natively delivers
+  `420v` (NV12) at 1920×1080. Fix: host accepts the device's
+  native format; `CMIOSinkWriter` runs each frame through
+  `VTPixelTransferSession` to convert to 1280×720 BGRA before
+  enqueueing. `CVPixelBufferPool` recycles the destination
+  buffers so steady-state capture doesn't churn allocations.
+  Verified end-to-end on both `home-office` (HDMI capture, NV12
+  1080p source path) and `laptop` (FaceTime HD, BGRA 720p
+  passthrough path) profiles.
 - **Resolution / format negotiation.** Match source for V2; revisit
   if Zoom complains about specific formats.
 - **Uninstall flow.** Settings should offer a "Disable virtual
@@ -2700,6 +2726,120 @@ The OBS-style sink-stream approach sidesteps this entirely:
 CMIO already has cross-process IOSurface plumbing built in,
 and using the second stream as a sink reuses that plumbing for
 free. No Mach services to register, no XPC code to maintain.
+
+### M3 — profile-driven source switching + hold-last-frame (SHIPPED 2026-05-04)
+
+End-to-end: changing the active profile (manually or by docking
+to a known location) swaps the virtual camera's source camera in
+the running `AVCaptureSession`, and the extension covers the
+~500 ms warm-up gap by re-emitting the last good frame at 30 fps.
+Zoom stays connected; the picture freezes for ~500 ms then comes
+alive on the new source. No call drop.
+
+Architecture (no XPC — M2's pivot eliminated it permanently):
+
+- **Engine layer** (`Sources/AVPainReliever/Adapters/CameraController.swift`):
+  - New `VirtualCameraSourceController` protocol with a single
+    `setSource(named:) -> CameraApplyResult` method. Mirrors the
+    existing `CameraController` shape so `ProfileApplier` handles
+    the two adapters symmetrically.
+  - `ProfileApplier` accepts an optional
+    `virtualCameraSource:`. When `profile.camera` is set it
+    drives BOTH the system `userPreferredCamera` (legacy
+    behavior, for AVFoundation-modern apps) AND the virtual
+    camera's source (new, for Zoom/Slack/Teams that ignore the
+    system preference but follow the AV Pain Reliever device).
+  - Nil injection = silent no-op. Production wires it only when
+    the env-var-gated activator booted the host capture pipeline;
+    v0.1.x and "didn't ask for virtual camera" launches inject
+    nil with no behavior change.
+
+- **Host app** (`Sources/AVPainRelieverApp/CameraCaptureSession.swift`):
+  - Refactored away from the hardcoded `.builtInWideAngleCamera`
+    lookup. Initial source is picked from the same fallback chain
+    `AVFoundationCameraController.currentPreferredName` uses
+    (`userPreferredCamera` → `systemPreferredCamera` → first
+    discovered) so the first frames match what a fresh AVCapture
+    client would naturally see.
+  - New `switchSource(toLocalizedName:)` runs on the capture
+    queue, looks up the device by `localizedName` (matches the
+    profile's camera field), and swaps inputs inside a
+    `beginConfiguration` / `commitConfiguration` block. The
+    session keeps running across the swap — no
+    `stopRunning`/`startRunning` cycle.
+  - `videoSettings` no longer forces a pixel format or
+    dimensions; the device delivers its native format
+    (FaceTime HD ships BGRA 720p, the user's HDMI capture card
+    ships NV12 1080p, etc) and the conversion happens
+    downstream in `CMIOSinkWriter`. M2's forced settings worked
+    for FaceTime but silently dropped every frame from the
+    HDMI capture card.
+  - Conforms to `VirtualCameraSourceController`. The static
+    `VirtualCameraActivator.virtualCameraSource` accessor exposes
+    the running session to `AppDelegate.buildEngine` so the
+    `ProfileApplier` gets the live adapter.
+  - `applicationDidFinishLaunching` order changed:
+    `VirtualCameraActivator.activateIfRequested()` now runs
+    BEFORE `bootEngine()` so the engine's first
+    evaluate-and-apply pass finds a live source to drive.
+
+- **Host's CMIO sink writer** (`Sources/AVPainRelieverApp/CMIOSinkWriter.swift`):
+  - Added a `VTPixelTransferSession` + `CVPixelBufferPool` pair
+    that converts every incoming frame to 1280×720 BGRA before
+    `CMSimpleQueueEnqueue`. Hardware-accelerated where the GPU
+    supports it; the pool recycles destination buffers so
+    steady-state capture allocates nothing per frame.
+  - Fast path for inputs that already match (FaceTime HD,
+    Continuity Camera) — passthrough, zero copy.
+  - Format description is re-derived per pool buffer (cached by
+    `CVPixelBuffer` pointer). Sharing one description across
+    different source frames gets rejected with -12743 because
+    VT attaches source-derived colorspace metadata to the
+    destination, and `CMSampleBufferCreateForImageBuffer`
+    validates strictly.
+  - `Host frame format: <fourcc> <w>x<h> — convert+scale|passthrough`
+    is logged once per (format, dimensions) signature change
+    so a profile switch is visible without flooding the log.
+
+- **Extension** (`Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift`):
+  - Caches the most recent `(CVPixelBuffer, CMFormatDescription)`
+    pair from the sink. On each consume tick that yields nil and
+    the source has at least one watcher, mints a fresh
+    `CMSampleBuffer` over the cached pixel buffer with the
+    current host time and sends it through the source stream.
+  - Held emissions are rate-limited to ~30 fps (matches the
+    source's declared `frameDuration`) so the 90 Hz consume
+    timer doesn't burst the source at 3× framerate.
+  - Holding the underlying `CVPixelBuffer` (not the parent
+    `CMSampleBuffer`) lets each repeat carry a fresh PTS without
+    AVCapture clients seeing duplicate timestamps.
+
+Wiring summary:
+
+```
+profile.camera = "Logitech BRIO"
+    │
+    ▼
+ProfileApplier.applyVirtualCameraSource("Logitech BRIO")
+    │
+    ▼
+CameraCaptureSession.setSource(named:)
+    │
+    ▼  (capture queue)
+session.beginConfiguration()
+remove old input
+add new AVCaptureDeviceInput(BRIO)
+session.commitConfiguration()
+    │
+    ▼  (~500 ms while BRIO warms up — sink dry)
+extension consumeOne() returns nil
+    │
+    ▼
+extension re-emits last cached frame at 30 fps to source
+    │
+    ▼
+Zoom keeps seeing 30 fps — no freeze, no drop
+```
 
 ### M2 lessons (gotchas the architecture or first attempts hit)
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2365,21 +2365,32 @@ Three pieces, separated by process boundary:
    - `NoopVirtualCameraController` — does nothing. Used in the
      default v0.1.x build. Lets the existing release pipeline
      continue untouched.
-   - `CMIOVirtualCameraController` — talks to the extension via
-     XPC. Sends "switch source camera," "pause," "resume," and
-     receives extension-side status (active client count, errors).
+   - `CMIOVirtualCameraController` — captures from the active
+     profile's source camera using AVFoundation, encodes each
+     frame as an IOSurface, and pushes it to the extension over
+     XPC. Receives extension-side status (active client count,
+     errors).
 2. **Camera Extension (`AVPainRelieverCameraExtension.systemextension`).**
    A `CMIOExtensionProvider` host with one `CMIOExtensionDevice`
-   ("AV Pain Reliever") and one `CMIOExtensionStream`. Owns the
-   real `AVCaptureSession` against the source camera; receives
-   source-camera-change commands from the main app over XPC; vends
-   frames downstream to whichever app currently has the virtual
-   camera open. Handles the hold-last-frame transition internally.
-3. **XPC service.** The pipe between (1) and (2). Trivial protocol:
-   `setSourceCamera(uniqueID:)`, `pause()`, `resume()`,
-   `currentStatus()`. Frames do not flow over XPC — only commands.
-   The extension reads frames directly from AVFoundation; that's
-   the whole point of doing it in-process.
+   ("AV Pain Reliever") and one `CMIOExtensionStream`. **Pure
+   relay** — receives `IOSurface` frames from the host app over
+   XPC, wraps each in a `CMSampleBuffer`, sends downstream via
+   `stream.send(...)`. Handles hold-last-frame on source-camera
+   switch (i.e., when the host app pauses the XPC frame feed).
+3. **XPC pipe.** Both frames and commands flow over the same XPC
+   connection. Frames piggyback on `IOSurface` references (zero-
+   copy across the process boundary). Commands are simple
+   messages: `setSourceCamera(uniqueID:)`, `pause()`, `resume()`,
+   `currentStatus()`.
+
+**The extension never touches AVFoundation or the physical camera
+hardware.** This is forced by an M2 lesson learned the hard way
+(see "Why the extension can't capture" below): a CMIO Camera
+Extension that calls `AVCaptureSession` enumerates devices through
+the very CMIO subsystem it's plugged into, sees itself in the
+list, and creates an IOKit-level deadlock that wedges every camera
+app on the machine. OBS, mmhmm, Hand Mirror, Camo all use the
+host-app-captures + XPC-to-extension pattern for the same reason.
 
 `ProfileApplier` gains one new step: after setting
 `userPreferredCamera`, also tell the `VirtualCameraController` to
@@ -2418,32 +2429,42 @@ device, which Zoom/Slack pick up via "Same as System" as today.
 ### Milestones
 
 Rough ordering, not a timeline (this is a side project; whenever
-each lands, it lands):
+each lands, it lands). Re-numbered after the M2 retreat (see "Why
+the extension can't capture"):
 
-1. **M1 — Project scaffold.** Add `AVPainReliever.xcodeproj`. Empty
-   Camera Extension target that activates and shows up in Zoom but
-   vends a black frame. `systemextensionsctl developer on` workflow
-   documented. No main-app integration yet. Goal: prove the
-   activation/signing/embedding plumbing works.
-2. **M2 — Frame pipeline.** Extension opens a hardcoded source
-   camera, vends real frames. Verify against Zoom + Slack +
-   FaceTime. No XPC yet, no profile integration. Goal: prove the
-   frame path works at acceptable resolution/framerate.
-3. **M3 — XPC + source switching.** Wire the XPC service. Main app
-   can tell the extension which source camera to use. Hold-last-
-   frame behavior implemented. Goal: prove dynamic switching works
-   without dropping the Zoom call.
-4. **M4 — Profile integration.** `VirtualCameraController` protocol
-   + both implementations. `ProfileApplier` wired up. Settings
-   toggle to install/enable. Goal: end-to-end feature works on
-   user's machine.
-5. **M5 — Apple entitlement request.** Submit with concrete app
-   demo, screenshots, use-case writeup. Wait.
-6. **M6 — Release readiness.** Notarized build with the entitled
-   provisioning profile. Sparkle integration verified for the
+1. **M1 — Project scaffold.** ~~`AVPainReliever.xcodeproj`~~ kept
+   the SPM + shell-script build pattern. Empty Camera Extension
+   target that activates and shows up in Zoom but vends a black
+   frame. Goal: prove the activation/signing/embedding plumbing
+   works. **SHIPPED 2026-05-04.**
+2. **M2 — Host-side capture + XPC frame pipe (was M3).** Host app
+   opens an `AVCaptureSession` against a hardcoded source camera
+   (built-in webcam during dev). Each frame's `IOSurface` is sent
+   to the extension over an XPC connection. Extension wraps the
+   `IOSurface` in a `CMSampleBuffer` and forwards via
+   `stream.send(...)`. No source switching yet (that's a one-line
+   change in M3, but tested in isolation here). Goal: prove the
+   whole frame path works end-to-end at acceptable
+   resolution/framerate.
+3. **M3 — Source switching + hold-last-frame.** Host app accepts
+   `setSourceCamera(uniqueID:)` over the XPC service, swaps the
+   `AVCaptureSession`'s source, and pauses the frame feed for
+   ~500 ms while the new source warms up. Extension holds the
+   last frame internally during the pause. Goal: prove dynamic
+   switching works without dropping the Zoom call.
+4. **M4 — Profile integration.** `VirtualCameraController`
+   protocol + both implementations (no-op + CMIO).
+   `ProfileApplier` wired up. Settings toggle to install/enable.
+   Goal: end-to-end feature works on user's machine.
+5. **M5 — Release readiness review.** No separate Apple entitlement
+   request needed (system-extension.install is auto-granted with
+   Developer Program); App Group registration was the surprise gate
+   and that's already done. Sparkle integration verified for the
    extension upgrade path (v0.2.0 → v0.2.1 must replace the
    extension cleanly). README + Settings copy explaining the
-   feature. Tag v0.2.0.
+   feature.
+6. **M6 — Tag v0.2.0.** Notarized release build, appcast update,
+   GitHub release.
 
 ### Deferred / open items
 
@@ -2581,6 +2602,49 @@ milestones don't relearn the same things:
 The dev workflow (`docs/VIRTUAL_CAMERA_DEV.md`) was rewritten in a
 follow-up commit to reflect the actual recipe instead of the
 ad-hoc + developer-mode + SIP-off path I originally documented.
+
+### Why the extension can't capture (M2 attempt #1, 2026-05-04)
+
+First M2 attempt put an `AVCaptureSession` inside the Camera
+Extension, opened against the built-in webcam, and forwarded the
+captured `CMSampleBuffer`s to `stream.send(...)`. The extension
+compiled, signed, notarized, and activated cleanly. But as soon as
+any client (Photo Booth, Zoom) selected the AV Pain Reliever
+camera, the entire camera pipeline on the machine wedged — Photo
+Booth froze hard, requiring force-quit and (sometimes) `sudo
+killall VDCAssistant` to unwedge.
+
+Diagnosis from the extension's logs: `AVCaptureSession` triggered
+`AVCaptureDALDevice _refreshPreferredCameraProperties` and full
+device-list enumeration *inside* the extension process. CMIO holds
+the system-wide camera-device list while waiting for the
+extension's reply on `startStream`; concurrently the extension was
+asking AVFoundation to enumerate cameras, which routes back through
+CMIO, which sees our extension as one of the devices, which calls
+back into the same path. IOKit deadlock — every camera app gets
+queued behind it.
+
+Architectural rule that fell out: **a CMIO Camera Extension cannot
+use AVFoundation.** Frames have to enter the extension from the
+outside, via XPC from the host app or a sibling helper. OBS,
+mmhmm, Hand Mirror, Camo, Ecamm Live all use the host-app-captures
++ XPC-to-extension pattern.
+
+This invalidates the original M2/M3 split (where M2 = "frames in
+the extension" and M3 = "XPC for commands"). Re-architected:
+M2 now means host-side capture + XPC frame pipe; source switching
+becomes a one-line change in M3.
+
+Concrete changes after the rollback:
+- `CameraExtensionStream.swift` reverted to the M1 black-frame
+  timer (no AVFoundation in the extension, ever).
+- Camera entitlement (`com.apple.security.device.camera`) and
+  `NSCameraUsageDescription` removed from the extension —
+  permanently. The extension doesn't need either.
+- `Resources/AVPainRelieverCameraExtension.entitlements` keeps
+  `com.apple.security.app-sandbox` and the App Group; nothing
+  else.
+- M2 plan rewritten in milestones list above.
 
 ---
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2471,15 +2471,23 @@ the extension can't capture"):
    re-enable quirk). `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` kept as a
    debug override that locks the toggle for the launch and shows
    a "Debug override" badge.
-5. **M5 — Release readiness review.** No separate Apple entitlement
-   request needed (system-extension.install is auto-granted with
-   Developer Program); App Group registration was the surprise gate
-   and that's already done. Sparkle integration verified for the
-   extension upgrade path (v0.2.0 → v0.2.1 must replace the
-   extension cleanly). README + Settings copy explaining the
-   feature.
+5. **M5 — Release readiness.** SHIPPED 2026-05-04. Release
+   workflow now picks the right build script per tag (v0.1.x →
+   make-app.sh, v0.2.x+ → make-app-with-virtual-camera.sh) so
+   the v0.1.x release line stays unblocked. New
+   `MACOS_PROVISIONING_PROFILE` GitHub Secret carries the
+   profile that the extension needs for activation outside
+   developer mode. README has a "Virtual camera" section
+   explaining the feature install-first; Settings UI's Camera
+   tab is the discovery path. Sparkle/extension upgrade-replace
+   verification is documented as an end-to-end test plan to be
+   run with the v0.2.0 → v0.2.0.1 cycle in M6 — can't be
+   shippable-verified until at least one v0.2.x release exists
+   on the appcast.
 6. **M6 — Tag v0.2.0.** Notarized release build, appcast update,
-   GitHub release.
+   GitHub release. First real-world Sparkle upgrade-replace test
+   happens here (cut v0.2.0, install fresh; cut v0.2.0.1 with a
+   trivial change; verify Sparkle replaces cleanly).
 
 ### Deferred / open items
 
@@ -2922,6 +2930,159 @@ Architecture:
   required). Footer rendered as a `Text` row inside the section
   body per the project memory's macOS-14 `Form(.grouped)`
   footer-slot convention.
+
+### M5 — release readiness (SHIPPED 2026-05-04)
+
+Three sub-tasks, all landed:
+
+1. **README — virtual camera section.** New "Virtual camera
+   (optional)" section between "Using the app" and "Privacy".
+   Install-first, scannable, executive aesthetic preserved
+   (per the README-audience memory). Calls out that Zoom /
+   Slack / Teams ignore the system default and tells the user
+   the four steps to enable it.
+
+2. **CI release workflow updates.**
+   `.github/workflows/release.yml` now picks the build script
+   from the tag prefix: `v0.0.0-*` and `v0.1.*` keep using
+   `scripts/make-app.sh`; everything else (`v0.2.*` and later)
+   uses `scripts/make-app-with-virtual-camera.sh`. New
+   `MACOS_PROVISIONING_PROFILE` GitHub Secret holds the
+   base64-encoded provisioning profile; decoded into
+   `Resources/AVPainReliever.provisionprofile` only for v0.2.x+
+   runs (skipped silently on v0.1.x to keep that pipeline a
+   no-op). `docs/RELEASING.md` updated to reflect the new
+   secret + the script-selection logic.
+
+3. **Sparkle / extension upgrade-replace verification —
+   recipe documented; execution in M6.** Can't be properly
+   verified until at least one v0.2.x release exists on the
+   appcast and there's an installed Sparkle-capable client to
+   upgrade FROM. The recipe lives in this section's "Upgrade-
+   replace test plan" subsection below; M6 runs it for real.
+
+### M5 — Sparkle upgrade-replace test plan (run during M6)
+
+The macOS quirk we hit during M3/M4 dev iteration was: rebuilding
+the extension binary marks the previous version
+`[terminated waiting to uninstall on reboot]`, and CMIO stops
+exposing the device until reboot or a Settings toggle off/on
+cycle. **This test plan validates that Sparkle's normal upgrade
+flow doesn't reproduce that quirk for end users**, because
+Sparkle quits the running host before swapping the bundle (fresh
+process for the new version, clean CMIO context).
+
+Pre-requisites:
+- v0.2.0 already released and live on the appcast.
+- A Mac with v0.2.0 installed via Sparkle (not via dev build)
+  and the virtual camera toggle ON for at least one launch (so
+  the extension is `[activated enabled]` in `systemextensionsctl
+  list`).
+
+Test steps:
+1. On the local dev machine, bump the source to a v0.2.0.1 patch
+   (e.g. trivial README typo or release-notes copy edit).
+2. `git tag v0.2.0.1 && git push --tags` — CI workflow runs.
+3. Verify the workflow used `make-app-with-virtual-camera.sh` and
+   notarization succeeded for both the host AND the embedded
+   extension bundle.
+4. Verify the workflow appended a new `<item>` to `appcast.xml`
+   on `main` with the v0.2.0.1 enclosure URL + EdDSA signature.
+5. On the test Mac (running v0.2.0): About → Check for Updates.
+   Sparkle should detect v0.2.0.1, prompt, download, quit,
+   replace the bundle, relaunch.
+6. Verify on the test Mac after Sparkle's relaunch:
+   - `systemextensionsctl list` — old v0.2.0 entry should
+     transition cleanly to v0.2.0.1; the previous version may
+     show as `[terminated waiting to uninstall on reboot]` for
+     a moment (expected) but the new version should be
+     `[activated enabled]`.
+   - `system_profiler SPCameraDataType` — AV Pain Reliever
+     entry still present.
+   - Open Photo Booth → AV Pain Reliever → live frames flowing
+     (no black screen).
+   - Settings → Camera → status row shows "Active".
+7. If step 6 shows black frames, that's the same-process CMIO
+   stale-handle bug from M4's known issues; click the
+   `Restart AV Pain Reliever` affordance in Settings → Camera
+   (which already exists) to recover. If we see this, file a
+   follow-up to investigate whether Sparkle's pre-upgrade quit
+   is reaching the activator's deactivation path cleanly.
+
+Failure modes worth watching for:
+- Apple's notary service rejecting the embedded extension bundle
+  for any reason (would surface in the workflow's "Notarize and
+  staple" step).
+- Sparkle's downloader / installer not preserving the embedded
+  `Library/SystemExtensions/...` directory (the extension would
+  be missing from the new bundle; would surface as the
+  activation request failing on the test Mac's first launch
+  after upgrade).
+
+### v0.2.0 release notes (draft, ready to copy)
+
+Paste this into the GitHub Release body when pre-creating the v0.2.0
+draft release (per `docs/RELEASING.md`'s curated-notes flow). The CI
+workflow renders it through GitHub's `/markdown` API and pipes the
+HTML into the appcast `<description>`, so what you write here is
+exactly what shows up in Sparkle's "What's New" panel for upgrading
+v0.1.x users.
+
+```markdown
+## What's new
+
+OK here's the deal. v0.2.0 is the big one. **AV Pain Reliever is now
+a virtual camera.** That's right — the same app that's been quietly
+swapping your audio defaults all this time can now also be the camera
+that Zoom, Slack, Teams, and any other video app picks up. One
+camera in their picker. One name. **AV Pain Reliever.** It streams
+whatever real camera the active profile names — your built-in webcam
+at the laptop, the HDMI capture at the home office, your iPhone via
+Continuity at the conference room — whatever you've configured. The
+profile changes, the picture follows. Money.
+
+Here's what this fixes: Zoom, Slack, and Teams keep their *own*
+camera selection that ignores the system default. So back in v0.1.x
+when you docked at a new location, your microphone and speakers
+would change, but Zoom would just sit there showing your laptop
+webcam like nothing happened. That's amateur hour. With v0.2.0, you
+pick "AV Pain Reliever" in Zoom once and you're done. Forever.
+
+It's **off by default** — installing a virtual camera is a real thing
+and we're not turning it on without your permission, that's not how
+we do business. Open **Settings → Camera** and flip the toggle.
+macOS will ask you to approve the extension once (System Settings →
+Login Items & Extensions → Camera Extensions). After that, you're in.
+
+A few technical things, briefly, because if you're reading this far
+you probably care:
+
+- **Hold-last-frame** during the swap. When you change profiles, the
+  new camera takes a beat to warm up — about half a second. Instead
+  of flashing black at your Zoom call, the virtual camera holds the
+  last frame from the old camera until the new one's delivering
+  frames. You see a soft pause; nobody on the call sees a glitch.
+- **Format conversion** for any camera. Built-in webcams ship BGRA,
+  USB capture cards ship YUV at 1080p, every device has its quirks.
+  We accept whatever the camera natively delivers and convert to
+  1280×720 BGRA on the fly, hardware-accelerated where possible.
+  Means your weird HDMI capture card just works.
+- **Profile-driven everywhere.** The same Add Profile wizard that
+  picks your audio defaults now also picks the camera the virtual
+  camera streams. No new config to learn — it's the same `camera =`
+  field you've already been using. v0.1.x configs upgrade clean.
+
+One known thing: if you toggle the virtual camera off and then back
+on inside the same launch, macOS holds the extension in a stale
+state and the feed goes black. The Settings UI catches this and
+gives you a **Restart AV Pain Reliever** button that handles it. One
+click, fresh process, you're back. Edge case — most folks turn it
+on once and leave it. Not a deal-breaker.
+
+That's the update. Virtual camera, profile-driven, hold-last-frame,
+universal format support. v0.1.x will keep getting patch releases
+in parallel for anyone who doesn't need any of this. **Money.**
+```
 
 ### M2 lessons (gotchas the architecture or first attempts hit)
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2484,10 +2484,14 @@ the extension can't capture"):
    run with the v0.2.0 → v0.2.0.1 cycle in M6 — can't be
    shippable-verified until at least one v0.2.x release exists
    on the appcast.
-6. **M6 — Tag v0.2.0.** Notarized release build, appcast update,
-   GitHub release. First real-world Sparkle upgrade-replace test
-   happens here (cut v0.2.0, install fresh; cut v0.2.0.1 with a
-   trivial change; verify Sparkle replaces cleanly).
+6. **M6 — Tag v0.2.0.** SHIPPED 2026-05-04. CI workflow ran
+   clean (1m48s) using `make-app-with-virtual-camera.sh`,
+   notarized + stapled both bundles, signed appcast item
+   appended to main, draft published. v0.2.0 live at
+   https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.
+   The Sparkle upgrade-replace verification (v0.2.0 → v0.2.0.1)
+   is its own follow-up — separate small patch release whenever
+   we have the next reason to cut one.
 
 ### Deferred / open items
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2489,9 +2489,20 @@ the extension can't capture"):
    notarized + stapled both bundles, signed appcast item
    appended to main, draft published. v0.2.0 live at
    https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.
-   The Sparkle upgrade-replace verification (v0.2.0 → v0.2.0.1)
-   is its own follow-up — separate small patch release whenever
-   we have the next reason to cut one.
+7. **M7 — Sparkle release channel split.** SHIPPED 2026-05-04.
+   v0.2.0 was retroactively marked
+   `<sparkle:channel>experimental</sparkle:channel>` so v0.1.x
+   users stop being prompted to upgrade. v0.1.14 ships an
+   "Receive experimental updates" toggle to Settings → General
+   → Updates plus an `SPUUpdaterDelegate` that returns
+   `["experimental"]` when the toggle is on (default off).
+   `scripts/sign-appcast.sh` now takes a `CHANNEL` env var; the
+   release workflow auto-sets it to `experimental` for v0.2.x+
+   tags. v0.2.0.1 backports the channel-aware Updater to
+   feature/virtual-camera (live at
+   https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.1)
+   so users on the experimental track get future patches
+   normally.
 
 ### Deferred / open items
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2437,15 +2437,17 @@ the extension can't capture"):
    target that activates and shows up in Zoom but vends a black
    frame. Goal: prove the activation/signing/embedding plumbing
    works. **SHIPPED 2026-05-04.**
-2. **M2 — Host-side capture + XPC frame pipe (was M3).** Host app
-   opens an `AVCaptureSession` against a hardcoded source camera
-   (built-in webcam during dev). Each frame's `IOSurface` is sent
-   to the extension over an XPC connection. Extension wraps the
-   `IOSurface` in a `CMSampleBuffer` and forwards via
-   `stream.send(...)`. No source switching yet (that's a one-line
-   change in M3, but tested in isolation here). Goal: prove the
-   whole frame path works end-to-end at acceptable
-   resolution/framerate.
+2. **M2 — Host-side capture + CMIO sink-stream pipe.** SHIPPED
+   2026-05-04. Host app opens an `AVCaptureSession` against the
+   built-in webcam, opens AV Pain Reliever's sink stream via raw
+   CMIO C API, and enqueues each captured `CMSampleBuffer` into
+   the sink's `CMSimpleQueue`. The kernel passes the underlying
+   IOSurfaces across the process boundary. Extension consumes
+   from the sink via `stream.consumeSampleBuffer(from:)` on a
+   timer at 3× framerate and forwards each consumed frame to the
+   source stream that AVCapture clients (Zoom, Photo Booth, etc.)
+   read. Initial XPC implementation was abandoned — see "Why XPC
+   didn't work for the frame pipe" below.
 3. **M3 — Source switching + hold-last-frame.** Host app accepts
    `setSourceCamera(uniqueID:)` over the XPC service, swaps the
    `AVCaptureSession`'s source, and pauses the frame feed for
@@ -2645,6 +2647,107 @@ Concrete changes after the rollback:
   `com.apple.security.app-sandbox` and the App Group; nothing
   else.
 - M2 plan rewritten in milestones list above.
+
+### M2 — host-side capture + CMIO sink (SHIPPED 2026-05-04)
+
+End-to-end working: host captures from the built-in FaceTime HD
+camera at 1280×720 BGRA, writes frames into the extension's sink
+stream via CMIO's `CMSimpleQueueEnqueue`, the extension drains
+the sink and forwards to the source stream that Zoom and Photo
+Booth read. Live webcam feed flows through the AV Pain Reliever
+virtual camera with no perceptible latency.
+
+Architecture (matches OBS's `mac-virtualcam` pattern,
+referenced for design):
+
+- **Extension**: declares two streams on its single device — a
+  `.source` stream (AVCapture clients read this) and a `.sink`
+  stream (host writes here). Owns no AVFoundation. Runs a
+  consume timer at 90 Hz that drains the sink and calls
+  `stream.send(...)` on the source when there's an active
+  consumer (`streamingCounter > 0`). See
+  `Sources/AVPainRelieverCameraExtension/`:
+  - `CameraExtensionStream.swift` — source side, just tracks
+    streaming counter.
+  - `CameraExtensionStreamSink.swift` — sink side, captures the
+    `CMIOExtensionClient` in `authorizedToStartStream`.
+  - `CameraExtensionDevice.swift` — owns both streams + the
+    consume loop.
+
+- **Host**: opens AV Pain Reliever as a CMIO consumer, queries
+  each stream's `kCMIOStreamPropertyDirection` to find the sink
+  (NOT the index 1 trick — direction-property check is robust
+  against ID ordering changes), gets the buffer queue via
+  `CMIOStreamCopyBufferQueue`, calls `CMIODeviceStartStream`,
+  then enqueues each captured frame via `CMSimpleQueueEnqueue`.
+  See `Sources/AVPainRelieverApp/`:
+  - `CameraCaptureSession.swift` — AVFoundation capture against
+    built-in camera (no recursion since host is a normal app).
+  - `CMIOSinkWriter.swift` — raw CMIO sink-write path.
+
+### Why XPC didn't work for the frame pipe
+
+First attempt put NSXPCConnection between host and extension on
+a Mach service named `HLH4LEWS9S.group.com.ericwillis.avpainreliever.framepipe`.
+The XPC connection failed with `failed to do a bootstrap look-up:
+xpc_error=[3: No such process]`. Root cause:
+`NSXPCListener(machServiceName:)` only attaches to launchd-
+registered services — system extensions don't have launchd
+plists for their custom Mach names, so the listener never
+registered the service and clients couldn't find it.
+
+The OBS-style sink-stream approach sidesteps this entirely:
+CMIO already has cross-process IOSurface plumbing built in,
+and using the second stream as a sink reuses that plumbing for
+free. No Mach services to register, no XPC code to maintain.
+
+### M2 lessons (gotchas the architecture or first attempts hit)
+
+1. **`AVCaptureVideoDataOutput.sessionPreset` ≠ output
+   dimensions.** Setting `session.sessionPreset = .hd1280x720`
+   does not force the output to 1280×720 — the FaceTime HD camera
+   shipped 1920×1080 frames anyway. Fix: add
+   `kCVPixelBufferWidthKey`/`kCVPixelBufferHeightKey` to
+   `output.videoSettings`. AVFoundation does the downscale.
+2. **Pre-built `CMFormatDescription` is fragile.** If the format
+   description's dimensions don't match the actual pixel buffer,
+   `CMSampleBufferCreateForImageBuffer` fails with -12743
+   (`kCMSampleBufferError_InvalidMediaFormat`). Derive the
+   format description from the pixel buffer (cached when
+   dimensions stay constant). See
+   `CMIOSinkWriter.formatDescription(for:)`.
+3. **Don't trust stream array order.** OBS's plugin uses
+   `streams[1]` to find its sink, but that's not portable across
+   device implementations. Query
+   `kCMIOStreamPropertyDirection` (0 = output/sink,
+   1 = input/source) and pick by direction.
+4. **Hardened runtime needs `com.apple.security.device.camera`
+   even outside the sandbox.** TCC won't even prompt — it
+   silently denies. Without that key, `requestAccess` returns
+   `denied` with no UI. Add the entitlement to the v0.2.0 host
+   entitlements file.
+5. **Swift `NSLog` doesn't reach unified logging on
+   macOS 14+** in our LSUIElement host or the system extension.
+   Use `os.Logger(subsystem:category:)` exclusively. Tail with
+   `log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever"' --info --style compact`.
+6. **Iterating on the extension binary requires either a reboot
+   OR a Settings toggle off/on cycle.** Each new extension
+   version queues the previous one as
+   `[terminated waiting to uninstall on reboot]`, and macOS
+   stops exposing the device through `system_profiler
+   SPCameraDataType` until that queue clears. Confirmed both
+   paths work: full reboot or System Settings → General →
+   Login Items & Extensions → Camera Extensions → toggle off,
+   wait, toggle on. The toggle path is faster but doesn't
+   always work; reboot is the supported recovery.
+7. **`open --env VAR=val`, not `VAR=val open`.** The shell-prefix
+   form is stripped by `open` before launchd handoff. Has
+   bitten us in M1 too — kept as a permanent note.
+8. **Don't overlay a new bundle in `/Applications` between a
+   build and a reboot.** macOS picks up the new bundle during
+   boot and kicks off another upgrade cycle, undoing whatever
+   the reboot was supposed to clean up. Reboot first, then
+   install.
 
 ---
 

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -2515,11 +2515,70 @@ What's deliberately not done: no main-app integration with
 Those are M2 / M3 / M4. M1's only job is to prove the
 activation/embedding/signing plumbing works.
 
-Verification steps (next): user runs
-`scripts/make-app-with-virtual-camera.sh`, dittos to
-`/Applications`, runs the activation, confirms "AV Pain Reliever"
-appears in Zoom and shows a black frame. Findings fold back into
-this section once we know what works and what didn't.
+Verification (2026-05-04, second attempt): activated successfully
+end-to-end. `systemextensionsctl list` reports `[activated enabled]`,
+the extension process is alive under `_cmiodalassistants`, and the
+host app's activation request returns success.
+
+### M1 lessons (gotchas the original scaffold missed)
+
+The first build attempt failed activation because the original
+plumbing was missing several non-obvious requirements. Each of
+these surfaced as a distinct error from `sysextd`, requiring
+re-signing and re-installing to fix. Documenting them so future
+milestones don't relearn the same things:
+
+1. **`open` strips environment variables.** The `AVPR_ACTIVATE_VIRTUAL_CAMERA=1`
+   env var has to be passed via `open --env AVPR_ACTIVATE_VIRTUAL_CAMERA=1`,
+   not the shell-prefix form, because `open` hands off to `launchd`
+   which doesn't inherit the calling shell's environment. The
+   shell-prefix form sets the var only for the `open` command
+   itself, not for the launched app.
+2. **Notarization is required for system extension activation,
+   even with valid Developer ID signing.** `sysextd` queries the
+   notary daemon during validation; an unnotarized bundle gets
+   `bundle code signature is not valid - does not satisfy
+   requirement: -67050`. The `make-app-with-virtual-camera.sh`
+   script grew a notarization step gated by
+   `NOTARIZE_KEYCHAIN_PROFILE=avpain-notary` (using the existing
+   v0.1.x notarytool keychain profile). One round trip is ~30s; a
+   `SKIP_NOTARIZE` style escape hatch is a future-niceness if
+   non-system-extension iteration speed becomes a concern.
+3. **The Info.plist `CMIOExtension` dict is the type marker.**
+   Without it, `sysextd` reports "system extension does not appear
+   to belong to any extension categories" — the daemon cycles
+   through DriverKit / NetworkExtension / EndpointSecurity checks,
+   finds no marker for any of them, and rejects the bundle. The
+   correct shape is `<dict><key>CMIOExtensionMachServiceName</key>
+   <string>{TEAMID}.{appgroup-id}.{suffix}</string></dict>`. We
+   substitute `__TEAM_ID__` at build time, parsed out of
+   `MAC_CERT_NAME`.
+4. **Mach service name must be prefixed by an App Group declared
+   in the extension's entitlements.** The error from `sysextd` is
+   "invalid mach service name or is not signed, the value must be
+   prefixed with one of the App Groups in the entitlement." This
+   meant registering an App Group at developer.apple.com
+   (`group.com.ericwillis.avpainreliever`), enabling the App
+   Groups capability on both App IDs (host + extension),
+   regenerating the Developer ID provisioning profile, and adding
+   `com.apple.security.application-groups` to both entitlements
+   files with the team-prefixed form
+   (`HLH4LEWS9S.group.com.ericwillis.avpainreliever`).
+5. **AMFI's entitlement parser doesn't tolerate XML comments.**
+   The entitlement plists need to be plain key/value dicts; even
+   well-formed `<!-- ... -->` comments fail signing with "Failed
+   to parse entitlements: AMFIUnserializeXML: syntax error."
+   Documentation has to live in adjacent files, not inline.
+6. **Final activation needs explicit user approval in System
+   Settings.** `[activated waiting for user]` is the
+   intermediate state; the user opens **System Settings → General
+   → Login Items & Extensions → Camera Extensions** and toggles
+   the extension on. State then transitions to
+   `[activated enabled]`.
+
+The dev workflow (`docs/VIRTUAL_CAMERA_DEV.md`) was rewritten in a
+follow-up commit to reflect the actual recipe instead of the
+ad-hoc + developer-mode + SIP-off path I originally documented.
 
 ---
 

--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -58,6 +58,30 @@ public protocol CameraController {
     func currentPreferredName() -> String?
 }
 
+/// Drives the source camera that AV Pain Reliever's own virtual
+/// camera streams from. Conceptually parallel to `CameraController`
+/// (which sets the system-wide `userPreferredCamera`) but operates
+/// on a different surface: the in-app virtual camera that Zoom /
+/// Slack / Teams pick when the user selects "AV Pain Reliever" in
+/// their own camera UI. A profile that names a camera should drive
+/// both:
+///
+/// - `CameraController` so AVFoundation-modern apps follow the system
+///   default.
+/// - `VirtualCameraSourceController` so apps connected to the virtual
+///   camera see frames from that same source.
+///
+/// `nil` injection (or omitting from `ProfileApplier`'s init) yields
+/// a silent no-op — the v0.1.x release path that doesn't bundle the
+/// Camera Extension simply doesn't pass one.
+public protocol VirtualCameraSourceController {
+    /// Switch the virtual camera's source to the AVFoundation device
+    /// whose `localizedName` matches `named`. Idempotent — a re-set
+    /// to the currently-active source returns `.ok` without churning
+    /// the running capture session.
+    func setSource(named: String) -> CameraApplyResult
+}
+
 /// Production `CameraController` backed by AVFoundation. Stateless —
 /// every call constructs a fresh `DiscoverySession`. Sessions are
 /// cheap (microseconds) and we want fresh results when the user

--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -80,6 +80,33 @@ public protocol VirtualCameraSourceController {
     /// to the currently-active source returns `.ok` without churning
     /// the running capture session.
     func setSource(named: String) -> CameraApplyResult
+
+    /// Localized name to use for the system-wide preferred camera
+    /// (`AVCaptureDevice.userPreferredCamera`) when this controller
+    /// is the active routing layer, or nil to fall through to the
+    /// profile's literal camera name.
+    ///
+    /// When the host's virtual camera is enabled, the preferred
+    /// camera should be the virtual camera itself — that's what
+    /// AVFoundation-modern apps (FaceTime, Safari getUserMedia)
+    /// pick up, so they route through the virtual camera the same
+    /// way Zoom/Slack/Teams do once the user manually selects "AV
+    /// Pain Reliever" in their picker. The profile still names the
+    /// real source camera; `setSource(named:)` swaps the virtual
+    /// camera's source to match.
+    ///
+    /// Returns nil when the controller is in any non-live state
+    /// (off, activating, requires-relaunch) — `ProfileApplier`
+    /// then sets the system preference to the profile's literal
+    /// camera as it did pre-virtual-camera.
+    var preferredCameraOverride: String? { get }
+}
+
+public extension VirtualCameraSourceController {
+    /// Default for callers/mocks that don't model the override —
+    /// preserves the historical "set system preferred to the
+    /// profile's literal camera" behavior.
+    var preferredCameraOverride: String? { nil }
 }
 
 /// Production `CameraController` backed by AVFoundation. Stateless —

--- a/Sources/AVPainReliever/Engine/Engine.swift
+++ b/Sources/AVPainReliever/Engine/Engine.swift
@@ -116,6 +116,20 @@ public final class Engine {
         evaluateAndApply()
     }
 
+    /// Force a re-apply of the current profile, even if the profile
+    /// name hasn't changed. Bypasses the applier's "skip if same
+    /// name" dedupe by clearing its last-applied state first. Used
+    /// when a config change (virtual camera toggle flip, settings
+    /// edit) means the same profile name now produces different
+    /// system-state writes — the engine has to re-run the side
+    /// effects with the new context.
+    public func reapply() {
+        guard started else { return }
+        debouncer?.cancel()
+        applier.invalidateLastApplied()
+        evaluateAndApply()
+    }
+
     /// Apply a specific profile, bypassing the resolver entirely.
     /// Used by the menu bar's "Switch to" UI when the user wants to
     /// force a profile that doesn't match the current USB state — for

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -24,16 +24,19 @@ public protocol ApplierLogger {
 public final class ProfileApplier {
     private let audio: AudioController
     private let camera: CameraController?
+    private let virtualCameraSource: VirtualCameraSourceController?
     private let logger: ApplierLogger
     private var lastAppliedName: String?
 
     public init(
         audio: AudioController,
         camera: CameraController? = nil,
+        virtualCameraSource: VirtualCameraSourceController? = nil,
         logger: ApplierLogger
     ) {
         self.audio = audio
         self.camera = camera
+        self.virtualCameraSource = virtualCameraSource
         self.logger = logger
     }
 
@@ -52,6 +55,7 @@ public final class ProfileApplier {
         }
         if let cameraName = profile.camera {
             applyCamera(cameraName)
+            applyVirtualCameraSource(cameraName)
         }
 
         lastAppliedName = profile.name
@@ -81,6 +85,19 @@ public final class ProfileApplier {
             logger.info("set preferred camera: \(name)")
         case .notFound:
             logger.warn("camera '\(name)' not found — skipping (it may not be currently attached)")
+        }
+    }
+
+    private func applyVirtualCameraSource(_ name: String) {
+        // Silently skipped on v0.1.x builds (no virtual camera
+        // bundled) and on v0.2.x launches without
+        // AVPR_ACTIVATE_VIRTUAL_CAMERA=1. Both paths inject nil.
+        guard let virtualCameraSource else { return }
+        switch virtualCameraSource.setSource(named: name) {
+        case .ok:
+            logger.info("set virtual camera source: \(name)")
+        case .notFound:
+            logger.warn("virtual camera source '\(name)' not found — skipping (it may not be currently attached)")
         }
     }
 }

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -54,11 +54,30 @@ public final class ProfileApplier {
             applyAudio(output, role: .output)
         }
         if let cameraName = profile.camera {
-            applyCamera(cameraName)
+            // When the virtual camera is the active routing layer,
+            // the *system-wide* preferred camera should point at the
+            // virtual camera itself — that's what FaceTime / Safari
+            // / any AVFoundation-modern client picks up, mirroring
+            // what Zoom/Slack/Teams see once the user has manually
+            // selected "AV Pain Reliever". The profile's literal
+            // camera name still drives the virtual camera's *source*
+            // (the real webcam frames feed in there).
+            let preferredName = virtualCameraSource?.preferredCameraOverride
+                ?? cameraName
+            applyCamera(preferredName)
             applyVirtualCameraSource(cameraName)
         }
 
         lastAppliedName = profile.name
+    }
+
+    /// Forget the dedupe key so the next `apply(profile)` re-fires
+    /// every side effect even when the profile name hasn't changed.
+    /// Used by the host when a config change (e.g. flipping the
+    /// virtual-camera toggle) means the same profile name should
+    /// resolve to a different set of system-state writes.
+    public func invalidateLastApplied() {
+        lastAppliedName = nil
     }
 
     private func applyAudio(_ name: String, role: AudioDeviceRole) {

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -118,11 +118,7 @@ struct AddProfileView: View {
                     // See USB fingerprint section above for why this
                     // helper text lives in the section body rather
                     // than the `footer:` slot.
-                    Text("Sets macOS's preferred camera. Apps with their own camera picker (Zoom, Slack, Teams) won't follow this — configure those once per location and they'll remember.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .fixedSize(horizontal: false, vertical: true)
+                    cameraSectionHelperText
                 } header: {
                     sectionHeader("Camera", symbol: Theme.Symbol.cameraSection)
                 }
@@ -365,6 +361,33 @@ struct AddProfileView: View {
                     }
                 }
             }
+        }
+    }
+
+    /// Helper caption under the Camera picker. Two modes:
+    ///
+    /// - Virtual camera off: legacy V1 messaging — picking a camera
+    ///   here sets macOS's preferred camera, but Zoom/Slack/Teams
+    ///   maintain their own selection.
+    /// - Virtual camera on: the picker's value names the *source*
+    ///   the virtual camera will route. Zoom/Slack/Teams should
+    ///   point at "AV Pain Reliever" once and inherit profile
+    ///   switches automatically — that's the whole point of the
+    ///   virtual camera being on.
+    @ViewBuilder
+    private var cameraSectionHelperText: some View {
+        if viewModel.virtualCameraEnabled {
+            Text("AV Pain Reliever's virtual camera will use this as its source. Set Zoom, Slack, and Teams to “AV Pain Reliever” once — they'll follow your profile automatically.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            Text("Sets macOS's preferred camera. Apps with their own camera picker (Zoom, Slack, Teams) won't follow this — configure those once per location and they'll remember.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -132,6 +132,21 @@ final class AddProfileViewModel: ObservableObject {
     /// pre-collision-check codepath).
     private let existingProfileSlugs: Set<String>
 
+    /// Whether the host's virtual camera is currently the active
+    /// routing layer. Used to (a) hide the virtual camera from the
+    /// camera picker — it's an *output*, not a source the user
+    /// should select per profile, and (b) tailor the helper text
+    /// under the picker so the wizard explains the model the user
+    /// has actually opted into.
+    let virtualCameraEnabled: Bool
+
+    /// Localized name AVFoundation reports for the embedded virtual
+    /// camera. Mirrors `VirtualCameraActivator.virtualCameraDisplayName`.
+    /// Hardcoded here rather than imported because the engine
+    /// module (which owns this view model's `CameraSummary` type)
+    /// has no view of the host activator's constants.
+    private static let virtualCameraDisplayName = "AV Pain Reliever"
+
     /// Saved fingerprint from the profile being edited — preserved
     /// verbatim across `refresh()` so saved-but-disconnected devices
     /// keep showing up even after the live watcher snapshot updates.
@@ -150,6 +165,7 @@ final class AddProfileViewModel: ObservableObject {
         configURL: URL,
         editing: Profile? = nil,
         existingProfileSlugs: Set<String> = [],
+        virtualCameraEnabled: Bool = false,
         onSaved: @escaping () -> Void
     ) {
         self.watcher = watcher
@@ -159,6 +175,7 @@ final class AddProfileViewModel: ObservableObject {
         self.onSaved = onSaved
         self.editingSlug = editing?.name
         self.existingProfileSlugs = existingProfileSlugs
+        self.virtualCameraEnabled = virtualCameraEnabled
 
         if let profile = editing {
             // Pre-populate from the existing profile so the user can
@@ -250,7 +267,17 @@ final class AddProfileViewModel: ObservableObject {
             )
         }
         audioDevices = audioController.availableDevices()
+        // Filter the embedded virtual camera out of the picker —
+        // it's an output, not a source. A profile names the *real*
+        // camera that the virtual camera should route. Filtering
+        // here also quietly cleans up profiles created during the
+        // brief window where the virtual camera was selectable: the
+        // saved-but-now-invalid value is sanitized below.
         cameras = cameraController.availableCameras()
+            .filter { $0.name != Self.virtualCameraDisplayName }
+        if camera == Self.virtualCameraDisplayName {
+            camera = nil
+        }
 
         // Pre-select whatever the system currently uses so the user
         // doesn't have to repeat audio/camera choices they already
@@ -259,7 +286,14 @@ final class AddProfileViewModel: ObservableObject {
         let defaults = audioController.currentDefaults()
         if audioInput == nil { audioInput = defaults.inputName }
         if audioOutput == nil { audioOutput = defaults.outputName }
-        if camera == nil { camera = cameraController.currentPreferredName() }
+        if camera == nil {
+            // `currentPreferredName()` will read back "AV Pain
+            // Reliever" once the virtual camera is the system-wide
+            // preferred — that's by design (#2). Skip it here so
+            // the pre-fill always lands on a *real* camera.
+            let preferred = cameraController.currentPreferredName()
+            camera = preferred == Self.virtualCameraDisplayName ? nil : preferred
+        }
 
         // First-launch convenience: if the user hasn't typed a name and
         // we recognize a docked-setup signature in the attached

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -450,6 +450,7 @@ private struct WizardForm: View {
             configURL: deps.configURL,
             editing: deps.editing,
             existingProfileSlugs: deps.existingProfileSlugs,
+            virtualCameraEnabled: deps.virtualCameraEnabled,
             onSaved: deps.onSaved
         ))
     }

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -456,5 +456,16 @@ private struct WizardForm: View {
 
     var body: some View {
         AddProfileView(viewModel: viewModel, dismiss: onDismiss)
+            // The wizard reads `cameras` once at init time. If the
+            // user opens the wizard while the Camera Extension is
+            // still activating (or before the host has TCC-grant
+            // settled), the embedded virtual camera is missing from
+            // the picker. Re-pull the device lists when the
+            // activator transitions to `.on` so a wizard already on
+            // screen catches up without the user having to click
+            // Refresh.
+            .onReceive(delegate.virtualCameraActivator.$state) { state in
+                if case .on = state { viewModel.refresh() }
+            }
     }
 }

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -159,6 +159,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         NSApp.applicationIconImage = AppIcon.image
         bootEngine()
         applyLaunchAtLoginPreference()
+        // V2 / M1: env-var-gated Camera Extension activation. No-op
+        // unless AVPR_ACTIVATE_VIRTUAL_CAMERA=1 is set in the
+        // environment AND the host app has the
+        // `com.apple.developer.system-extension.install` entitlement
+        // (v0.2.0+ builds only). v0.1.x users see no behavior change.
+        VirtualCameraActivator.activateIfRequested()
         // Spin up Sparkle only inside a real .app bundle that has a
         // real EdDSA public key embedded. The full predicate (and
         // the reasoning behind each branch) lives on Updater itself

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import AVFoundation
 import SwiftUI
 import Combine
 import AVPainReliever
@@ -193,6 +194,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // foreground for windows. Generated at runtime so a palette
         // tweak doesn't need a regenerated `.icns` asset.
         NSApp.applicationIconImage = AppIcon.image
+        // Pre-grant camera TCC for the host process. Without this,
+        // `AVCaptureDevice.DiscoverySession` from inside the wizard
+        // hides the embedded Camera Extension even though Photo
+        // Booth and other approved apps see it. Idempotent — once
+        // the user has accepted, subsequent launches return
+        // immediately without re-prompting.
+        if AVCaptureDevice.authorizationStatus(for: .video) == .notDetermined {
+            AVCaptureDevice.requestAccess(for: .video) { _ in }
+        }
         // V2: enable the virtual camera if (a) the user previously
         // turned the Settings toggle on, OR (b) the
         // `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` debug override is set.

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -23,6 +23,11 @@ struct AddProfileDependencies {
     /// already taken — preventing the wizard from pre-loading a
     /// duplicate name that would collide at save time.
     let existingProfileSlugs: Set<String>
+    /// Whether the virtual camera is the active routing layer at
+    /// wizard-open time. Drives the camera picker's filter (the
+    /// virtual camera is hidden from the list) and the helper text
+    /// that explains the per-profile camera setting under each mode.
+    let virtualCameraEnabled: Bool
     let onSaved: () -> Void
 }
 
@@ -159,6 +164,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] enabled in
                 self?.applyVirtualCameraToggle(enabled: enabled)
+            }
+            .store(in: &cancellables)
+        // The activator's `preferredCameraOverride` flips with state.
+        // When state crosses into / out of `.on`, the active profile's
+        // camera should be re-applied with the new override semantics
+        // (system-wide preferred = virtual camera vs. = real camera).
+        // `removeDuplicates` collapses the no-op transitions so we
+        // don't reapply on every internal `.activating` →
+        // `.needsApproval` shimmer.
+        virtualCameraActivator.$state
+            .map { state -> Bool in
+                if case .on = state { return true }
+                return false
+            }
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.engine?.reapply()
             }
             .store(in: &cancellables)
     }
@@ -465,6 +489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             configURL: Self.profilesTOMLURL,
             editing: editing,
             existingProfileSlugs: existing,
+            virtualCameraEnabled: virtualCameraActivator.state == .on,
             onSaved: { [weak self] in
                 // Saving any profile is taken as the user being
                 // committed — no need to keep showing the welcome
@@ -574,8 +599,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private func applyVirtualCameraToggle(enabled: Bool) {
         if enabled {
             virtualCameraActivator.enable(envOverride: false)
+            // The `.on` transition (when activation completes)
+            // triggers `engine.reapply()` via the state observer
+            // wired up in `init`. Nothing to do here.
         } else {
             virtualCameraActivator.disable()
+            // Disable is synchronous — state goes to `.off`
+            // immediately. Re-apply the active profile so its
+            // camera setting flows back to the real device, not
+            // the virtual one we just torn down. (`disable` itself
+            // already cleared a stale `userPreferredCamera`; this
+            // gives the profile applier a chance to set it
+            // explicitly to the profile's real camera.)
+            engine?.reapply()
         }
     }
 

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -60,6 +60,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     private var engine: Engine?
 
+    /// Owns the lifecycle of the embedded Camera Extension and the
+    /// host capture pipeline. SwiftUI views observe this directly
+    /// so the Settings UI can show a live status badge as the
+    /// extension activates / fails / deactivates. Stable across
+    /// `bootEngine()` calls — only `enable()` / `disable()` change
+    /// its internal pipeline state.
+    let virtualCameraActivator = VirtualCameraActivator()
+
     /// Pick the bundle-aware UserNotifications notifier when running
     /// inside the signed `.app` (clean icon, click-to-dismiss). Fall
     /// back to the AppleScript shim for `swift run` dev binaries that
@@ -124,6 +132,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         settings.objectWillChange
             .sink { [weak self] in self?.objectWillChange.send() }
             .store(in: &cancellables)
+        // Same propagation for the activator — Settings views show a
+        // live state badge that needs to repaint on every state
+        // transition.
+        virtualCameraActivator.objectWillChange
+            .sink { [weak self] in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        // Drive the activator from the persisted toggle. Skips the
+        // initial value (delivered synchronously when the sink
+        // attaches) — `applicationDidFinishLaunching` handles the
+        // first apply once `submitRequest` is safe to call. Runtime
+        // changes (user flipping the toggle in Settings) come
+        // through here, and we rebuild the engine afterwards so
+        // `ProfileApplier`'s `virtualCameraSource` reference picks
+        // up the activator's new lifecycle state.
+        settings.$virtualCameraEnabled
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] enabled in
+                self?.applyVirtualCameraToggle(enabled: enabled)
+            }
+            .store(in: &cancellables)
     }
 
     private static let profilesTOMLURL: URL =
@@ -157,17 +187,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // foreground for windows. Generated at runtime so a palette
         // tweak doesn't need a regenerated `.icns` asset.
         NSApp.applicationIconImage = AppIcon.image
-        // V2 / M1+M2+M3: env-var-gated Camera Extension activation.
-        // Boots the host-side capture pipeline (M2) and exposes the
-        // running session as a `VirtualCameraSourceController` so the
-        // engine that follows can drive its source from the active
-        // profile (M3). No-op unless `AVPR_ACTIVATE_VIRTUAL_CAMERA=1`
-        // is set AND the host has the
-        // `com.apple.developer.system-extension.install` entitlement
-        // (v0.2.0+ builds only). Runs before `bootEngine()` so the
-        // engine's first evaluate-and-apply finds a live source to
-        // drive.
-        VirtualCameraActivator.activateIfRequested()
+        // V2: enable the virtual camera if (a) the user previously
+        // turned the Settings toggle on, OR (b) the
+        // `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` debug override is set.
+        // The override stays in the codebase as a developer
+        // affordance — useful for re-activation after a
+        // `systemextensionsctl uninstall` without touching the
+        // persisted setting. Runs before `bootEngine()` so the
+        // engine's first evaluate-and-apply finds a live source.
+        let envOverride = ProcessInfo.processInfo
+            .environment[VirtualCameraActivator.envVar] == "1"
+        if VirtualCameraActivator.shouldAutoEnable(
+            persistedToggle: settings.virtualCameraEnabled
+        ) {
+            virtualCameraActivator.enable(envOverride: envOverride)
+        }
         bootEngine()
         applyLaunchAtLoginPreference()
         // Spin up Sparkle only inside a real .app bundle that has a
@@ -485,16 +519,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let resolver = ProfileResolver(profiles: profiles)
         let audio = CoreAudioController()
         let camera = AVFoundationCameraController()
-        // Plumbed only when the env-var-gated activator booted the
-        // capture pipeline. v0.1.x and "didn't ask for virtual camera"
-        // launches inject nil, which `ProfileApplier` treats as
-        // silent skip. Set on first `bootEngine()` and stable across
-        // `reloadConfig()` — the activator runs once per launch.
-        let virtualCameraSource = VirtualCameraActivator.virtualCameraSource
+        // The activator is itself a `VirtualCameraSourceController` —
+        // it forwards `setSource` to the running capture session
+        // when enabled, and silently no-ops when disabled. Always
+        // injected so toggle flips at runtime are picked up
+        // without rebuilding the engine.
         let applier = ProfileApplier(
             audio: audio,
             camera: camera,
-            virtualCameraSource: virtualCameraSource,
+            virtualCameraSource: virtualCameraActivator,
             logger: logger
         )
         return Engine(
@@ -505,6 +538,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             debounceInterval: settings.debounceInterval,
             clock: DispatchClock()
         )
+    }
+
+    /// User flipped the Settings toggle. The activator handles
+    /// idempotency for repeats; this method is a thin dispatcher.
+    /// Engine rebuild is unnecessary because the activator is the
+    /// `VirtualCameraSourceController` plumbed into `ProfileApplier`
+    /// — its forwarding behavior changes with state, no engine
+    /// reconfiguration needed.
+    private func applyVirtualCameraToggle(enabled: Bool) {
+        if enabled {
+            virtualCameraActivator.enable(envOverride: false)
+        } else {
+            virtualCameraActivator.disable()
+        }
     }
 
     // MARK: - Convenience surfaces for the menu

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -157,14 +157,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // foreground for windows. Generated at runtime so a palette
         // tweak doesn't need a regenerated `.icns` asset.
         NSApp.applicationIconImage = AppIcon.image
+        // V2 / M1+M2+M3: env-var-gated Camera Extension activation.
+        // Boots the host-side capture pipeline (M2) and exposes the
+        // running session as a `VirtualCameraSourceController` so the
+        // engine that follows can drive its source from the active
+        // profile (M3). No-op unless `AVPR_ACTIVATE_VIRTUAL_CAMERA=1`
+        // is set AND the host has the
+        // `com.apple.developer.system-extension.install` entitlement
+        // (v0.2.0+ builds only). Runs before `bootEngine()` so the
+        // engine's first evaluate-and-apply finds a live source to
+        // drive.
+        VirtualCameraActivator.activateIfRequested()
         bootEngine()
         applyLaunchAtLoginPreference()
-        // V2 / M1: env-var-gated Camera Extension activation. No-op
-        // unless AVPR_ACTIVATE_VIRTUAL_CAMERA=1 is set in the
-        // environment AND the host app has the
-        // `com.apple.developer.system-extension.install` entitlement
-        // (v0.2.0+ builds only). v0.1.x users see no behavior change.
-        VirtualCameraActivator.activateIfRequested()
         // Spin up Sparkle only inside a real .app bundle that has a
         // real EdDSA public key embedded. The full predicate (and
         // the reasoning behind each branch) lives on Updater itself
@@ -480,7 +485,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let resolver = ProfileResolver(profiles: profiles)
         let audio = CoreAudioController()
         let camera = AVFoundationCameraController()
-        let applier = ProfileApplier(audio: audio, camera: camera, logger: logger)
+        // Plumbed only when the env-var-gated activator booted the
+        // capture pipeline. v0.1.x and "didn't ask for virtual camera"
+        // launches inject nil, which `ProfileApplier` treats as
+        // silent skip. Set on first `bootEngine()` and stable across
+        // `reloadConfig()` — the activator runs once per launch.
+        let virtualCameraSource = VirtualCameraActivator.virtualCameraSource
+        let applier = ProfileApplier(
+            audio: audio,
+            camera: camera,
+            virtualCameraSource: virtualCameraSource,
+            logger: logger
+        )
         return Engine(
             watcher: watcher,
             resolver: resolver,

--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -1,0 +1,209 @@
+import Foundation
+import CoreMediaIO
+import CoreMedia
+import CoreVideo
+
+/// Opens the AV Pain Reliever virtual camera as a CMIO consumer
+/// and writes frames into its sink stream's `CMSimpleQueue`. The
+/// kernel's CMIO subsystem passes those frames (including the
+/// underlying IOSurfaces) through to the extension process — no
+/// XPC, no sockets, no shared memory plumbing on our side.
+///
+/// Why raw CMIO instead of AVFoundation: AVFoundation only exposes
+/// cameras as *inputs*. The sink stream we're writing to looks
+/// like a camera to the system but accepts frames as if it were
+/// an output device. The CMIO C API is the only public way to do
+/// this writing today.
+///
+/// Mirrors the pattern OBS uses in its mac-virtualcam plugin
+/// (referenced for architecture, not code).
+final class CMIOSinkWriter {
+    private let deviceUID: String
+    private let formatDescription: CMFormatDescription
+    private var deviceID: CMIODeviceID = 0
+    private var streamID: CMIOStreamID = 0
+    private var queue: CMSimpleQueue?
+
+    init(deviceUID: String, width: Int32, height: Int32) {
+        self.deviceUID = deviceUID
+        var fmt: CMFormatDescription?
+        CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCVPixelFormatType_32BGRA,
+            width: width,
+            height: height,
+            extensions: nil,
+            formatDescriptionOut: &fmt
+        )
+        // Force-unwrap is fine — CMVideoFormatDescriptionCreate
+        // doesn't fail for legal pixel format / dimensions.
+        self.formatDescription = fmt!
+    }
+
+    /// Discovers the device, opens its sink stream, primes the
+    /// buffer queue, and starts streaming. Returns true on success.
+    /// All failures log to stderr and return false — caller decides
+    /// whether to retry.
+    func start() -> Bool {
+        guard let device = findDevice(matchingUID: deviceUID) else {
+            NSLog("[AVPR-host] CMIO device with UID \(deviceUID) not found")
+            return false
+        }
+        deviceID = device
+
+        guard let sink = findSinkStream(deviceID: device) else {
+            NSLog("[AVPR-host] sink stream not found on device")
+            return false
+        }
+        streamID = sink
+
+        var unmanaged: Unmanaged<CMSimpleQueue>?
+        let copyStatus = CMIOStreamCopyBufferQueue(sink, { _, _, _ in }, nil, &unmanaged)
+        guard copyStatus == noErr, let unmanaged else {
+            NSLog("[AVPR-host] CMIOStreamCopyBufferQueue failed: \(copyStatus)")
+            return false
+        }
+        self.queue = unmanaged.takeRetainedValue()
+
+        let startStatus = CMIODeviceStartStream(device, sink)
+        guard startStatus == noErr else {
+            NSLog("[AVPR-host] CMIODeviceStartStream failed: \(startStatus)")
+            return false
+        }
+
+        NSLog("[AVPR-host] CMIOSinkWriter started")
+        return true
+    }
+
+    func stop() {
+        if deviceID != 0 && streamID != 0 {
+            CMIODeviceStopStream(deviceID, streamID)
+        }
+        deviceID = 0
+        streamID = 0
+        queue = nil
+    }
+
+    /// Wraps an incoming pixel buffer in a CMSampleBuffer and
+    /// enqueues it. Caller owns the pixel buffer; this method does
+    /// NOT retain it long-term — `CMSampleBufferCreateForImageBuffer`
+    /// retains internally.
+    func enqueue(pixelBuffer: CVPixelBuffer, hostTimeNs: UInt64) {
+        guard let queue else { return }
+
+        var timing = CMSampleTimingInfo(
+            duration: .invalid,
+            presentationTimeStamp: CMTime(
+                value: CMTimeValue(hostTimeNs),
+                timescale: CMTimeScale(NSEC_PER_SEC)
+            ),
+            decodeTimeStamp: .invalid
+        )
+        var sampleBuffer: CMSampleBuffer?
+        let status = CMSampleBufferCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            dataReady: true,
+            makeDataReadyCallback: nil,
+            refcon: nil,
+            formatDescription: formatDescription,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        )
+        guard status == noErr, let sampleBuffer else { return }
+
+        // CMSimpleQueue takes ownership of the enqueued ref. Pass
+        // a retained pointer so the queue can release after the
+        // consumer takes it.
+        let retained = Unmanaged.passRetained(sampleBuffer).toOpaque()
+        let enqueueStatus = CMSimpleQueueEnqueue(queue, element: retained)
+        if enqueueStatus != noErr {
+            // Queue full or otherwise rejected. Reclaim the retain
+            // we just gave it so the buffer doesn't leak.
+            Unmanaged<CMSampleBuffer>.fromOpaque(retained).release()
+        }
+    }
+
+    // MARK: - CMIO discovery
+
+    private func findDevice(matchingUID uid: String) -> CMIODeviceID? {
+        var address = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+        var dataSize: UInt32 = 0
+        guard
+            CMIOObjectGetPropertyDataSize(
+                CMIOObjectID(kCMIOObjectSystemObject),
+                &address, 0, nil,
+                &dataSize
+            ) == noErr,
+            dataSize > 0
+        else { return nil }
+
+        let count = Int(dataSize) / MemoryLayout<CMIOObjectID>.size
+        var devices = [CMIOObjectID](repeating: 0, count: count)
+        var dataUsed: UInt32 = 0
+        guard
+            CMIOObjectGetPropertyData(
+                CMIOObjectID(kCMIOObjectSystemObject),
+                &address, 0, nil,
+                dataSize, &dataUsed,
+                &devices
+            ) == noErr
+        else { return nil }
+
+        for device in devices {
+            guard let candidate = copyDeviceUID(deviceID: device) else { continue }
+            if candidate.caseInsensitiveCompare(uid) == .orderedSame {
+                return device
+            }
+        }
+        return nil
+    }
+
+    private func copyDeviceUID(deviceID: CMIODeviceID) -> String? {
+        var address = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceUID),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+        var size: UInt32 = UInt32(MemoryLayout<CFString>.size)
+        var uid: Unmanaged<CFString>?
+        let status = CMIOObjectGetPropertyData(
+            deviceID, &address, 0, nil, size, &size, &uid
+        )
+        guard status == noErr, let unmanaged = uid else { return nil }
+        return unmanaged.takeRetainedValue() as String
+    }
+
+    private func findSinkStream(deviceID: CMIODeviceID) -> CMIOStreamID? {
+        var address = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyStreams),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+        var dataSize: UInt32 = 0
+        guard
+            CMIOObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize)
+                == noErr,
+            dataSize >= 2 * UInt32(MemoryLayout<CMIOStreamID>.size)
+        else { return nil }
+
+        let count = Int(dataSize) / MemoryLayout<CMIOStreamID>.size
+        var streams = [CMIOStreamID](repeating: 0, count: count)
+        var dataUsed: UInt32 = 0
+        guard
+            CMIOObjectGetPropertyData(
+                deviceID, &address, 0, nil,
+                dataSize, &dataUsed, &streams
+            ) == noErr
+        else { return nil }
+
+        // Index 0 = source (what Zoom reads), index 1 = sink. The
+        // extension adds them in this order in
+        // `CameraExtensionDeviceSource.init`.
+        return streams[1]
+    }
+}

--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreMediaIO
 import CoreMedia
 import CoreVideo
+import VideoToolbox
 import os.log
 
 private let logger = Logger(
@@ -29,20 +30,50 @@ final class CMIOSinkWriter {
     private var streamID: CMIOStreamID = 0
     private var queue: CMSimpleQueue?
 
-    /// Cached format description matching the most recent pixel
-    /// buffer. We derive this per-frame rather than pre-building
-    /// because the camera's actual delivered dimensions may not
-    /// match what `sessionPreset` requested (e.g., FaceTime HD
-    /// camera ignores `.hd1280x720` and ships 1920x1080 unless
-    /// width/height keys are set on the output's videoSettings).
-    private var formatDescription: CMFormatDescription?
-    private var formatDescriptionDimensions: (Int, Int) = (0, 0)
+    /// Format description used for the most recent enqueue,
+    /// keyed by the underlying pixel buffer pointer. Re-derived
+    /// when the buffer changes — VT-converted destination
+    /// buffers carry source-derived color attachments that the
+    /// strict CMSampleBuffer validator (-12743) rejects when a
+    /// format description from one buffer is reused for another,
+    /// even when dimensions + format are identical. M2's lesson:
+    /// derive the format description from the SAME buffer you're
+    /// wrapping. The pool recycles a small handful of buffers, so
+    /// in steady state the cache hits 90%+ even with this strict
+    /// keying.
+    private var lastFormatBufferPtr: UnsafeRawPointer?
+    private var lastFormatDescription: CMFormatDescription?
+
+    /// Convert + scale arbitrary input pixel buffers (any format,
+    /// any dimensions — capture cards typically deliver YUV at
+    /// 1080p) to the target 1280×720 BGRA. Hardware-accelerated
+    /// where the GPU supports it. Created lazily on first enqueue
+    /// so we don't pay the cost when the host isn't producing.
+    private var transferSession: VTPixelTransferSession?
+
+    /// Recycles the destination BGRA pixel buffers VT writes into.
+    /// Pool size is left to CV defaults (small, refill as needed)
+    /// — capture is steady-state at 30 fps so we'd retain at most
+    /// a couple of buffers in flight.
+    private var bufferPool: CVPixelBufferPool?
+
+    /// Logged once per (format, dimensions) pair the host
+    /// delivers, so a profile change shows up in the log without
+    /// flooding with one line per frame.
+    private var lastLoggedInputSignature: (OSType, Int, Int) = (0, 0, 0)
+
+    /// Output target. The extension's source stream advertises
+    /// 1280×720 BGRA; matching here avoids a format mismatch on
+    /// AVCapture clients that read from the source.
+    private static let outputWidth: Int = 1280
+    private static let outputHeight: Int = 720
+    private static let outputFormat: OSType = kCVPixelFormatType_32BGRA
 
     init(deviceUID: String, width: Int32, height: Int32) {
         self.deviceUID = deviceUID
         // width/height retained as ignored params for backward-
-        // compat with the call site; the actual format used at
-        // runtime is derived per-pixel-buffer below.
+        // compat with the call site; the output target is fixed
+        // at 1280×720 BGRA (matches the extension's source format).
         _ = width
         _ = height
     }
@@ -90,6 +121,11 @@ final class CMIOSinkWriter {
         deviceID = 0
         streamID = 0
         queue = nil
+        transferSession = nil
+        bufferPool = nil
+        lastFormatBufferPtr = nil
+        lastFormatDescription = nil
+        lastLoggedInputSignature = (0, 0, 0)
     }
 
     private var enqueueCount: UInt64 = 0
@@ -107,9 +143,13 @@ final class CMIOSinkWriter {
             return
         }
 
-        guard let formatDescription = formatDescription(for: pixelBuffer) else {
-            return
-        }
+        logIncomingFormatIfChanged(pixelBuffer: pixelBuffer)
+
+        guard let convertedBuffer = convertToOutputBuffer(input: pixelBuffer)
+        else { return }
+
+        guard let formatDescription = ensureOutputFormatDescription(for: convertedBuffer)
+        else { return }
 
         var timing = CMSampleTimingInfo(
             duration: .invalid,
@@ -122,7 +162,7 @@ final class CMIOSinkWriter {
         var sampleBuffer: CMSampleBuffer?
         let status = CMSampleBufferCreateForImageBuffer(
             allocator: kCFAllocatorDefault,
-            imageBuffer: pixelBuffer,
+            imageBuffer: convertedBuffer,
             dataReady: true,
             makeDataReadyCallback: nil,
             refcon: nil,
@@ -257,16 +297,18 @@ final class CMIOSinkWriter {
         return nil
     }
 
-    /// Returns a format description matching the supplied pixel
-    /// buffer. Cached so steady-state captures don't allocate a
-    /// fresh description per frame.
-    private func formatDescription(for pixelBuffer: CVPixelBuffer)
+    /// Returns a format description derived from the supplied
+    /// pixel buffer. Cached against the buffer's pointer because
+    /// the pool recycles a small handful of IOSurface-backed
+    /// buffers — same pointer → same attachments → cache hit.
+    /// New pointer → rebuild, because VT-attached colorspace
+    /// metadata differs per source frame.
+    private func ensureOutputFormatDescription(for pixelBuffer: CVPixelBuffer)
         -> CMFormatDescription?
     {
-        let width = CVPixelBufferGetWidth(pixelBuffer)
-        let height = CVPixelBufferGetHeight(pixelBuffer)
-        if let cached = formatDescription,
-           formatDescriptionDimensions == (width, height)
+        let ptr = Unmanaged.passUnretained(pixelBuffer).toOpaque()
+        if let cached = lastFormatDescription,
+           lastFormatBufferPtr == UnsafeRawPointer(ptr)
         {
             return cached
         }
@@ -280,12 +322,130 @@ final class CMIOSinkWriter {
             logger.error("CMVideoFormatDescriptionCreateForImageBuffer failed: \(status)")
             return nil
         }
-        formatDescription = fmt
-        formatDescriptionDimensions = (width, height)
-        logger.info(
-            "Built format description for \(width, privacy: .public)x\(height, privacy: .public)"
-        )
+        lastFormatBufferPtr = UnsafeRawPointer(ptr)
+        lastFormatDescription = fmt
         return fmt
+    }
+
+    /// Convert + scale `input` into a freshly-pooled 1280×720 BGRA
+    /// pixel buffer. Returns the input as-is when it already
+    /// matches the target format AND dimensions, so built-in
+    /// cameras that natively deliver 1280×720 BGRA stay on the
+    /// zero-copy fast path. USB capture cards (HDMI to U3 capture
+    /// is the user's known case) deliver 1080p YUV422 — those
+    /// flow through `VTPixelTransferSessionTransferImage` for
+    /// hardware-accelerated downscale + colorspace conversion.
+    private func convertToOutputBuffer(input: CVPixelBuffer) -> CVPixelBuffer? {
+        let inputWidth = CVPixelBufferGetWidth(input)
+        let inputHeight = CVPixelBufferGetHeight(input)
+        let inputFormat = CVPixelBufferGetPixelFormatType(input)
+        if inputFormat == Self.outputFormat
+            && inputWidth == Self.outputWidth
+            && inputHeight == Self.outputHeight
+        {
+            return input
+        }
+
+        guard let session = ensureTransferSession(),
+              let pool = ensureBufferPool()
+        else { return nil }
+
+        var destination: CVPixelBuffer?
+        let createStatus = CVPixelBufferPoolCreatePixelBuffer(
+            kCFAllocatorDefault, pool, &destination
+        )
+        guard createStatus == kCVReturnSuccess, let destination else {
+            logger.error(
+                "CVPixelBufferPoolCreatePixelBuffer failed: \(createStatus, privacy: .public)"
+            )
+            return nil
+        }
+
+        let xferStatus = VTPixelTransferSessionTransferImage(
+            session,
+            from: input,
+            to: destination
+        )
+        guard xferStatus == noErr else {
+            logger.error(
+                "VTPixelTransferSessionTransferImage failed: \(xferStatus, privacy: .public)"
+            )
+            return nil
+        }
+        return destination
+    }
+
+    private func ensureTransferSession() -> VTPixelTransferSession? {
+        if let transferSession { return transferSession }
+        var session: VTPixelTransferSession?
+        let status = VTPixelTransferSessionCreate(
+            allocator: kCFAllocatorDefault,
+            pixelTransferSessionOut: &session
+        )
+        guard status == noErr, let session else {
+            logger.error("VTPixelTransferSessionCreate failed: \(status, privacy: .public)")
+            return nil
+        }
+        // High-quality scaling — hardware path on Apple Silicon,
+        // worth the negligible cost on Intel too. The session
+        // reads the source/destination buffer attributes to pick
+        // an internal pixel-transfer pipeline; no further config
+        // needed for our 30-fps single-stream use case.
+        VTSessionSetProperty(
+            session,
+            key: kVTPixelTransferPropertyKey_ScalingMode,
+            value: kVTScalingMode_Letterbox
+        )
+        transferSession = session
+        return session
+    }
+
+    private func ensureBufferPool() -> CVPixelBufferPool? {
+        if let bufferPool { return bufferPool }
+        let attrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: Self.outputFormat,
+            kCVPixelBufferWidthKey as String: Self.outputWidth,
+            kCVPixelBufferHeightKey as String: Self.outputHeight,
+            // IOSurface-backed so the buffer can be marshalled
+            // across the host → extension process boundary by
+            // CMIO without an extra copy.
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        var pool: CVPixelBufferPool?
+        let status = CVPixelBufferPoolCreate(
+            kCFAllocatorDefault,
+            nil,
+            attrs as CFDictionary,
+            &pool
+        )
+        guard status == kCVReturnSuccess, let pool else {
+            logger.error("CVPixelBufferPoolCreate failed: \(status, privacy: .public)")
+            return nil
+        }
+        bufferPool = pool
+        return pool
+    }
+
+    private func logIncomingFormatIfChanged(pixelBuffer: CVPixelBuffer) {
+        let signature = (
+            CVPixelBufferGetPixelFormatType(pixelBuffer),
+            CVPixelBufferGetWidth(pixelBuffer),
+            CVPixelBufferGetHeight(pixelBuffer)
+        )
+        if signature == lastLoggedInputSignature { return }
+        lastLoggedInputSignature = signature
+        let fourcc = String(bytes: [
+            UInt8((signature.0 >> 24) & 0xFF),
+            UInt8((signature.0 >> 16) & 0xFF),
+            UInt8((signature.0 >> 8) & 0xFF),
+            UInt8(signature.0 & 0xFF),
+        ], encoding: .ascii) ?? "????"
+        let needsConversion = signature.0 != Self.outputFormat
+            || signature.1 != Self.outputWidth
+            || signature.2 != Self.outputHeight
+        logger.info(
+            "Host frame format: \(fourcc, privacy: .public) \(signature.1, privacy: .public)x\(signature.2, privacy: .public) — \(needsConversion ? "convert+scale" : "passthrough", privacy: .public)"
+        )
     }
 
     private func streamDirection(streamID: CMIOStreamID) -> UInt32? {

--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -2,6 +2,12 @@ import Foundation
 import CoreMediaIO
 import CoreMedia
 import CoreVideo
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever",
+    category: "CMIOSinkWriter"
+)
 
 /// Opens the AV Pain Reliever virtual camera as a CMIO consumer
 /// and writes frames into its sink stream's `CMSimpleQueue`. The
@@ -42,36 +48,37 @@ final class CMIOSinkWriter {
 
     /// Discovers the device, opens its sink stream, primes the
     /// buffer queue, and starts streaming. Returns true on success.
-    /// All failures log to stderr and return false — caller decides
-    /// whether to retry.
+    /// All failures log via os.log; caller decides whether to retry.
     func start() -> Bool {
         guard let device = findDevice(matchingUID: deviceUID) else {
-            NSLog("[AVPR-host] CMIO device with UID \(deviceUID) not found")
+            logger.error("CMIO device with UID \(self.deviceUID) not found")
             return false
         }
         deviceID = device
+        logger.info("Found device id=\(device, privacy: .public)")
 
         guard let sink = findSinkStream(deviceID: device) else {
-            NSLog("[AVPR-host] sink stream not found on device")
+            logger.error("sink stream not found on device")
             return false
         }
         streamID = sink
+        logger.info("Picked sink stream id=\(sink, privacy: .public)")
 
         var unmanaged: Unmanaged<CMSimpleQueue>?
         let copyStatus = CMIOStreamCopyBufferQueue(sink, { _, _, _ in }, nil, &unmanaged)
         guard copyStatus == noErr, let unmanaged else {
-            NSLog("[AVPR-host] CMIOStreamCopyBufferQueue failed: \(copyStatus)")
+            logger.error("CMIOStreamCopyBufferQueue failed: \(copyStatus)")
             return false
         }
         self.queue = unmanaged.takeRetainedValue()
 
         let startStatus = CMIODeviceStartStream(device, sink)
         guard startStatus == noErr else {
-            NSLog("[AVPR-host] CMIODeviceStartStream failed: \(startStatus)")
+            logger.error("CMIODeviceStartStream failed: \(startStatus)")
             return false
         }
 
-        NSLog("[AVPR-host] CMIOSinkWriter started")
+        logger.info("CMIOSinkWriter started successfully")
         return true
     }
 
@@ -84,12 +91,20 @@ final class CMIOSinkWriter {
         queue = nil
     }
 
+    private var enqueueCount: UInt64 = 0
+    private var enqueueRejectCount: UInt64 = 0
+
     /// Wraps an incoming pixel buffer in a CMSampleBuffer and
     /// enqueues it. Caller owns the pixel buffer; this method does
     /// NOT retain it long-term — `CMSampleBufferCreateForImageBuffer`
     /// retains internally.
     func enqueue(pixelBuffer: CVPixelBuffer, hostTimeNs: UInt64) {
-        guard let queue else { return }
+        guard let queue else {
+            if enqueueCount == 0 {
+                logger.error("enqueue called before queue ready — dropping")
+            }
+            return
+        }
 
         var timing = CMSampleTimingInfo(
             duration: .invalid,
@@ -110,7 +125,10 @@ final class CMIOSinkWriter {
             sampleTiming: &timing,
             sampleBufferOut: &sampleBuffer
         )
-        guard status == noErr, let sampleBuffer else { return }
+        guard status == noErr, let sampleBuffer else {
+            logger.error("CMSampleBufferCreateForImageBuffer failed: \(status)")
+            return
+        }
 
         // CMSimpleQueue takes ownership of the enqueued ref. Pass
         // a retained pointer so the queue can release after the
@@ -121,6 +139,20 @@ final class CMIOSinkWriter {
             // Queue full or otherwise rejected. Reclaim the retain
             // we just gave it so the buffer doesn't leak.
             Unmanaged<CMSampleBuffer>.fromOpaque(retained).release()
+            enqueueRejectCount += 1
+            if enqueueRejectCount % 30 == 1 {
+                logger.error(
+                    "CMSimpleQueueEnqueue rejected (rejects=\(self.enqueueRejectCount)/\(self.enqueueCount), status=\(enqueueStatus))"
+                )
+            }
+            return
+        }
+
+        enqueueCount += 1
+        if enqueueCount == 1 || enqueueCount % 60 == 0 {
+            logger.info(
+                "Enqueued frame #\(self.enqueueCount, privacy: .public) (rejects=\(self.enqueueRejectCount, privacy: .public))"
+            )
         }
     }
 
@@ -188,7 +220,7 @@ final class CMIOSinkWriter {
         guard
             CMIOObjectGetPropertyDataSize(deviceID, &address, 0, nil, &dataSize)
                 == noErr,
-            dataSize >= 2 * UInt32(MemoryLayout<CMIOStreamID>.size)
+            dataSize > 0
         else { return nil }
 
         let count = Int(dataSize) / MemoryLayout<CMIOStreamID>.size
@@ -201,9 +233,37 @@ final class CMIOSinkWriter {
             ) == noErr
         else { return nil }
 
-        // Index 0 = source (what Zoom reads), index 1 = sink. The
-        // extension adds them in this order in
-        // `CameraExtensionDeviceSource.init`.
-        return streams[1]
+        logger.info("Device exposes \(count, privacy: .public) stream(s): \(streams.map(String.init).joined(separator: ", "), privacy: .public)")
+
+        // Don't trust ordering — query each stream's direction
+        // property and return the first sink. CMIO assigns IDs in
+        // its own order which may not match the order
+        // CameraExtensionDeviceSource.init added them.
+        for stream in streams {
+            if let direction = streamDirection(streamID: stream) {
+                logger.info("Stream \(stream, privacy: .public) direction=\(direction, privacy: .public)")
+                // direction 0 = output (host → device, i.e. sink)
+                // direction 1 = input  (device → host, i.e. source)
+                if direction == 0 {
+                    return stream
+                }
+            }
+        }
+        return nil
+    }
+
+    private func streamDirection(streamID: CMIOStreamID) -> UInt32? {
+        var address = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOStreamPropertyDirection),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+        var direction: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var used: UInt32 = 0
+        let status = CMIOObjectGetPropertyData(
+            streamID, &address, 0, nil, size, &used, &direction
+        )
+        return status == noErr ? direction : nil
     }
 }

--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -25,25 +25,26 @@ private let logger = Logger(
 /// (referenced for architecture, not code).
 final class CMIOSinkWriter {
     private let deviceUID: String
-    private let formatDescription: CMFormatDescription
     private var deviceID: CMIODeviceID = 0
     private var streamID: CMIOStreamID = 0
     private var queue: CMSimpleQueue?
 
+    /// Cached format description matching the most recent pixel
+    /// buffer. We derive this per-frame rather than pre-building
+    /// because the camera's actual delivered dimensions may not
+    /// match what `sessionPreset` requested (e.g., FaceTime HD
+    /// camera ignores `.hd1280x720` and ships 1920x1080 unless
+    /// width/height keys are set on the output's videoSettings).
+    private var formatDescription: CMFormatDescription?
+    private var formatDescriptionDimensions: (Int, Int) = (0, 0)
+
     init(deviceUID: String, width: Int32, height: Int32) {
         self.deviceUID = deviceUID
-        var fmt: CMFormatDescription?
-        CMVideoFormatDescriptionCreate(
-            allocator: kCFAllocatorDefault,
-            codecType: kCVPixelFormatType_32BGRA,
-            width: width,
-            height: height,
-            extensions: nil,
-            formatDescriptionOut: &fmt
-        )
-        // Force-unwrap is fine — CMVideoFormatDescriptionCreate
-        // doesn't fail for legal pixel format / dimensions.
-        self.formatDescription = fmt!
+        // width/height retained as ignored params for backward-
+        // compat with the call site; the actual format used at
+        // runtime is derived per-pixel-buffer below.
+        _ = width
+        _ = height
     }
 
     /// Discovers the device, opens its sink stream, primes the
@@ -103,6 +104,10 @@ final class CMIOSinkWriter {
             if enqueueCount == 0 {
                 logger.error("enqueue called before queue ready — dropping")
             }
+            return
+        }
+
+        guard let formatDescription = formatDescription(for: pixelBuffer) else {
             return
         }
 
@@ -250,6 +255,37 @@ final class CMIOSinkWriter {
             }
         }
         return nil
+    }
+
+    /// Returns a format description matching the supplied pixel
+    /// buffer. Cached so steady-state captures don't allocate a
+    /// fresh description per frame.
+    private func formatDescription(for pixelBuffer: CVPixelBuffer)
+        -> CMFormatDescription?
+    {
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        if let cached = formatDescription,
+           formatDescriptionDimensions == (width, height)
+        {
+            return cached
+        }
+        var fmt: CMFormatDescription?
+        let status = CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &fmt
+        )
+        guard status == noErr, let fmt else {
+            logger.error("CMVideoFormatDescriptionCreateForImageBuffer failed: \(status)")
+            return nil
+        }
+        formatDescription = fmt
+        formatDescriptionDimensions = (width, height)
+        logger.info(
+            "Built format description for \(width, privacy: .public)x\(height, privacy: .public)"
+        )
+        return fmt
     }
 
     private func streamDirection(streamID: CMIOStreamID) -> UInt32? {

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -139,6 +139,14 @@ final class CameraCaptureSession: NSObject {
         let output = AVCaptureVideoDataOutput()
         output.videoSettings = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            // Force frames to the dimensions the extension's source
+            // stream declared, regardless of the camera's native
+            // resolution. AVFoundation does the downscale in
+            // hardware where possible. Without these keys the
+            // FaceTime HD Camera ignores .hd1280x720 and ships
+            // 1920x1080.
+            kCVPixelBufferWidthKey as String: 1280,
+            kCVPixelBufferHeightKey as String: 720,
             kCVPixelBufferIOSurfacePropertiesKey as String: [:],
         ]
         output.alwaysDiscardsLateVideoFrames = true

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -1,6 +1,12 @@
 import Foundation
 import AVFoundation
 import CoreVideo
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever",
+    category: "CameraCaptureSession"
+)
 
 /// Captures from the built-in webcam (hardcoded for M2 dev) and
 /// hands each frame to `CMIOSinkWriter`, which enqueues it on the
@@ -24,10 +30,32 @@ final class CameraCaptureSession: NSObject {
     )
     private let sink: CMIOSinkWriter
     private var sinkStarted = false
+    private var capturedFrameCount: UInt64 = 0
 
     init(sink: CMIOSinkWriter) {
         self.sink = sink
         super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRuntimeError(_:)),
+            name: .AVCaptureSessionRuntimeError,
+            object: session
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSessionStarted(_:)),
+            name: .AVCaptureSessionDidStartRunning,
+            object: session
+        )
+    }
+
+    @objc private func handleRuntimeError(_ notification: Notification) {
+        let error = notification.userInfo?[AVCaptureSessionErrorKey] as? Error
+        logger.error("AVCaptureSession runtime error: \(error?.localizedDescription ?? "unknown", privacy: .public)")
+    }
+
+    @objc private func handleSessionStarted(_ notification: Notification) {
+        logger.info("AVCaptureSession reported running")
     }
 
     /// Boots up capture asynchronously. Returns immediately.
@@ -51,28 +79,33 @@ final class CameraCaptureSession: NSObject {
 
     private func bootIfAuthorized() {
         let status = AVCaptureDevice.authorizationStatus(for: .video)
+        logger.info("Camera authorization status: \(status.rawValue, privacy: .public) (0=notDetermined 1=restricted 2=denied 3=authorized)")
         switch status {
         case .authorized:
             installAndStart()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                logger.info("Camera access request: granted=\(granted, privacy: .public)")
                 self?.captureQueue.async {
                     if granted {
                         self?.installAndStart()
                     } else {
-                        NSLog("[AVPR-host] camera access denied; virtual camera will see no frames")
+                        logger.error("Camera access denied; virtual camera will see no frames")
                     }
                 }
             }
         case .denied, .restricted:
-            NSLog("[AVPR-host] camera access denied/restricted; virtual camera will see no frames")
+            logger.error("Camera access denied/restricted; virtual camera will see no frames")
         @unknown default:
-            NSLog("[AVPR-host] unknown camera authorization status")
+            logger.error("Unknown camera authorization status")
         }
     }
 
     private func installAndStart() {
-        guard !session.isRunning else { return }
+        guard !session.isRunning else {
+            logger.info("installAndStart: session already running")
+            return
+        }
 
         guard
             let device = AVCaptureDevice.default(
@@ -81,9 +114,10 @@ final class CameraCaptureSession: NSObject {
                 position: .unspecified
             )
         else {
-            NSLog("[AVPR-host] no built-in wide-angle camera found")
+            logger.error("No built-in wide-angle camera found")
             return
         }
+        logger.info("Found capture device: \(device.localizedName, privacy: .public) (\(device.uniqueID, privacy: .public))")
 
         session.beginConfiguration()
         session.sessionPreset = .hd1280x720
@@ -91,13 +125,13 @@ final class CameraCaptureSession: NSObject {
         do {
             let input = try AVCaptureDeviceInput(device: device)
             guard session.canAddInput(input) else {
-                NSLog("[AVPR-host] cannot add camera input")
+                logger.error("Cannot add camera input")
                 session.commitConfiguration()
                 return
             }
             session.addInput(input)
         } catch {
-            NSLog("[AVPR-host] AVCaptureDeviceInput failed: \(error)")
+            logger.error("AVCaptureDeviceInput failed: \(error.localizedDescription, privacy: .public)")
             session.commitConfiguration()
             return
         }
@@ -105,29 +139,25 @@ final class CameraCaptureSession: NSObject {
         let output = AVCaptureVideoDataOutput()
         output.videoSettings = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-            // IOSurface backing — the kernel CMIO subsystem will
-            // share these by reference across processes.
             kCVPixelBufferIOSurfacePropertiesKey as String: [:],
         ]
         output.alwaysDiscardsLateVideoFrames = true
         output.setSampleBufferDelegate(self, queue: captureQueue)
 
         guard session.canAddOutput(output) else {
-            NSLog("[AVPR-host] cannot add video output")
+            logger.error("Cannot add video output")
             session.commitConfiguration()
             return
         }
         session.addOutput(output)
         session.commitConfiguration()
 
+        logger.info("Calling session.startRunning()")
         session.startRunning()
-        NSLog("[AVPR-host] capture session started")
+        logger.info("session.isRunning=\(self.session.isRunning, privacy: .public)")
 
-        // Open the sink AFTER the capture session is running, so
-        // the first attempt to enqueue has a real frame ready.
-        // Retried by the delegate path below if it fails initially
-        // (extension may not be activated/enabled yet).
         sinkStarted = sink.start()
+        logger.info("sink.start() returned \(self.sinkStarted, privacy: .public)")
     }
 }
 
@@ -137,11 +167,30 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
+        capturedFrameCount += 1
+        if capturedFrameCount == 1, let pb = CMSampleBufferGetImageBuffer(sampleBuffer) {
+            let w = CVPixelBufferGetWidth(pb)
+            let h = CVPixelBufferGetHeight(pb)
+            let pf = CVPixelBufferGetPixelFormatType(pb)
+            // Pretty-print FourCC
+            let fourcc = String(bytes: [
+                UInt8((pf >> 24) & 0xFF),
+                UInt8((pf >> 16) & 0xFF),
+                UInt8((pf >> 8) & 0xFF),
+                UInt8(pf & 0xFF)
+            ], encoding: .ascii) ?? "????"
+            logger.info("First frame from webcam: \(w, privacy: .public)x\(h, privacy: .public) format=\(fourcc, privacy: .public)")
+        }
+
         // If sink wasn't ready when capture started (extension not
-        // yet active), retry every few frames. Cheap — finds the
-        // device by UID, opens the stream, primes the queue.
+        // yet active), retry every few frames.
         if !sinkStarted {
             sinkStarted = sink.start()
+            if sinkStarted {
+                logger.info("Sink writer connected on retry (after \(self.capturedFrameCount, privacy: .public) frames)")
+            } else if capturedFrameCount % 90 == 1 {
+                logger.error("Sink writer still not ready after \(self.capturedFrameCount, privacy: .public) frames")
+            }
             if !sinkStarted { return }
         }
 

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -1,0 +1,155 @@
+import Foundation
+import AVFoundation
+import CoreVideo
+
+/// Captures from the built-in webcam (hardcoded for M2 dev) and
+/// hands each frame to `CMIOSinkWriter`, which enqueues it on the
+/// virtual camera's sink stream.
+///
+/// The host app is a normal user-process AVFoundation client — no
+/// sandbox, no recursion through CMIO. TCC permission for the
+/// camera is granted to the host on first use; the extension never
+/// touches AVFoundation.
+///
+/// M3 will replace the hardcoded `.builtInWideAngleCamera` lookup
+/// with profile-driven source-camera switching. M4 will add
+/// "should we be capturing right now" lifecycle awareness so the
+/// camera light only comes on when an AVCapture client actually
+/// has the virtual camera open.
+final class CameraCaptureSession: NSObject {
+    private let session = AVCaptureSession()
+    private let captureQueue = DispatchQueue(
+        label: "com.ericwillis.avpainreliever.host.capture",
+        qos: .userInteractive
+    )
+    private let sink: CMIOSinkWriter
+    private var sinkStarted = false
+
+    init(sink: CMIOSinkWriter) {
+        self.sink = sink
+        super.init()
+    }
+
+    /// Boots up capture asynchronously. Returns immediately.
+    /// Failures are logged; M2 doesn't surface them through any UI.
+    func start() {
+        captureQueue.async { [weak self] in
+            self?.bootIfAuthorized()
+        }
+    }
+
+    func stop() {
+        captureQueue.async { [weak self] in
+            guard let self else { return }
+            self.session.stopRunning()
+            if self.sinkStarted {
+                self.sink.stop()
+                self.sinkStarted = false
+            }
+        }
+    }
+
+    private func bootIfAuthorized() {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        switch status {
+        case .authorized:
+            installAndStart()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                self?.captureQueue.async {
+                    if granted {
+                        self?.installAndStart()
+                    } else {
+                        NSLog("[AVPR-host] camera access denied; virtual camera will see no frames")
+                    }
+                }
+            }
+        case .denied, .restricted:
+            NSLog("[AVPR-host] camera access denied/restricted; virtual camera will see no frames")
+        @unknown default:
+            NSLog("[AVPR-host] unknown camera authorization status")
+        }
+    }
+
+    private func installAndStart() {
+        guard !session.isRunning else { return }
+
+        guard
+            let device = AVCaptureDevice.default(
+                .builtInWideAngleCamera,
+                for: .video,
+                position: .unspecified
+            )
+        else {
+            NSLog("[AVPR-host] no built-in wide-angle camera found")
+            return
+        }
+
+        session.beginConfiguration()
+        session.sessionPreset = .hd1280x720
+
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(input) else {
+                NSLog("[AVPR-host] cannot add camera input")
+                session.commitConfiguration()
+                return
+            }
+            session.addInput(input)
+        } catch {
+            NSLog("[AVPR-host] AVCaptureDeviceInput failed: \(error)")
+            session.commitConfiguration()
+            return
+        }
+
+        let output = AVCaptureVideoDataOutput()
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            // IOSurface backing — the kernel CMIO subsystem will
+            // share these by reference across processes.
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        output.alwaysDiscardsLateVideoFrames = true
+        output.setSampleBufferDelegate(self, queue: captureQueue)
+
+        guard session.canAddOutput(output) else {
+            NSLog("[AVPR-host] cannot add video output")
+            session.commitConfiguration()
+            return
+        }
+        session.addOutput(output)
+        session.commitConfiguration()
+
+        session.startRunning()
+        NSLog("[AVPR-host] capture session started")
+
+        // Open the sink AFTER the capture session is running, so
+        // the first attempt to enqueue has a real frame ready.
+        // Retried by the delegate path below if it fails initially
+        // (extension may not be activated/enabled yet).
+        sinkStarted = sink.start()
+    }
+}
+
+extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        // If sink wasn't ready when capture started (extension not
+        // yet active), retry every few frames. Cheap — finds the
+        // device by UID, opens the stream, primes the queue.
+        if !sinkStarted {
+            sinkStarted = sink.start()
+            if !sinkStarted { return }
+        }
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+        else { return }
+
+        let hostTime = CMClockGetTime(CMClockGetHostTimeClock())
+        let hostTimeNs = UInt64(hostTime.seconds * Double(NSEC_PER_SEC))
+        sink.enqueue(pixelBuffer: pixelBuffer, hostTimeNs: hostTimeNs)
+    }
+}

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import CoreVideo
+import AVPainReliever
 import os.log
 
 private let logger = Logger(
@@ -8,20 +9,27 @@ private let logger = Logger(
     category: "CameraCaptureSession"
 )
 
-/// Captures from the built-in webcam (hardcoded for M2 dev) and
-/// hands each frame to `CMIOSinkWriter`, which enqueues it on the
-/// virtual camera's sink stream.
+/// Captures from a webcam and hands each frame to `CMIOSinkWriter`,
+/// which enqueues it on the virtual camera's sink stream. The host
+/// app is a normal user-process AVFoundation client — no sandbox,
+/// no recursion through CMIO. TCC permission for the camera is
+/// granted to the host on first use; the extension never touches
+/// AVFoundation.
 ///
-/// The host app is a normal user-process AVFoundation client — no
-/// sandbox, no recursion through CMIO. TCC permission for the
-/// camera is granted to the host on first use; the extension never
-/// touches AVFoundation.
+/// Source selection:
 ///
-/// M3 will replace the hardcoded `.builtInWideAngleCamera` lookup
-/// with profile-driven source-camera switching. M4 will add
-/// "should we be capturing right now" lifecycle awareness so the
-/// camera light only comes on when an AVCapture client actually
-/// has the virtual camera open.
+/// - First start picks the system's preferred camera (`userPreferredCamera`
+///   → `systemPreferredCamera` → first discovered) so the virtual
+///   camera shows *something* before the engine has resolved a
+///   profile.
+/// - `setSource(named:)` swaps inputs on the running session at
+///   runtime. The active profile drives this through
+///   `VirtualCameraSourceController` from `ProfileApplier`.
+///
+/// Switching uses `beginConfiguration` / `commitConfiguration` so
+/// the session keeps running across the swap — the only gap is the
+/// ~500 ms it takes the new device to start delivering frames. The
+/// extension covers that gap by holding the last frame.
 final class CameraCaptureSession: NSObject {
     private let session = AVCaptureSession()
     private let captureQueue = DispatchQueue(
@@ -31,6 +39,9 @@ final class CameraCaptureSession: NSObject {
     private let sink: CMIOSinkWriter
     private var sinkStarted = false
     private var capturedFrameCount: UInt64 = 0
+    private var output: AVCaptureVideoDataOutput?
+    private var currentInput: AVCaptureDeviceInput?
+    private var currentDeviceUniqueID: String?
 
     init(sink: CMIOSinkWriter) {
         self.sink = sink
@@ -59,7 +70,7 @@ final class CameraCaptureSession: NSObject {
     }
 
     /// Boots up capture asynchronously. Returns immediately.
-    /// Failures are logged; M2 doesn't surface them through any UI.
+    /// Failures are logged; the menu bar doesn't surface them today.
     func start() {
         captureQueue.async { [weak self] in
             self?.bootIfAuthorized()
@@ -107,46 +118,34 @@ final class CameraCaptureSession: NSObject {
             return
         }
 
-        guard
-            let device = AVCaptureDevice.default(
-                .builtInWideAngleCamera,
-                for: .video,
-                position: .unspecified
-            )
-        else {
-            logger.error("No built-in wide-angle camera found")
+        guard let device = pickInitialDevice() else {
+            logger.error("No video capture devices available")
             return
         }
-        logger.info("Found capture device: \(device.localizedName, privacy: .public) (\(device.uniqueID, privacy: .public))")
+        logger.info("Initial capture device: \(device.localizedName, privacy: .public) (\(device.uniqueID, privacy: .public))")
 
         session.beginConfiguration()
         session.sessionPreset = .hd1280x720
 
-        do {
-            let input = try AVCaptureDeviceInput(device: device)
-            guard session.canAddInput(input) else {
-                logger.error("Cannot add camera input")
-                session.commitConfiguration()
-                return
-            }
-            session.addInput(input)
-        } catch {
-            logger.error("AVCaptureDeviceInput failed: \(error.localizedDescription, privacy: .public)")
+        guard installInput(device: device) else {
             session.commitConfiguration()
             return
         }
 
         let output = AVCaptureVideoDataOutput()
+        // Deliver the device's NATIVE pixel format and dimensions.
+        // M2 forced 1280×720 BGRA via `videoSettings`, which works
+        // for the FaceTime HD camera but silently produces zero
+        // frames on USB capture cards (HDMI to U3 capture
+        // 0x1e4e/0x701f is the user's known case — it advertises
+        // BGRA in `availableVideoPixelFormatTypes` but the actual
+        // delivery path drops every frame). Letting the device
+        // pick its own format makes the AVCaptureSession work for
+        // every camera; `CMIOSinkWriter` then converts to
+        // 1280×720 BGRA via `VTPixelTransferSession` before
+        // enqueueing — that's the format the extension's source
+        // stream advertises to AVCapture clients.
         output.videoSettings = [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-            // Force frames to the dimensions the extension's source
-            // stream declared, regardless of the camera's native
-            // resolution. AVFoundation does the downscale in
-            // hardware where possible. Without these keys the
-            // FaceTime HD Camera ignores .hd1280x720 and ships
-            // 1920x1080.
-            kCVPixelBufferWidthKey as String: 1280,
-            kCVPixelBufferHeightKey as String: 720,
             kCVPixelBufferIOSurfacePropertiesKey as String: [:],
         ]
         output.alwaysDiscardsLateVideoFrames = true
@@ -158,6 +157,7 @@ final class CameraCaptureSession: NSObject {
             return
         }
         session.addOutput(output)
+        self.output = output
         session.commitConfiguration()
 
         logger.info("Calling session.startRunning()")
@@ -166,6 +166,100 @@ final class CameraCaptureSession: NSObject {
 
         sinkStarted = sink.start()
         logger.info("sink.start() returned \(self.sinkStarted, privacy: .public)")
+    }
+
+    /// Initial source pick before any profile has resolved. Mirrors
+    /// `AVFoundationCameraController.currentPreferredName`'s fallback
+    /// chain so the virtual camera's first frames match whatever the
+    /// system would naturally deliver to a fresh AVCapture client.
+    private func pickInitialDevice() -> AVCaptureDevice? {
+        if let user = AVCaptureDevice.userPreferredCamera { return user }
+        if let system = AVCaptureDevice.systemPreferredCamera { return system }
+        return Self.discoverySession().devices.first
+    }
+
+    /// Add an `AVCaptureDeviceInput` for `device` to the session.
+    /// Caller is responsible for `beginConfiguration` /
+    /// `commitConfiguration`. Updates `currentInput` and
+    /// `currentDeviceUniqueID` on success.
+    private func installInput(device: AVCaptureDevice) -> Bool {
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(input) else {
+                logger.error("Cannot add input for \(device.localizedName, privacy: .public)")
+                return false
+            }
+            session.addInput(input)
+            currentInput = input
+            currentDeviceUniqueID = device.uniqueID
+            return true
+        } catch {
+            logger.error("AVCaptureDeviceInput failed for \(device.localizedName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Swap the running session's input to the camera with the given
+    /// `localizedName`. No-ops when the source is already that
+    /// device. Runs on `captureQueue` so it serializes with frame
+    /// delivery.
+    func switchSource(toLocalizedName name: String) {
+        captureQueue.async { [weak self] in
+            self?.swapInputLocked(toLocalizedName: name)
+        }
+    }
+
+    private func swapInputLocked(toLocalizedName name: String) {
+        guard let device = Self.findDevice(named: name) else {
+            logger.error("switchSource: no camera with localizedName '\(name, privacy: .public)' — skipping")
+            return
+        }
+        if device.uniqueID == currentDeviceUniqueID {
+            logger.info("switchSource: already on '\(name, privacy: .public)' — no-op")
+            return
+        }
+
+        logger.info("switchSource: '\(self.currentDeviceUniqueID ?? "<none>", privacy: .public)' → '\(device.uniqueID, privacy: .public)' (\(name, privacy: .public))")
+
+        session.beginConfiguration()
+        if let currentInput {
+            session.removeInput(currentInput)
+            self.currentInput = nil
+            self.currentDeviceUniqueID = nil
+        }
+        _ = installInput(device: device)
+        session.commitConfiguration()
+
+        if !session.isRunning {
+            // installAndStart never finished (e.g. initial discovery
+            // returned nil). Start now that we have a real source.
+            logger.info("switchSource: session was not running — starting")
+            session.startRunning()
+        }
+
+        if !sinkStarted {
+            sinkStarted = sink.start()
+            if sinkStarted {
+                logger.info("switchSource: sink started after source swap")
+            }
+        }
+    }
+
+    private static func findDevice(named name: String) -> AVCaptureDevice? {
+        discoverySession().devices.first { $0.localizedName == name }
+    }
+
+    private static func discoverySession() -> AVCaptureDevice.DiscoverySession {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .external,
+                .continuityCamera,
+                .deskViewCamera,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
     }
 }
 
@@ -208,5 +302,15 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
         let hostTime = CMClockGetTime(CMClockGetHostTimeClock())
         let hostTimeNs = UInt64(hostTime.seconds * Double(NSEC_PER_SEC))
         sink.enqueue(pixelBuffer: pixelBuffer, hostTimeNs: hostTimeNs)
+    }
+}
+
+extension CameraCaptureSession: VirtualCameraSourceController {
+    func setSource(named: String) -> CameraApplyResult {
+        guard Self.findDevice(named: named) != nil else {
+            return .notFound
+        }
+        switchSource(toLocalizedName: named)
+        return .ok
     }
 }

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -19,6 +19,7 @@ final class SettingsStore: ObservableObject {
         static let profileSwitchCount = "profileSwitchCount"
         static let suppressedWelcome = "suppressedWelcome"
         static let launchAtLogin = "launchAtLogin"
+        static let virtualCameraEnabled = "virtualCameraEnabled"
     }
 
     /// Toast on profile change?  Default on — the at-a-glance signal
@@ -84,6 +85,19 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Opt-in toggle for the V2 virtual camera. Default off. When on,
+    /// the app installs/activates its CMIO Camera Extension and the
+    /// active profile drives the virtual camera's source. When off,
+    /// the extension is deactivated and the host capture pipeline is
+    /// torn down — keeping the camera light off and AVCapture clients
+    /// like Zoom from seeing a stale "AV Pain Reliever" device.
+    /// `VirtualCameraActivator` reads this on launch and observes
+    /// changes; `AppDelegate.applyVirtualCameraEnabled(_:)` mediates
+    /// the actual state transitions.
+    @Published var virtualCameraEnabled: Bool {
+        didSet { defaults.set(virtualCameraEnabled, forKey: Key.virtualCameraEnabled) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -100,6 +114,7 @@ final class SettingsStore: ObservableObject {
         self.profileSwitchCount = (defaults.object(forKey: Key.profileSwitchCount) as? Int) ?? 0
         self.suppressedWelcome = (defaults.object(forKey: Key.suppressedWelcome) as? Bool) ?? false
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool) ?? false
+        self.virtualCameraEnabled = (defaults.object(forKey: Key.virtualCameraEnabled) as? Bool) ?? false
     }
 
     func incrementSwitchCount() {

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -9,12 +9,14 @@ import AVPainReliever
 enum SettingsTab: Hashable {
     case general
     case profiles
+    case camera
 }
 
-/// The Settings scene has two tabs: General (toggles + slider) and
-/// Profiles (list with edit/delete). Deliberately *no* mention of
-/// Hammerspoon, OBS, or any other third-party tool — the app must read
-/// as its own product.
+/// The Settings scene has three tabs: General (toggles + slider),
+/// Profiles (list with edit/delete), and Camera (virtual camera
+/// install/enable + status). Deliberately *no* mention of
+/// Hammerspoon, OBS, or any other third-party tool — the app must
+/// read as its own product.
 ///
 /// Hosted inside SwiftUI's dedicated `Settings { ... }` scene rather
 /// than a generic `Window` scene so the TabView gets the System-
@@ -38,9 +40,146 @@ struct SettingsView: View {
                     Label("Profiles", systemImage: "list.bullet.rectangle")
                 }
                 .tag(SettingsTab.profiles)
+
+            CameraSettingsTab(
+                settings: settings,
+                activator: delegate.virtualCameraActivator
+            )
+                .tabItem {
+                    Label("Camera", systemImage: "camera")
+                }
+                .tag(SettingsTab.camera)
         }
         .frame(width: 480, height: 380)
         .centeredOnScreen()
+    }
+}
+
+/// Camera tab — opt-in toggle for the virtual camera that lets
+/// Zoom / Slack / Teams pick up the active profile's source camera
+/// (those apps ignore the system's `userPreferredCamera`).
+/// Installing requires user approval through System Settings, so
+/// the section explains what's about to happen and surfaces a
+/// status row that mirrors the activator's state machine.
+private struct CameraSettingsTab: View {
+    @ObservedObject var settings: SettingsStore
+    @ObservedObject var activator: VirtualCameraActivator
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(
+                    "Enable AV Pain Reliever as a virtual camera",
+                    isOn: $settings.virtualCameraEnabled
+                )
+                .disabled(activator.isEnvOverride)
+
+                statusRow
+
+                if case .requiresRelaunch = activator.state {
+                    Button("Restart AV Pain Reliever") {
+                        activator.relaunch()
+                    }
+                    .controlSize(.small)
+                } else if showsApprovalAffordance {
+                    Button("Open Login Items & Extensions") {
+                        openExtensionsSettings()
+                    }
+                    .controlSize(.small)
+                }
+
+                // Form footer hint rendered as the last row in the
+                // section body — `footer:` is constrained on
+                // macOS 14, locked convention per project memory.
+                Text(explanationText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Label("Virtual camera", systemImage: "camera.metering.center.weighted")
+            }
+        }
+        .formStyle(.grouped)
+        .padding(8)
+    }
+
+    /// Live status row — colored dot + human-readable label that
+    /// repaints on every activator state transition.
+    private var statusRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            Text(statusLabel)
+                .font(.callout)
+            Spacer()
+            if activator.isEnvOverride {
+                Text("Debug override")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange, in: Capsule())
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var statusColor: Color {
+        switch activator.state {
+        case .on: return .green
+        case .activating, .needsApproval: return .orange
+        case .failed, .requiresRelaunch: return .red
+        case .off: return .secondary
+        }
+    }
+
+    private var statusLabel: String {
+        switch activator.state {
+        case .off: return "Off"
+        case .activating: return "Activating…"
+        case .needsApproval: return "Approval needed"
+        case .on: return "Active"
+        case .failed(let msg): return "Failed: \(msg)"
+        case .requiresRelaunch: return "Restart required"
+        }
+    }
+
+    private var showsApprovalAffordance: Bool {
+        switch activator.state {
+        case .needsApproval, .failed: return true
+        default: return false
+        }
+    }
+
+    private var explanationText: String {
+        if activator.isEnvOverride {
+            return "The AVPR_ACTIVATE_VIRTUAL_CAMERA debug override is active for this launch. The toggle is locked until you relaunch without it."
+        }
+        switch activator.state {
+        case .off:
+            return "When on, Zoom, Slack, Teams, and other apps that have their own camera picker can choose 'AV Pain Reliever' to follow the active profile's source camera."
+        case .activating:
+            return "Submitting the activation request to macOS. If a system prompt appears, approve it in System Settings."
+        case .needsApproval:
+            return "macOS is waiting for you to approve the Camera Extension. Open System Settings → General → Login Items & Extensions → Camera Extensions."
+        case .on:
+            return "Pick 'AV Pain Reliever' in Zoom, Slack, or any app's camera picker. The active profile's source camera flows through it."
+        case .failed:
+            return "Activation didn't complete. Open System Settings → General → Login Items & Extensions to check the extension's state, then toggle this off and on to retry."
+        case .requiresRelaunch:
+            return "macOS holds the virtual camera in a stale state after toggling off and back on inside one session. Restart AV Pain Reliever to re-enable it cleanly."
+        }
+    }
+
+    private func openExtensionsSettings() {
+        // Apple's documented x-apple URL for the extensions page.
+        // Falls back to the general System Settings app on older
+        // macOS versions where the deep link isn't recognized —
+        // still gets the user one click closer than nothing.
+        let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension")
+            ?? URL(string: "x-apple.systempreferences:")!
+        NSWorkspace.shared.open(url)
     }
 }
 

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -21,6 +21,7 @@ import OSLog
 /// they've consented) is what we want.
 final class Updater {
     private let controller: SPUStandardUpdaterController
+    private let settings: SettingsStore
     private static let logger = Logger(
         subsystem: "com.ericwillis.avpainreliever",
         category: "updater"
@@ -69,6 +70,7 @@ final class Updater {
         // re-queried on every check, so flipping the experimental-
         // updates toggle takes effect on the next scheduled tick or
         // user-initiated check — no Updater rebuild needed.
+        self.settings = settings
         let channelDelegate = ChannelGatingDelegate(settings: settings)
         self.channelDelegate = channelDelegate
         let controller = SPUStandardUpdaterController(
@@ -114,9 +116,85 @@ final class Updater {
     /// appears after the feed fetch — without this, an LSUIElement
     /// build's update window can land behind whatever app you've
     /// switched to while the network call was in flight.
+    ///
+    /// One pre-check intercept: when the user is running an
+    /// experimental version (v0.2.x+) AND the experimental-updates
+    /// toggle is off, Sparkle would silently filter the appcast to
+    /// stable-only and tell the user "you're up to date" while they
+    /// run a version newer than the latest stable. That's
+    /// technically true (relative to the channels they consume) but
+    /// reads as a bug to the user. Show a tailored alert that
+    /// explains the situation and offers a one-click path to enable
+    /// the experimental channel.
     func checkForUpdates() {
         NSApp.activate(ignoringOtherApps: true)
+        if let version = Self.runningVersion(),
+           Self.isExperimentalVersion(version),
+           !settings.experimentalUpdates
+        {
+            showExperimentalNudge(currentVersion: version)
+            return
+        }
         controller.checkForUpdates(nil)
+    }
+
+    /// Bundle's marketing version, e.g. "0.2.0". Falls back to
+    /// `CFBundleVersion` if the marketing key is missing — should
+    /// never happen in a real release build but keeps the predicate
+    /// total in any case.
+    private static func runningVersion() -> String? {
+        let info = Bundle.main.infoDictionary
+        if let s = info?["CFBundleShortVersionString"] as? String, !s.isEmpty {
+            return s
+        }
+        return info?["CFBundleVersion"] as? String
+    }
+
+    /// True for versions that ship through the experimental Sparkle
+    /// channel. Mirrors the workflow's tag-prefix dispatch: anything
+    /// at v0.2.x or higher (including v1.x) is experimental;
+    /// v0.0.x and v0.1.x are stable. Prefix-matches the leading
+    /// `MAJOR.MINOR` so suffixes like "-iter-m3" or build metadata
+    /// don't break the parse.
+    static func isExperimentalVersion(_ version: String) -> Bool {
+        let parts = version.split(separator: ".")
+        guard parts.count >= 2,
+              let major = Int(parts[0]),
+              // The minor segment may carry suffixes (e.g. "1-rc"),
+              // so split it on a non-digit prefix.
+              let minor = Int(parts[1].prefix(while: { $0.isNumber }))
+        else { return false }
+        if major == 0 { return minor >= 2 }
+        return major >= 1
+    }
+
+    private func showExperimentalNudge(currentVersion: String) {
+        let alert = NSAlert()
+        alert.messageText = "You're running an experimental version"
+        alert.informativeText = """
+            AV Pain Reliever \(currentVersion) is from the experimental release channel. To receive future experimental patches automatically, enable Experimental Updates in Settings → General → Updates.
+
+            Otherwise, only stable releases appear when you check for updates — and the latest stable is currently older than what you're running.
+            """
+        alert.alertStyle = .informational
+        alert.icon = NSApp.applicationIconImage
+        alert.addButton(withTitle: "Enable Experimental Updates")
+        alert.addButton(withTitle: "Check Stable Anyway")
+        alert.addButton(withTitle: "Cancel")
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            // Flipping the toggle in-process re-queries the
+            // ChannelGatingDelegate on the next check, so we can
+            // immediately fire a real Sparkle check that now
+            // considers experimental items.
+            settings.experimentalUpdates = true
+            controller.checkForUpdates(nil)
+        case .alertSecondButtonReturn:
+            controller.checkForUpdates(nil)
+        default:
+            break
+        }
     }
 }
 

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SystemExtensions
+import AVPainReliever
 import os.log
 
 private let logger = Logger(
@@ -29,6 +30,15 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
     private static var retained: VirtualCameraActivator?
     private static var sinkWriter: CMIOSinkWriter?
     private static var captureSession: CameraCaptureSession?
+
+    /// The running capture session as a `VirtualCameraSourceController`,
+    /// or nil if the env-var-gated activator never ran (v0.1.x build,
+    /// or v0.2.x launched without `AVPR_ACTIVATE_VIRTUAL_CAMERA=1`).
+    /// `AppDelegate.buildEngine` reads this to plumb the active
+    /// profile's camera selection into the virtual camera.
+    static var virtualCameraSource: VirtualCameraSourceController? {
+        captureSession
+    }
 
     /// Stable UUID matching the extension's
     /// `CameraExtensionDeviceSource.deviceUUID`. The host uses this

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -67,6 +67,33 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     /// to find the virtual camera in the CMIO device list.
     static let virtualCameraUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
 
+    /// Localized name the extension registers — also what
+    /// AVFoundation reports for the virtual camera's
+    /// `localizedName`. Used as the value of
+    /// `preferredCameraOverride` so `ProfileApplier` can set the
+    /// system-wide preferred camera to "AV Pain Reliever" when the
+    /// virtual camera is live, mirroring what users set in Zoom.
+    static let virtualCameraDisplayName = "AV Pain Reliever"
+
+    /// Mirror of the extension's notification names. Kept in sync by
+    /// hand — both targets are sandboxed-vs-not separate executables
+    /// without a shared Swift module, and three constants is cheaper
+    /// than building one. Any change here MUST mirror in
+    /// `CameraExtensionStream.swift`.
+    private static let consumerActiveNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-active"
+    private static let consumerInactiveNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-inactive"
+    private static let queryConsumerStateNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.query-consumer-state"
+
+    /// Time we keep the host capture pipeline warm after the last
+    /// AVCapture client disconnects. Bridges back-to-back Zoom calls
+    /// without re-paying the ~300-500 ms AVCaptureSession warmup, and
+    /// avoids the green light flickering off-then-on between every
+    /// hangup and the next ring.
+    private static let stopGraceSeconds: TimeInterval = 30
+
     @Published private(set) var state: State = .off
 
     /// True when the env var override forced enable on launch.
@@ -86,6 +113,21 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     /// `.requiresRelaunch` state instead of silently producing a
     /// black feed.
     private var deactivatedThisSession = false
+
+    /// True iff at least one AVCapture client (Zoom, FaceTime, …) is
+    /// currently reading the virtual camera's source stream.
+    /// Maintained from Darwin notifications posted by the extension.
+    private var consumerActive: Bool = false
+
+    /// Set when `endConsumerWatch` would otherwise be called twice
+    /// (Sparkle replace re-fires `.completed` while state is already
+    /// `.on`). Idempotency flag.
+    private var consumerWatchActive: Bool = false
+
+    /// Pending pipeline teardown from the last `consumerInactive`
+    /// notification. Cancelled when a new consumer connects within
+    /// the grace window so we don't tear down then immediately rebuild.
+    private var stopGraceTimer: DispatchSourceTimer?
 
     /// Returns true if launch should auto-enable: env-var debug
     /// override OR the user's persisted toggle is on. The env var
@@ -125,7 +167,12 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         request.delegate = self
         OSSystemExtensionManager.shared.submitRequest(request)
 
-        startCapturePipeline()
+        // Capture pipeline is no longer started eagerly here. It
+        // spins up only when `beginConsumerWatch` (called after the
+        // extension reaches `.on`) sees a `consumerActive`
+        // notification — i.e. when an AVCapture client actually
+        // selects the virtual camera. Keeps the macOS green camera
+        // light off while the app is idle.
     }
 
     /// Tear down the capture pipeline and submit a deactivation
@@ -139,7 +186,12 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
             break
         }
         logger.info("Disabling: stopping capture pipeline + deactivating extension")
+        endConsumerWatch()
+        stopGraceTimer?.cancel()
+        stopGraceTimer = nil
+        consumerActive = false
         stopCapturePipeline()
+        Self.restoreUserPreferredCameraIfVirtual()
 
         let request = OSSystemExtensionRequest.deactivationRequest(
             forExtensionWithIdentifier: Self.extensionBundleID,
@@ -198,6 +250,18 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
 
     // MARK: - VirtualCameraSourceController
 
+    var preferredCameraOverride: String? {
+        // Only direct AVFoundation-modern apps at the virtual camera
+        // when it's actually live and we've confirmed the host can
+        // see it. During `.activating` / `.needsApproval` we don't
+        // know whether the device is reachable yet; during
+        // `.requiresRelaunch` it's known broken; `.failed` /
+        // `.off` — same. In every non-`.on` case, fall back to the
+        // profile's literal camera so AVFoundation-modern apps
+        // don't hop to a virtual camera that can't deliver frames.
+        state == .on ? Self.virtualCameraDisplayName : nil
+    }
+
     func setSource(named: String) -> CameraApplyResult {
         guard let captureSession else {
             // Toggle off OR mid-activation with capture not yet
@@ -233,9 +297,32 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
                 return
             }
             logger.error("Visibility check: host process can't see its own Camera Extension — escalating to .requiresRelaunch")
+            self.endConsumerWatch()
+            self.stopGraceTimer?.cancel()
+            self.stopGraceTimer = nil
+            self.consumerActive = false
             self.stopCapturePipeline()
             self.state = .requiresRelaunch
         }
+    }
+
+    /// On disable, if the system-wide preferred camera still points
+    /// at our virtual camera (because a recent profile-apply set it
+    /// while the toggle was on), redirect AVFoundation-modern apps
+    /// to whatever macOS would naturally pick instead. Otherwise
+    /// FaceTime / Safari getUserMedia stay stuck on a virtual
+    /// camera that's no longer producing frames. AppDelegate
+    /// follows up with `engine.reapply()` so the active profile's
+    /// real camera is the new explicit preference where applicable.
+    private static func restoreUserPreferredCameraIfVirtual() {
+        guard
+            let user = AVCaptureDevice.userPreferredCamera,
+            user.uniqueID == Self.virtualCameraUID
+        else { return }
+        AVCaptureDevice.userPreferredCamera = AVCaptureDevice.systemPreferredCamera
+        logger.info(
+            "Cleared userPreferredCamera that was pointing at the virtual camera; system fallback now \(AVCaptureDevice.systemPreferredCamera?.localizedName ?? "(none)", privacy: .public)"
+        )
     }
 
     private static func hostCanSeeVirtualCamera() -> Bool {
@@ -250,6 +337,104 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
             position: .unspecified
         )
         return session.devices.contains { $0.uniqueID == Self.virtualCameraUID }
+    }
+
+    // MARK: - Consumer-driven capture lifecycle
+
+    /// Subscribe to the extension's "consumer connected/disconnected"
+    /// Darwin notifications and seed the initial state. The capture
+    /// pipeline is started/stopped purely from these signals — the
+    /// activator no longer eagerly opens an `AVCaptureSession` on
+    /// `enable()`. Idempotent.
+    private func beginConsumerWatch() {
+        guard !consumerWatchActive else {
+            logger.info("beginConsumerWatch: already active — no-op")
+            return
+        }
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let callback: CFNotificationCallback = { _, observer, name, _, _ in
+            guard let observer, let name else { return }
+            let me = Unmanaged<VirtualCameraActivator>
+                .fromOpaque(observer)
+                .takeUnretainedValue()
+            // CFNotificationName.rawValue is a CFString; bridge to
+            // String for ergonomic switching.
+            let nameStr = name.rawValue as String
+            DispatchQueue.main.async {
+                switch nameStr {
+                case VirtualCameraActivator.consumerActiveNotification:
+                    me.handleConsumerActive()
+                case VirtualCameraActivator.consumerInactiveNotification:
+                    me.handleConsumerInactive()
+                default:
+                    break
+                }
+            }
+        }
+        CFNotificationCenterAddObserver(
+            center, observer, callback,
+            Self.consumerActiveNotification as CFString,
+            nil, .deliverImmediately
+        )
+        CFNotificationCenterAddObserver(
+            center, observer, callback,
+            Self.consumerInactiveNotification as CFString,
+            nil, .deliverImmediately
+        )
+        consumerWatchActive = true
+
+        // Seed initial state. Edge case worth covering: extension was
+        // activated by a prior host instance and a Zoom call is
+        // already in progress when this host launches. Without the
+        // ping, we'd miss the 0→1 transition and the call would see
+        // no frames until it disconnects.
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(Self.queryConsumerStateNotification as CFString),
+            nil, nil, true
+        )
+    }
+
+    private func endConsumerWatch() {
+        guard consumerWatchActive else { return }
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterRemoveEveryObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            observer
+        )
+        consumerWatchActive = false
+    }
+
+    private func handleConsumerActive() {
+        consumerActive = true
+        // A new consumer arrived inside the grace window — keep the
+        // pipeline that's already running and cancel the pending stop.
+        stopGraceTimer?.cancel()
+        stopGraceTimer = nil
+        if captureSession == nil {
+            logger.info("Consumer connected — starting host capture pipeline")
+            startCapturePipeline()
+        }
+    }
+
+    private func handleConsumerInactive() {
+        consumerActive = false
+        // Don't tear down immediately. Most users hang up one Zoom
+        // call and start another within seconds; a 30-s grace bridges
+        // those without re-paying the AVCaptureSession warmup, and
+        // collapses the green-light flicker between calls.
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + Self.stopGraceSeconds)
+        timer.setEventHandler { [weak self] in
+            guard let self, !self.consumerActive else { return }
+            logger.info("Stop grace expired — tearing down host capture pipeline")
+            self.stopCapturePipeline()
+            self.stopGraceTimer = nil
+        }
+        stopGraceTimer?.cancel()
+        stopGraceTimer = timer
+        timer.resume()
     }
 
     // MARK: - OSSystemExtensionRequestDelegate
@@ -292,6 +477,7 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
                 if self.state != .off {
                     self.state = .on
                     self.scheduleHostVisibilityCheck()
+                    self.beginConsumerWatch()
                 }
             case .willCompleteAfterReboot:
                 // Rare path — extension upgrade queued for next

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -21,6 +21,13 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
     static let envVar = "AVPR_ACTIVATE_VIRTUAL_CAMERA"
 
     private static var retained: VirtualCameraActivator?
+    private static var sinkWriter: CMIOSinkWriter?
+    private static var captureSession: CameraCaptureSession?
+
+    /// Stable UUID matching the extension's
+    /// `CameraExtensionDeviceSource.deviceUUID`. The host uses this
+    /// to find the virtual camera in the CMIO device list.
+    private static let virtualCameraUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
 
     static func activateIfRequested() {
         guard ProcessInfo.processInfo.environment[envVar] == "1" else { return }
@@ -35,6 +42,25 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
         // is fine — there's at most one of these per launch.
         retained = activator
         NSLog("[AVPR] Submitted Camera Extension activation request")
+
+        // Start the host-side capture pipeline. The CMIOSinkWriter
+        // lazily finds the device + sink stream on first enqueue,
+        // so even on a fresh activation it starts producing frames
+        // as soon as the extension is enabled.
+        startCapturePipeline()
+    }
+
+    private static func startCapturePipeline() {
+        let writer = CMIOSinkWriter(
+            deviceUID: virtualCameraUID,
+            width: 1280,
+            height: 720
+        )
+        let session = CameraCaptureSession(sink: writer)
+        session.start()
+        sinkWriter = writer
+        captureSession = session
+        NSLog("[AVPR] Started host-side capture + CMIO sink writer")
     }
 
     func request(

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import SystemExtensions
 import AVPainReliever
 import os.log
@@ -8,67 +9,175 @@ private let logger = Logger(
     category: "Activator"
 )
 
-/// M1 plumbing: triggers `OSSystemExtensionRequest` activation for
-/// the embedded Camera Extension when the env var
-/// `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` is set at launch.
+/// Owns the lifecycle of the embedded Camera Extension AND the
+/// host-side capture pipeline that feeds it. Driven by the
+/// `SettingsStore.virtualCameraEnabled` toggle, with
+/// `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` as a debug-only override that
+/// forces enable on launch regardless of the persisted setting.
 ///
-/// Why an env var instead of a Settings toggle: M1 is just proving
-/// the activation/embedding/signing plumbing. A real opt-in toggle
-/// in Settings lands in M4. The env-var path stays in the codebase
-/// for the lifetime of the feature branch as a debug affordance —
-/// hidden from regular users, useful for re-activating after a
-/// `systemextensionsctl uninstall`.
+/// State machine:
 ///
-/// Requires the `com.apple.developer.system-extension.install`
-/// entitlement on the host app. v0.1.x builds don't have it; calls
-/// from those builds will fail with an authorization error, which
-/// is the intended no-op.
-final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
+/// ```
+/// .off ──enable()──▶ .activating ──didFinishWithResult──▶ .on
+///   ▲                       │                              │
+///   │                       └─didFailWithError──▶ .failed   │
+///   │                                                       │
+///   └────────────────disable()──────────────────────────────┘
+/// ```
+///
+/// `.activating` covers both submitted-and-waiting and
+/// needs-user-approval — they're indistinguishable from the host's
+/// perspective until macOS fires didFinishWithResult.
+///
+/// SwiftUI surfaces the state via the `@Published state` property;
+/// the Settings view shows a status row that mirrors it.
+final class VirtualCameraActivator: NSObject, ObservableObject,
+    OSSystemExtensionRequestDelegate, VirtualCameraSourceController
+{
+    enum State: Equatable {
+        case off
+        case activating
+        case needsApproval
+        case on
+        case failed(String)
+        /// Special "the user toggled off then back on in the same
+        /// process" state. macOS marks the extension
+        /// `[terminated waiting to uninstall on reboot]` after
+        /// deactivation; re-enabling without a host-process restart
+        /// hands the host a stale CMIO device registration that
+        /// can't be queried successfully. Detected by tracking the
+        /// in-session deactivation; resolved by relaunching the
+        /// app from a fresh process.
+        case requiresRelaunch
+
+        var isLive: Bool {
+            switch self {
+            case .activating, .needsApproval, .on: return true
+            case .off, .failed, .requiresRelaunch: return false
+            }
+        }
+    }
+
     static let extensionBundleID = "com.ericwillis.avpainreliever.CameraExtension"
     static let envVar = "AVPR_ACTIVATE_VIRTUAL_CAMERA"
-
-    private static var retained: VirtualCameraActivator?
-    private static var sinkWriter: CMIOSinkWriter?
-    private static var captureSession: CameraCaptureSession?
-
-    /// The running capture session as a `VirtualCameraSourceController`,
-    /// or nil if the env-var-gated activator never ran (v0.1.x build,
-    /// or v0.2.x launched without `AVPR_ACTIVATE_VIRTUAL_CAMERA=1`).
-    /// `AppDelegate.buildEngine` reads this to plumb the active
-    /// profile's camera selection into the virtual camera.
-    static var virtualCameraSource: VirtualCameraSourceController? {
-        captureSession
-    }
 
     /// Stable UUID matching the extension's
     /// `CameraExtensionDeviceSource.deviceUUID`. The host uses this
     /// to find the virtual camera in the CMIO device list.
-    private static let virtualCameraUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
+    static let virtualCameraUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
 
-    static func activateIfRequested() {
-        guard ProcessInfo.processInfo.environment[envVar] == "1" else { return }
-        let activator = VirtualCameraActivator()
+    @Published private(set) var state: State = .off
+
+    /// True when the env var override forced enable on launch.
+    /// Settings UI hides the toggle's persistence-driven semantics
+    /// and shows a "debug override active" badge instead so the
+    /// user understands why disabling doesn't seem to stick.
+    private(set) var isEnvOverride: Bool = false
+
+    private var sinkWriter: CMIOSinkWriter?
+    private var captureSession: CameraCaptureSession?
+
+    /// True after a successful `disable()` until the host process
+    /// is relaunched. Re-enabling within the same process hits the
+    /// macOS "queued for uninstall on reboot" CMIO quirk where the
+    /// host can't find the device even though System Settings shows
+    /// it as active. Tracked here so `enable()` can surface the
+    /// `.requiresRelaunch` state instead of silently producing a
+    /// black feed.
+    private var deactivatedThisSession = false
+
+    /// Returns true if launch should auto-enable: env-var debug
+    /// override OR the user's persisted toggle is on. The env var
+    /// is checked first so a developer can force-enable without
+    /// touching the persisted setting.
+    static func shouldAutoEnable(persistedToggle: Bool) -> Bool {
+        if ProcessInfo.processInfo.environment[envVar] == "1" { return true }
+        return persistedToggle
+    }
+
+    /// Begin activation. Idempotent: subsequent calls while in any
+    /// non-`.off`/`.failed` state are silent no-ops.
+    func enable(envOverride: Bool = false) {
+        switch state {
+        case .activating, .needsApproval, .on:
+            logger.info("enable() called while already \(String(describing: self.state), privacy: .public) — no-op")
+            return
+        case .requiresRelaunch:
+            logger.info("enable() called while .requiresRelaunch — keeping that state until relaunch")
+            return
+        case .off, .failed:
+            break
+        }
+        if deactivatedThisSession {
+            logger.info("enable() blocked: in-session deactivation requires a host relaunch")
+            state = .requiresRelaunch
+            return
+        }
+        isEnvOverride = envOverride
+        state = .activating
+        logger.info("Submitting Camera Extension activation request (envOverride=\(envOverride, privacy: .public))")
+
         let request = OSSystemExtensionRequest.activationRequest(
-            forExtensionWithIdentifier: extensionBundleID,
+            forExtensionWithIdentifier: Self.extensionBundleID,
             queue: .main
         )
-        request.delegate = activator
+        request.delegate = self
         OSSystemExtensionManager.shared.submitRequest(request)
-        // Retain across the async lifecycle. App-lifetime retention
-        // is fine — there's at most one of these per launch.
-        retained = activator
-        logger.info("Submitted Camera Extension activation request")
 
-        // Start the host-side capture pipeline. The CMIOSinkWriter
-        // lazily finds the device + sink stream on first enqueue,
-        // so even on a fresh activation it starts producing frames
-        // as soon as the extension is enabled.
         startCapturePipeline()
     }
 
-    private static func startCapturePipeline() {
+    /// Tear down the capture pipeline and submit a deactivation
+    /// request. Idempotent: a call while `.off` is a no-op.
+    func disable() {
+        switch state {
+        case .off:
+            logger.info("disable() called while already off — no-op")
+            return
+        default:
+            break
+        }
+        logger.info("Disabling: stopping capture pipeline + deactivating extension")
+        stopCapturePipeline()
+
+        let request = OSSystemExtensionRequest.deactivationRequest(
+            forExtensionWithIdentifier: Self.extensionBundleID,
+            queue: .main
+        )
+        request.delegate = self
+        OSSystemExtensionManager.shared.submitRequest(request)
+
+        state = .off
+        isEnvOverride = false
+        deactivatedThisSession = true
+    }
+
+    /// Quit + relaunch the host. The fresh process auto-enables
+    /// from the persisted toggle and gets a clean CMIO context that
+    /// finds the activated extension immediately. Wired to the
+    /// "Restart" button on the Settings UI's `.requiresRelaunch`
+    /// state.
+    func relaunch() {
+        let bundleURL = Bundle.main.bundleURL
+        logger.info("Relaunching host: \(bundleURL.path, privacy: .public)")
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = [bundleURL.path]
+        do {
+            try task.run()
+        } catch {
+            logger.error("relaunch open failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        DispatchQueue.main.async {
+            NSApplication.shared.terminate(nil)
+        }
+    }
+
+    private func startCapturePipeline() {
+        guard captureSession == nil else { return }
         let writer = CMIOSinkWriter(
-            deviceUID: virtualCameraUID,
+            deviceUID: Self.virtualCameraUID,
             width: 1280,
             height: 720
         )
@@ -78,6 +187,28 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
         captureSession = session
         logger.info("Started host-side capture + CMIO sink writer")
     }
+
+    private func stopCapturePipeline() {
+        captureSession?.stop()
+        captureSession = nil
+        sinkWriter = nil
+        logger.info("Stopped host-side capture pipeline")
+    }
+
+    // MARK: - VirtualCameraSourceController
+
+    func setSource(named: String) -> CameraApplyResult {
+        guard let captureSession else {
+            // Toggle off OR mid-activation with capture not yet
+            // running. Treat as silent no-op (.ok) so the engine's
+            // per-profile log line doesn't claim a failure for what
+            // is just "user has the virtual camera disabled."
+            return .ok
+        }
+        return captureSession.setSource(named: named)
+    }
+
+    // MARK: - OSSystemExtensionRequestDelegate
 
     func request(
         _ request: OSSystemExtensionRequest,
@@ -90,20 +221,51 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
     }
 
     func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
-        logger.info("Camera Extension needs user approval — open System Settings → Login Items & Extensions → Camera Extensions")
+        logger.info("Camera Extension needs user approval — open System Settings → Login Items & Extensions")
+        DispatchQueue.main.async { [weak self] in
+            // Don't override .on — a Sparkle-driven upgrade-replace
+            // flow can fire needs-user-approval AFTER the original
+            // is already running, and we don't want to regress the
+            // status badge in that case.
+            guard let self, self.state != .on else { return }
+            self.state = .needsApproval
+        }
     }
 
     func request(
         _ request: OSSystemExtensionRequest,
         didFinishWithResult result: OSSystemExtensionRequest.Result
     ) {
-        logger.info("Camera Extension activation finished: result=\(result.rawValue, privacy: .public)")
+        logger.info("Camera Extension request finished: result=\(result.rawValue, privacy: .public)")
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch result {
+            case .completed:
+                // Activation OR deactivation completed. Distinguish
+                // by current state: if we were already heading off
+                // (disable() set state=.off), leave it. Otherwise
+                // this is a successful activation → .on.
+                if self.state != .off { self.state = .on }
+            case .willCompleteAfterReboot:
+                // Rare path — extension upgrade queued for next
+                // reboot. Mark as failed so the user knows the new
+                // version isn't live yet.
+                self.state = .failed("Upgrade pending — reboot required")
+            @unknown default:
+                self.state = .failed("Unknown activation result")
+            }
+        }
     }
 
     func request(
         _ request: OSSystemExtensionRequest,
         didFailWithError error: Error
     ) {
-        logger.error("Camera Extension activation failed: \(error.localizedDescription, privacy: .public)")
+        let message = error.localizedDescription
+        logger.error("Camera Extension request failed: \(message, privacy: .public)")
+        DispatchQueue.main.async { [weak self] in
+            self?.stopCapturePipeline()
+            self?.state = .failed(message)
+        }
     }
 }

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SystemExtensions
+
+/// M1 plumbing: triggers `OSSystemExtensionRequest` activation for
+/// the embedded Camera Extension when the env var
+/// `AVPR_ACTIVATE_VIRTUAL_CAMERA=1` is set at launch.
+///
+/// Why an env var instead of a Settings toggle: M1 is just proving
+/// the activation/embedding/signing plumbing. A real opt-in toggle
+/// in Settings lands in M4. The env-var path stays in the codebase
+/// for the lifetime of the feature branch as a debug affordance —
+/// hidden from regular users, useful for re-activating after a
+/// `systemextensionsctl uninstall`.
+///
+/// Requires the `com.apple.developer.system-extension.install`
+/// entitlement on the host app. v0.1.x builds don't have it; calls
+/// from those builds will fail with an authorization error, which
+/// is the intended no-op.
+final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
+    static let extensionBundleID = "com.ericwillis.avpainreliever.CameraExtension"
+    static let envVar = "AVPR_ACTIVATE_VIRTUAL_CAMERA"
+
+    private static var retained: VirtualCameraActivator?
+
+    static func activateIfRequested() {
+        guard ProcessInfo.processInfo.environment[envVar] == "1" else { return }
+        let activator = VirtualCameraActivator()
+        let request = OSSystemExtensionRequest.activationRequest(
+            forExtensionWithIdentifier: extensionBundleID,
+            queue: .main
+        )
+        request.delegate = activator
+        OSSystemExtensionManager.shared.submitRequest(request)
+        // Retain across the async lifecycle. App-lifetime retention
+        // is fine — there's at most one of these per launch.
+        retained = activator
+        NSLog("[AVPR] Submitted Camera Extension activation request")
+    }
+
+    func request(
+        _ request: OSSystemExtensionRequest,
+        actionForReplacingExtension existing: OSSystemExtensionProperties,
+        withExtension ext: OSSystemExtensionProperties
+    ) -> OSSystemExtensionRequest.ReplacementAction {
+        // Always replace. Sparkle-installed upgrades will hit this
+        // path for every v0.2.x → v0.2.y bump.
+        .replace
+    }
+
+    func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
+        NSLog("[AVPR] Camera Extension needs user approval — open System Settings → Privacy & Security")
+    }
+
+    func request(
+        _ request: OSSystemExtensionRequest,
+        didFinishWithResult result: OSSystemExtensionRequest.Result
+    ) {
+        NSLog("[AVPR] Camera Extension activation finished: result=\(result.rawValue)")
+    }
+
+    func request(
+        _ request: OSSystemExtensionRequest,
+        didFailWithError error: Error
+    ) {
+        NSLog("[AVPR] Camera Extension activation failed: \(error)")
+    }
+}

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -1,5 +1,11 @@
 import Foundation
 import SystemExtensions
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever",
+    category: "Activator"
+)
 
 /// M1 plumbing: triggers `OSSystemExtensionRequest` activation for
 /// the embedded Camera Extension when the env var
@@ -41,7 +47,7 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
         // Retain across the async lifecycle. App-lifetime retention
         // is fine — there's at most one of these per launch.
         retained = activator
-        NSLog("[AVPR] Submitted Camera Extension activation request")
+        logger.info("Submitted Camera Extension activation request")
 
         // Start the host-side capture pipeline. The CMIOSinkWriter
         // lazily finds the device + sink stream on first enqueue,
@@ -60,7 +66,7 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
         session.start()
         sinkWriter = writer
         captureSession = session
-        NSLog("[AVPR] Started host-side capture + CMIO sink writer")
+        logger.info("Started host-side capture + CMIO sink writer")
     }
 
     func request(
@@ -74,20 +80,20 @@ final class VirtualCameraActivator: NSObject, OSSystemExtensionRequestDelegate {
     }
 
     func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
-        NSLog("[AVPR] Camera Extension needs user approval — open System Settings → Privacy & Security")
+        logger.info("Camera Extension needs user approval — open System Settings → Login Items & Extensions → Camera Extensions")
     }
 
     func request(
         _ request: OSSystemExtensionRequest,
         didFinishWithResult result: OSSystemExtensionRequest.Result
     ) {
-        NSLog("[AVPR] Camera Extension activation finished: result=\(result.rawValue)")
+        logger.info("Camera Extension activation finished: result=\(result.rawValue, privacy: .public)")
     }
 
     func request(
         _ request: OSSystemExtensionRequest,
         didFailWithError error: Error
     ) {
-        NSLog("[AVPR] Camera Extension activation failed: \(error)")
+        logger.error("Camera Extension activation failed: \(error.localizedDescription, privacy: .public)")
     }
 }

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import AVFoundation
 import SystemExtensions
 import AVPainReliever
 import os.log
@@ -208,6 +209,49 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         return captureSession.setSource(named: named)
     }
 
+    // MARK: - Host-process visibility check
+
+    /// After activation flips to `.on`, AVFoundation in the host
+    /// process sometimes doesn't see the newly-published CMIO
+    /// device — the discovery cache was warmed before the extension
+    /// registered, and stays stale until a fresh process reads CMIO
+    /// for the first time. Other apps (Photo Booth, FaceTime) see
+    /// the device fine; only this host is blind to it. Detected by
+    /// running `AVCaptureDevice.DiscoverySession` and looking for
+    /// our extension's UID. If absent, escalate to
+    /// `.requiresRelaunch` so Settings can offer the same Restart
+    /// affordance the disable→enable path uses.
+    private func scheduleHostVisibilityCheck() {
+        // ~1.5 s is enough for CMIO to publish after activation on
+        // every machine I've measured. Too short and a healthy
+        // first-activation gets misclassified; longer adds dead time
+        // before the wizard's camera list reflects reality.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            guard let self, self.state == .on else { return }
+            if Self.hostCanSeeVirtualCamera() {
+                logger.info("Visibility check: host sees the virtual camera in DiscoverySession")
+                return
+            }
+            logger.error("Visibility check: host process can't see its own Camera Extension — escalating to .requiresRelaunch")
+            self.stopCapturePipeline()
+            self.state = .requiresRelaunch
+        }
+    }
+
+    private static func hostCanSeeVirtualCamera() -> Bool {
+        let session = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .external,
+                .continuityCamera,
+                .deskViewCamera,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+        return session.devices.contains { $0.uniqueID == Self.virtualCameraUID }
+    }
+
     // MARK: - OSSystemExtensionRequestDelegate
 
     func request(
@@ -245,7 +289,10 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
                 // by current state: if we were already heading off
                 // (disable() set state=.off), leave it. Otherwise
                 // this is a successful activation → .on.
-                if self.state != .off { self.state = .on }
+                if self.state != .off {
+                    self.state = .on
+                    self.scheduleHostVisibilityCheck()
+                }
             case .willCompleteAfterReboot:
                 // Rare path — extension upgrade queued for next
                 // reboot. Mark as failed so the user knows the new

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
@@ -151,6 +151,28 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
     private var consumedCount: UInt64 = 0
     private var forwardedCount: UInt64 = 0
     private var emptyConsumeCount: UInt64 = 0
+    private var heldFrameCount: UInt64 = 0
+
+    /// Most recent sample buffer received from the host. Re-emitted
+    /// when the sink yields nothing — keeps the source flowing during
+    /// the ~500 ms input-swap window inside `CameraCaptureSession`.
+    /// Without this, AVCapture clients (Zoom) see the call freeze or
+    /// drop while the new camera warms up.
+    private var lastFrameImage: CVPixelBuffer?
+    private var lastFrameFormat: CMFormatDescription?
+
+    /// Host time of the most recent frame we sent through the source
+    /// stream — whether a fresh sink frame or a held repeat. Used to
+    /// rate-limit hold-last-frame emissions to roughly the source's
+    /// declared frame duration.
+    private var lastSourceSendHostTimeNs: UInt64 = 0
+
+    /// Minimum spacing between hold-last-frame emissions. Matches the
+    /// source's declared 30 fps so AVCapture clients see a steady
+    /// cadence rather than a 90 Hz burst (the consume timer ticks at
+    /// 3× framerate, but only one in three should re-emit).
+    private static let heldFrameMinSpacingNs: UInt64 =
+        UInt64(1_000_000_000.0 / 30.0)
 
     private func consumeOne(client: CMIOExtensionClient) {
         streamSink.stream.consumeSampleBuffer(from: client) {
@@ -160,6 +182,11 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                 logger.error("consume error: \(error.localizedDescription, privacy: .public)")
                 return
             }
+            let nowNs = UInt64(
+                CMClockGetTime(CMClockGetHostTimeClock()).seconds
+                    * Double(NSEC_PER_SEC)
+            )
+
             guard let sampleBuffer else {
                 self.emptyConsumeCount += 1
                 if self.emptyConsumeCount % 90 == 1 {
@@ -167,6 +194,7 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                         "consume returned no buffer (\(self.emptyConsumeCount, privacy: .public) empty so far)"
                     )
                 }
+                self.maybeEmitHeldFrame(nowNs: nowNs)
                 return
             }
 
@@ -180,15 +208,23 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
             // Tell the sink the frame moved through, so its
             // `streamSinkEndOfData` and underrun counters stay
             // sane.
-            let nowNs = UInt64(
-                CMClockGetTime(CMClockGetHostTimeClock()).seconds
-                    * Double(NSEC_PER_SEC)
-            )
             let scheduled = CMIOExtensionScheduledOutput(
                 sequenceNumber: sequenceNumber,
                 hostTimeInNanoseconds: nowNs
             )
             self.streamSink.stream.notifyScheduledOutputChanged(scheduled)
+
+            // Cache the underlying image + format so we can re-emit
+            // it during a source swap when the sink temporarily
+            // dries up. Holding the CVPixelBuffer (not the parent
+            // CMSampleBuffer) lets us mint fresh sample buffers
+            // with current timestamps for each repeat.
+            if let image = CMSampleBufferGetImageBuffer(sampleBuffer),
+               let format = CMSampleBufferGetFormatDescription(sampleBuffer)
+            {
+                self.lastFrameImage = image
+                self.lastFrameFormat = format
+            }
 
             // Drop the frame on the floor if no AVCapture client is
             // currently watching the source. Saves the cost of
@@ -202,6 +238,7 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                 discontinuity: [],
                 hostTimeInNanoseconds: ptsNs
             )
+            self.lastSourceSendHostTimeNs = nowNs
             self.forwardedCount += 1
             if self.forwardedCount == 1 || self.forwardedCount % 60 == 0 {
                 logger.info(
@@ -209,5 +246,68 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                 )
             }
         }
+    }
+
+    /// Re-emit the cached frame on a sink-empty tick when (a) someone
+    /// is watching, (b) we have a frame to repeat, and (c) we haven't
+    /// already sent one recently. The "recent" gate keeps the source's
+    /// effective FPS pinned to ~30 even though the consume timer
+    /// fires at 90 Hz.
+    private func maybeEmitHeldFrame(nowNs: UInt64) {
+        guard streamSource.streamingCounter > 0,
+              let image = lastFrameImage,
+              let format = lastFrameFormat
+        else { return }
+        if nowNs - lastSourceSendHostTimeNs < Self.heldFrameMinSpacingNs {
+            return
+        }
+        guard let repeated = makeSampleBuffer(
+            image: image,
+            format: format,
+            hostTimeNs: nowNs
+        ) else { return }
+        streamSource.stream.send(
+            repeated,
+            discontinuity: [],
+            hostTimeInNanoseconds: nowNs
+        )
+        lastSourceSendHostTimeNs = nowNs
+        heldFrameCount += 1
+        if heldFrameCount == 1 || heldFrameCount % 30 == 0 {
+            logger.info(
+                "Held-last-frame emit #\(self.heldFrameCount, privacy: .public)"
+            )
+        }
+    }
+
+    private func makeSampleBuffer(
+        image: CVPixelBuffer,
+        format: CMFormatDescription,
+        hostTimeNs: UInt64
+    ) -> CMSampleBuffer? {
+        var timing = CMSampleTimingInfo(
+            duration: .invalid,
+            presentationTimeStamp: CMTime(
+                value: CMTimeValue(hostTimeNs),
+                timescale: CMTimeScale(NSEC_PER_SEC)
+            ),
+            decodeTimeStamp: .invalid
+        )
+        var out: CMSampleBuffer?
+        let status = CMSampleBufferCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: image,
+            dataReady: true,
+            makeDataReadyCallback: nil,
+            refcon: nil,
+            formatDescription: format,
+            sampleTiming: &timing,
+            sampleBufferOut: &out
+        )
+        if status != noErr {
+            logger.error("makeSampleBuffer failed: \(status, privacy: .public)")
+            return nil
+        }
+        return out
     }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
@@ -2,6 +2,12 @@ import Foundation
 import CoreMediaIO
 import CoreMedia
 import IOKit.audio
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever.CameraExtension",
+    category: "Device"
+)
 
 /// The single virtual camera device registered by this extension.
 /// Owns two streams:
@@ -110,6 +116,7 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
     /// host starts pushing frames to the sink. Begins the consume
     /// timer that drains the sink and forwards to the source.
     func sinkStartedStreaming(client: CMIOExtensionClient) {
+        logger.info("sinkStartedStreaming")
         consumeQueue.async { [weak self] in
             guard let self else { return }
             self.startConsumeTimer(client: client)
@@ -117,6 +124,7 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
     }
 
     func sinkStoppedStreaming() {
+        logger.info("sinkStoppedStreaming")
         consumeQueue.async { [weak self] in
             self?.consumeTimer?.cancel()
             self?.consumeTimer = nil
@@ -140,15 +148,34 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
         timer.resume()
     }
 
+    private var consumedCount: UInt64 = 0
+    private var forwardedCount: UInt64 = 0
+    private var emptyConsumeCount: UInt64 = 0
+
     private func consumeOne(client: CMIOExtensionClient) {
         streamSink.stream.consumeSampleBuffer(from: client) {
             [weak self] sampleBuffer, sequenceNumber, _, _, error in
             guard let self else { return }
             if let error {
-                NSLog("[AVPR-ext] consume error: \(error)")
+                logger.error("consume error: \(error.localizedDescription, privacy: .public)")
                 return
             }
-            guard let sampleBuffer else { return }
+            guard let sampleBuffer else {
+                self.emptyConsumeCount += 1
+                if self.emptyConsumeCount % 90 == 1 {
+                    logger.debug(
+                        "consume returned no buffer (\(self.emptyConsumeCount, privacy: .public) empty so far)"
+                    )
+                }
+                return
+            }
+
+            self.consumedCount += 1
+            if self.consumedCount == 1 || self.consumedCount % 60 == 0 {
+                logger.info(
+                    "Consumed frame #\(self.consumedCount, privacy: .public), source streamingCounter=\(self.streamSource.streamingCounter, privacy: .public)"
+                )
+            }
 
             // Tell the sink the frame moved through, so its
             // `streamSinkEndOfData` and underrun counters stay
@@ -175,6 +202,12 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
                 discontinuity: [],
                 hostTimeInNanoseconds: ptsNs
             )
+            self.forwardedCount += 1
+            if self.forwardedCount == 1 || self.forwardedCount % 60 == 0 {
+                logger.info(
+                    "Forwarded frame #\(self.forwardedCount, privacy: .public) to source"
+                )
+            }
         }
     }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CoreMediaIO
+import IOKit.audio
+
+/// The single virtual camera device registered by this extension.
+/// Identifier and name are stable so reinstalls don't churn the
+/// device registry — apps that remember "AV Pain Reliever" by
+/// uniqueID continue to find it after a v0.2.x → v0.2.y upgrade.
+final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
+    private(set) var device: CMIOExtensionDevice!
+    private(set) var streamSource: CameraExtensionStreamSource!
+
+    // Stable UUIDs. Generated once for the lifetime of the project;
+    // never regenerate without a clear migration story.
+    private static let deviceUUID = UUID(
+        uuidString: "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
+    )!
+    private static let streamUUID = UUID(
+        uuidString: "C7E8F901-2A3B-4C5D-6E7F-8091A2B3C4D5"
+    )!
+
+    init(localizedName: String) {
+        super.init()
+        self.device = CMIOExtensionDevice(
+            localizedName: localizedName,
+            deviceID: Self.deviceUUID,
+            legacyDeviceID: nil,
+            source: self
+        )
+        self.streamSource = CameraExtensionStreamSource(
+            localizedName: "\(localizedName).video",
+            streamID: Self.streamUUID,
+            streamFormat: CameraExtensionStreamSource.standardFormat()
+        )
+        do {
+            try device.addStream(streamSource.stream)
+        } catch {
+            fatalError("addStream failed: \(error)")
+        }
+    }
+
+    var availableProperties: Set<CMIOExtensionProperty> {
+        [.deviceTransportType, .deviceModel]
+    }
+
+    func deviceProperties(forProperties properties: Set<CMIOExtensionProperty>)
+        throws -> CMIOExtensionDeviceProperties
+    {
+        let p = CMIOExtensionDeviceProperties(dictionary: [:])
+        if properties.contains(.deviceTransportType) {
+            // 'virt' FourCC. The constant is named for audio but is
+            // the conventional value for any virtual CMIO device —
+            // CMIO doesn't ship a video-specific equivalent.
+            p.transportType = kIOAudioDeviceTransportTypeVirtual
+        }
+        if properties.contains(.deviceModel) {
+            p.model = "AV Pain Reliever Virtual Camera"
+        }
+        return p
+    }
+
+    func setDeviceProperties(_ deviceProperties: CMIOExtensionDeviceProperties)
+        throws {}
+}

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionDevice.swift
@@ -1,23 +1,51 @@
 import Foundation
 import CoreMediaIO
+import CoreMedia
 import IOKit.audio
 
 /// The single virtual camera device registered by this extension.
+/// Owns two streams:
+///
+/// - `streamSource` (.source direction) — what AVCapture clients
+///   like Zoom read from.
+/// - `streamSink` (.sink direction) — what the host app writes to
+///   over CMIO's cross-process queue.
+///
+/// When the host starts streaming into the sink, this class kicks
+/// off a `consumeSampleBuffer` loop that pulls frames out and
+/// pushes them through the source stream. macOS's CMIO subsystem
+/// passes IOSurfaces between host and extension processes
+/// transparently — no explicit XPC.
+///
 /// Identifier and name are stable so reinstalls don't churn the
 /// device registry — apps that remember "AV Pain Reliever" by
 /// uniqueID continue to find it after a v0.2.x → v0.2.y upgrade.
 final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
     private(set) var device: CMIOExtensionDevice!
     private(set) var streamSource: CameraExtensionStreamSource!
+    private(set) var streamSink: CameraExtensionStreamSink!
 
-    // Stable UUIDs. Generated once for the lifetime of the project;
-    // never regenerate without a clear migration story.
     private static let deviceUUID = UUID(
         uuidString: "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
     )!
-    private static let streamUUID = UUID(
+    private static let sourceStreamUUID = UUID(
         uuidString: "C7E8F901-2A3B-4C5D-6E7F-8091A2B3C4D5"
     )!
+    private static let sinkStreamUUID = UUID(
+        uuidString: "D8F9A012-3B4C-5D6E-7F80-91A2B3C4D5E6"
+    )!
+
+    /// The host app finds this device via `CMIODevicePropertyDeviceUID`.
+    /// The string form must match what we set as `deviceID` on the
+    /// `CMIOExtensionDevice` — exposed here so the host doesn't
+    /// have to reach inside.
+    static let deviceUID = deviceUUID.uuidString
+
+    private let consumeQueue = DispatchQueue(
+        label: "com.ericwillis.avpainreliever.cameraext.consume",
+        qos: .userInteractive
+    )
+    private var consumeTimer: DispatchSourceTimer?
 
     init(localizedName: String) {
         super.init()
@@ -27,13 +55,28 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
             legacyDeviceID: nil,
             source: self
         )
+
+        let format = CameraExtensionStreamSource.standardFormat()
+
         self.streamSource = CameraExtensionStreamSource(
             localizedName: "\(localizedName).video",
-            streamID: Self.streamUUID,
-            streamFormat: CameraExtensionStreamSource.standardFormat()
+            streamID: Self.sourceStreamUUID,
+            streamFormat: format
         )
+        streamSource.device = self
+
+        self.streamSink = CameraExtensionStreamSink(
+            localizedName: "\(localizedName).sink",
+            streamID: Self.sinkStreamUUID,
+            streamFormat: format
+        )
+        streamSink.device = self
+
         do {
+            // Order matters: source first, sink second. The host
+            // picks the sink by index (streams[1]) when finding it.
             try device.addStream(streamSource.stream)
+            try device.addStream(streamSink.stream)
         } catch {
             fatalError("addStream failed: \(error)")
         }
@@ -48,9 +91,8 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
     {
         let p = CMIOExtensionDeviceProperties(dictionary: [:])
         if properties.contains(.deviceTransportType) {
-            // 'virt' FourCC. The constant is named for audio but is
-            // the conventional value for any virtual CMIO device —
-            // CMIO doesn't ship a video-specific equivalent.
+            // 'virt' FourCC. Constant is named for audio but is the
+            // conventional value for any virtual CMIO device.
             p.transportType = kIOAudioDeviceTransportTypeVirtual
         }
         if properties.contains(.deviceModel) {
@@ -61,4 +103,78 @@ final class CameraExtensionDeviceSource: NSObject, CMIOExtensionDeviceSource {
 
     func setDeviceProperties(_ deviceProperties: CMIOExtensionDeviceProperties)
         throws {}
+
+    // MARK: - Sink → source pipeline
+
+    /// Called by `CameraExtensionStreamSink.startStream` when the
+    /// host starts pushing frames to the sink. Begins the consume
+    /// timer that drains the sink and forwards to the source.
+    func sinkStartedStreaming(client: CMIOExtensionClient) {
+        consumeQueue.async { [weak self] in
+            guard let self else { return }
+            self.startConsumeTimer(client: client)
+        }
+    }
+
+    func sinkStoppedStreaming() {
+        consumeQueue.async { [weak self] in
+            self?.consumeTimer?.cancel()
+            self?.consumeTimer = nil
+        }
+    }
+
+    private func startConsumeTimer(client: CMIOExtensionClient) {
+        consumeTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(flags: .strict, queue: consumeQueue)
+        // 3× the frame rate so we never lag behind a producer that
+        // happens to deliver slightly bursty frames. Empty queue
+        // ticks are cheap.
+        let interval = DispatchTimeInterval.nanoseconds(
+            Int(1_000_000_000.0 / (30.0 * 3.0))
+        )
+        timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(1))
+        timer.setEventHandler { [weak self] in
+            self?.consumeOne(client: client)
+        }
+        consumeTimer = timer
+        timer.resume()
+    }
+
+    private func consumeOne(client: CMIOExtensionClient) {
+        streamSink.stream.consumeSampleBuffer(from: client) {
+            [weak self] sampleBuffer, sequenceNumber, _, _, error in
+            guard let self else { return }
+            if let error {
+                NSLog("[AVPR-ext] consume error: \(error)")
+                return
+            }
+            guard let sampleBuffer else { return }
+
+            // Tell the sink the frame moved through, so its
+            // `streamSinkEndOfData` and underrun counters stay
+            // sane.
+            let nowNs = UInt64(
+                CMClockGetTime(CMClockGetHostTimeClock()).seconds
+                    * Double(NSEC_PER_SEC)
+            )
+            let scheduled = CMIOExtensionScheduledOutput(
+                sequenceNumber: sequenceNumber,
+                hostTimeInNanoseconds: nowNs
+            )
+            self.streamSink.stream.notifyScheduledOutputChanged(scheduled)
+
+            // Drop the frame on the floor if no AVCapture client is
+            // currently watching the source. Saves the cost of
+            // a `stream.send` that nobody would consume anyway.
+            guard self.streamSource.streamingCounter > 0 else { return }
+
+            let pts = sampleBuffer.presentationTimeStamp
+            let ptsNs = UInt64(pts.seconds * Double(NSEC_PER_SEC))
+            self.streamSource.stream.send(
+                sampleBuffer,
+                discontinuity: [],
+                hostTimeInNanoseconds: ptsNs
+            )
+        }
+    }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionProvider.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionProvider.swift
@@ -2,11 +2,12 @@ import Foundation
 import CoreMediaIO
 
 /// Top-level CMIO Camera Extension provider. Owns exactly one
-/// device ("AV Pain Reliever"), which in turn owns one video
-/// stream. macOS instantiates this once per extension process.
+/// device ("AV Pain Reliever"), which in turn owns one source and
+/// one sink stream. macOS instantiates this once per extension
+/// process.
 final class CameraExtensionProviderSource: NSObject, CMIOExtensionProviderSource {
     private(set) var provider: CMIOExtensionProvider!
-    private let deviceSource: CameraExtensionDeviceSource
+    let deviceSource: CameraExtensionDeviceSource
 
     init(clientQueue: DispatchQueue?) {
         self.deviceSource = CameraExtensionDeviceSource(

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionProvider.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionProvider.swift
@@ -1,0 +1,44 @@
+import Foundation
+import CoreMediaIO
+
+/// Top-level CMIO Camera Extension provider. Owns exactly one
+/// device ("AV Pain Reliever"), which in turn owns one video
+/// stream. macOS instantiates this once per extension process.
+final class CameraExtensionProviderSource: NSObject, CMIOExtensionProviderSource {
+    private(set) var provider: CMIOExtensionProvider!
+    private let deviceSource: CameraExtensionDeviceSource
+
+    init(clientQueue: DispatchQueue?) {
+        self.deviceSource = CameraExtensionDeviceSource(
+            localizedName: "AV Pain Reliever"
+        )
+        super.init()
+        self.provider = CMIOExtensionProvider(source: self, clientQueue: clientQueue)
+        do {
+            try provider.addDevice(deviceSource.device)
+        } catch {
+            fatalError("addDevice failed: \(error)")
+        }
+    }
+
+    func connect(to client: CMIOExtensionClient) throws {}
+
+    func disconnect(from client: CMIOExtensionClient) {}
+
+    var availableProperties: Set<CMIOExtensionProperty> {
+        [.providerManufacturer]
+    }
+
+    func providerProperties(forProperties properties: Set<CMIOExtensionProperty>)
+        throws -> CMIOExtensionProviderProperties
+    {
+        let p = CMIOExtensionProviderProperties(dictionary: [:])
+        if properties.contains(.providerManufacturer) {
+            p.manufacturer = "Eric Willis"
+        }
+        return p
+    }
+
+    func setProviderProperties(_ providerProperties: CMIOExtensionProviderProperties)
+        throws {}
+}

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -15,6 +15,23 @@ private let logger = Logger(
 /// to the sink; the device source forwards each consumed frame
 /// here via `stream.send(...)`.
 final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
+    /// Darwin notification names used to tell the host whether any
+    /// AVCapture client is currently reading the source. The host
+    /// uses this to gate its real-camera capture pipeline (and
+    /// therefore the macOS green camera light): pipeline runs only
+    /// while a consumer is connected, plus a grace window after the
+    /// last one disconnects. Names are Team-ID-prefixed so the
+    /// sandbox lets this extension post them.
+    static let consumerActiveNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-active"
+    static let consumerInactiveNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-inactive"
+    /// Sent by the host when it (re)starts observing — extension
+    /// responds by re-posting the current state so a host that
+    /// missed the most recent transition can seed its initial value.
+    static let queryConsumerStateNotification =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.query-consumer-state"
+
     private(set) var stream: CMIOExtensionStream!
     private let streamFormat: CMIOExtensionStreamFormat
     weak var device: CameraExtensionDeviceSource?
@@ -60,6 +77,48 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
             clockType: .hostTime,
             source: self
         )
+        registerQueryListener()
+    }
+
+    deinit {
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterRemoveEveryObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            observer
+        )
+    }
+
+    /// Listen for the host's "what's the current state?" ping and
+    /// respond by re-broadcasting the current consumer-active value.
+    /// Lets a host that just registered observers seed its initial
+    /// state without having to read a property cross-process.
+    private func registerQueryListener() {
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            observer,
+            { _, observer, _, _, _ in
+                guard let observer else { return }
+                let me = Unmanaged<CameraExtensionStreamSource>
+                    .fromOpaque(observer)
+                    .takeUnretainedValue()
+                me.postCurrentState()
+            },
+            Self.queryConsumerStateNotification as CFString,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func postCurrentState() {
+        let name = streamingCounter > 0
+            ? Self.consumerActiveNotification
+            : Self.consumerInactiveNotification
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(name as CFString),
+            nil, nil, true
+        )
     }
 
     var formats: [CMIOExtensionStreamFormat] { [streamFormat] }
@@ -87,12 +146,31 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
     func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool { true }
 
     func startStream() throws {
+        let wasIdle = streamingCounter == 0
         streamingCounter += 1
         logger.info("source startStream — streamingCounter=\(self.streamingCounter, privacy: .public)")
+        // Edge-trigger only: a 0→1 transition is the moment the host
+        // needs to spin up its capture pipeline. Subsequent clients
+        // joining a stream that's already live don't need to wake
+        // anything up.
+        if wasIdle {
+            CFNotificationCenterPostNotification(
+                CFNotificationCenterGetDarwinNotifyCenter(),
+                CFNotificationName(Self.consumerActiveNotification as CFString),
+                nil, nil, true
+            )
+        }
     }
 
     func stopStream() throws {
         if streamingCounter > 0 { streamingCounter -= 1 }
         logger.info("source stopStream — streamingCounter=\(self.streamingCounter, privacy: .public)")
+        if streamingCounter == 0 {
+            CFNotificationCenterPostNotification(
+                CFNotificationCenterGetDarwinNotifyCenter(),
+                CFNotificationName(Self.consumerInactiveNotification as CFString),
+                nil, nil, true
+            )
+        }
     }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -1,6 +1,12 @@
 import Foundation
 import CoreMediaIO
 import CoreMedia
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever.CameraExtension",
+    category: "Source"
+)
 
 /// The .source direction stream — what AVCapture clients (Zoom,
 /// FaceTime, Slack, …) read from. Pure relay endpoint: frames are
@@ -82,9 +88,11 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
 
     func startStream() throws {
         streamingCounter += 1
+        logger.info("source startStream — streamingCounter=\(self.streamingCounter, privacy: .public)")
     }
 
     func stopStream() throws {
         if streamingCounter > 0 { streamingCounter -= 1 }
+        logger.info("source stopStream — streamingCounter=\(self.streamingCounter, privacy: .public)")
     }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -6,10 +6,20 @@ import CoreVideo
 /// Vends video frames downstream to whichever AVCapture client has
 /// the virtual camera open (Zoom, FaceTime, Slack, etc.).
 ///
-/// M1 implementation: emits a black 1280×720 BGRA frame at 30 fps.
-/// The pixel buffer pool is allocated once per stream-start and
-/// reused for every frame. M2 will replace the black-frame fill
-/// with frames captured from a real source camera.
+/// Current implementation: emits a black 1280×720 BGRA frame at
+/// 30 fps. The pixel buffer pool is allocated once per
+/// stream-start and reused for every frame.
+///
+/// Why no AVCaptureSession in this file: a CMIO Camera Extension
+/// CANNOT use AVFoundation to capture from physical cameras
+/// without triggering an IOKit-level deadlock — AVFoundation's
+/// device enumeration walks the CMIO device list, which includes
+/// the very extension making the call, and concurrent client apps
+/// (e.g. Photo Booth) wedge waiting on the loop. The supported
+/// pattern (used by OBS, mmhmm, Hand Mirror, Camo, etc.) is to
+/// capture in the host app and forward frames to the extension
+/// over XPC. That work lives in M3 of the V2 plan; until M3
+/// lands, this stream stays a black-frame placeholder.
 final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
     private(set) var stream: CMIOExtensionStream!
     private let streamFormat: CMIOExtensionStreamFormat
@@ -82,12 +92,7 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
     func setStreamProperties(_ streamProperties: CMIOExtensionStreamProperties)
         throws {}
 
-    func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool {
-        // M1 has no client gating. M3 may revisit if we want to
-        // restrict who can open the virtual camera (probably not —
-        // any AVCapture client should be allowed).
-        true
-    }
+    func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool { true }
 
     func startStream() throws {
         try ensurePixelBufferPool()
@@ -144,7 +149,6 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
             let pixelBuffer
         else { return }
 
-        // Zero the buffer — black frame.
         CVPixelBufferLockBaseAddress(pixelBuffer, [])
         if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
             let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -1,0 +1,188 @@
+import Foundation
+import CoreMediaIO
+import CoreMedia
+import CoreVideo
+
+/// Vends video frames downstream to whichever AVCapture client has
+/// the virtual camera open (Zoom, FaceTime, Slack, etc.).
+///
+/// M1 implementation: emits a black 1280×720 BGRA frame at 30 fps.
+/// The pixel buffer pool is allocated once per stream-start and
+/// reused for every frame. M2 will replace the black-frame fill
+/// with frames captured from a real source camera.
+final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
+    private(set) var stream: CMIOExtensionStream!
+    private let streamFormat: CMIOExtensionStreamFormat
+
+    private var timer: DispatchSourceTimer?
+    private let timerQueue = DispatchQueue(
+        label: "com.ericwillis.avpainreliever.cameraext.framepump",
+        qos: .userInteractive
+    )
+    private var pixelBufferPool: CVPixelBufferPool?
+    private var sequenceNumber: UInt64 = 0
+
+    static let frameWidth: Int32 = 1280
+    static let frameHeight: Int32 = 720
+    static let frameDuration = CMTime(value: 1, timescale: 30)
+
+    static func standardFormat() -> CMIOExtensionStreamFormat {
+        var formatDescription: CMFormatDescription?
+        CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCVPixelFormatType_32BGRA,
+            width: frameWidth,
+            height: frameHeight,
+            extensions: nil,
+            formatDescriptionOut: &formatDescription
+        )
+        return CMIOExtensionStreamFormat(
+            formatDescription: formatDescription!,
+            maxFrameDuration: frameDuration,
+            minFrameDuration: frameDuration,
+            validFrameDurations: nil
+        )
+    }
+
+    init(
+        localizedName: String,
+        streamID: UUID,
+        streamFormat: CMIOExtensionStreamFormat
+    ) {
+        self.streamFormat = streamFormat
+        super.init()
+        self.stream = CMIOExtensionStream(
+            localizedName: localizedName,
+            streamID: streamID,
+            direction: .source,
+            clockType: .hostTime,
+            source: self
+        )
+    }
+
+    var formats: [CMIOExtensionStreamFormat] { [streamFormat] }
+
+    var availableProperties: Set<CMIOExtensionProperty> {
+        [.streamActiveFormatIndex, .streamFrameDuration]
+    }
+
+    func streamProperties(forProperties properties: Set<CMIOExtensionProperty>)
+        throws -> CMIOExtensionStreamProperties
+    {
+        let p = CMIOExtensionStreamProperties(dictionary: [:])
+        if properties.contains(.streamActiveFormatIndex) {
+            p.activeFormatIndex = 0
+        }
+        if properties.contains(.streamFrameDuration) {
+            p.frameDuration = Self.frameDuration
+        }
+        return p
+    }
+
+    func setStreamProperties(_ streamProperties: CMIOExtensionStreamProperties)
+        throws {}
+
+    func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool {
+        // M1 has no client gating. M3 may revisit if we want to
+        // restrict who can open the virtual camera (probably not —
+        // any AVCapture client should be allowed).
+        true
+    }
+
+    func startStream() throws {
+        try ensurePixelBufferPool()
+        sequenceNumber = 0
+
+        let timer = DispatchSource.makeTimerSource(flags: .strict, queue: timerQueue)
+        let interval = DispatchTimeInterval.nanoseconds(
+            Int(1_000_000_000.0 / 30.0)
+        )
+        timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(2))
+        timer.setEventHandler { [weak self] in
+            self?.emitFrame()
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    func stopStream() throws {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func ensurePixelBufferPool() throws {
+        if pixelBufferPool != nil { return }
+        let attrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: Self.frameWidth,
+            kCVPixelBufferHeightKey as String: Self.frameHeight,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        var pool: CVPixelBufferPool?
+        let status = CVPixelBufferPoolCreate(
+            kCFAllocatorDefault,
+            nil,
+            attrs as CFDictionary,
+            &pool
+        )
+        guard status == kCVReturnSuccess, let pool else {
+            throw NSError(
+                domain: "AVPainRelieverCameraExtension",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "CVPixelBufferPoolCreate failed"]
+            )
+        }
+        self.pixelBufferPool = pool
+    }
+
+    private func emitFrame() {
+        guard let pool = pixelBufferPool else { return }
+        var pixelBuffer: CVPixelBuffer?
+        guard
+            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+                == kCVReturnSuccess,
+            let pixelBuffer
+        else { return }
+
+        // Zero the buffer — black frame.
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+            let height = CVPixelBufferGetHeight(pixelBuffer)
+            memset(base, 0, bytesPerRow * height)
+        }
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+
+        var formatDescription: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescriptionOut: &formatDescription
+        )
+        guard let formatDescription else { return }
+
+        let timestamp = CMClockGetTime(CMClockGetHostTimeClock())
+        var timing = CMSampleTimingInfo(
+            duration: Self.frameDuration,
+            presentationTimeStamp: timestamp,
+            decodeTimeStamp: .invalid
+        )
+
+        var sampleBuffer: CMSampleBuffer?
+        let createStatus = CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer,
+            formatDescription: formatDescription,
+            sampleTiming: &timing,
+            sampleBufferOut: &sampleBuffer
+        )
+        guard createStatus == noErr, let sampleBuffer else { return }
+
+        sequenceNumber &+= 1
+        stream.send(
+            sampleBuffer,
+            discontinuity: [],
+            hostTimeInNanoseconds: UInt64(timestamp.seconds * Double(NSEC_PER_SEC))
+        )
+    }
+}

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -1,36 +1,22 @@
 import Foundation
 import CoreMediaIO
 import CoreMedia
-import CoreVideo
 
-/// Vends video frames downstream to whichever AVCapture client has
-/// the virtual camera open (Zoom, FaceTime, Slack, etc.).
-///
-/// Current implementation: emits a black 1280×720 BGRA frame at
-/// 30 fps. The pixel buffer pool is allocated once per
-/// stream-start and reused for every frame.
-///
-/// Why no AVCaptureSession in this file: a CMIO Camera Extension
-/// CANNOT use AVFoundation to capture from physical cameras
-/// without triggering an IOKit-level deadlock — AVFoundation's
-/// device enumeration walks the CMIO device list, which includes
-/// the very extension making the call, and concurrent client apps
-/// (e.g. Photo Booth) wedge waiting on the loop. The supported
-/// pattern (used by OBS, mmhmm, Hand Mirror, Camo, etc.) is to
-/// capture in the host app and forward frames to the extension
-/// over XPC. That work lives in M3 of the V2 plan; until M3
-/// lands, this stream stays a black-frame placeholder.
+/// The .source direction stream — what AVCapture clients (Zoom,
+/// FaceTime, Slack, …) read from. Pure relay endpoint: frames are
+/// pushed in by `CameraExtensionDeviceSource` after it consumes
+/// them from the sibling sink stream. The host app writes frames
+/// to the sink; the device source forwards each consumed frame
+/// here via `stream.send(...)`.
 final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
     private(set) var stream: CMIOExtensionStream!
     private let streamFormat: CMIOExtensionStreamFormat
+    weak var device: CameraExtensionDeviceSource?
 
-    private var timer: DispatchSourceTimer?
-    private let timerQueue = DispatchQueue(
-        label: "com.ericwillis.avpainreliever.cameraext.framepump",
-        qos: .userInteractive
-    )
-    private var pixelBufferPool: CVPixelBufferPool?
-    private var sequenceNumber: UInt64 = 0
+    /// Number of currently-active CMIO clients reading this stream.
+    /// `device` checks this before forwarding consumed frames so we
+    /// don't waste cycles encoding when no one's watching.
+    private(set) var streamingCounter: UInt32 = 0
 
     static let frameWidth: Int32 = 1280
     static let frameHeight: Int32 = 720
@@ -95,98 +81,10 @@ final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
     func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool { true }
 
     func startStream() throws {
-        try ensurePixelBufferPool()
-        sequenceNumber = 0
-
-        let timer = DispatchSource.makeTimerSource(flags: .strict, queue: timerQueue)
-        let interval = DispatchTimeInterval.nanoseconds(
-            Int(1_000_000_000.0 / 30.0)
-        )
-        timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(2))
-        timer.setEventHandler { [weak self] in
-            self?.emitFrame()
-        }
-        self.timer = timer
-        timer.resume()
+        streamingCounter += 1
     }
 
     func stopStream() throws {
-        timer?.cancel()
-        timer = nil
-    }
-
-    private func ensurePixelBufferPool() throws {
-        if pixelBufferPool != nil { return }
-        let attrs: [String: Any] = [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-            kCVPixelBufferWidthKey as String: Self.frameWidth,
-            kCVPixelBufferHeightKey as String: Self.frameHeight,
-            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
-        ]
-        var pool: CVPixelBufferPool?
-        let status = CVPixelBufferPoolCreate(
-            kCFAllocatorDefault,
-            nil,
-            attrs as CFDictionary,
-            &pool
-        )
-        guard status == kCVReturnSuccess, let pool else {
-            throw NSError(
-                domain: "AVPainRelieverCameraExtension",
-                code: Int(status),
-                userInfo: [NSLocalizedDescriptionKey: "CVPixelBufferPoolCreate failed"]
-            )
-        }
-        self.pixelBufferPool = pool
-    }
-
-    private func emitFrame() {
-        guard let pool = pixelBufferPool else { return }
-        var pixelBuffer: CVPixelBuffer?
-        guard
-            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
-                == kCVReturnSuccess,
-            let pixelBuffer
-        else { return }
-
-        CVPixelBufferLockBaseAddress(pixelBuffer, [])
-        if let base = CVPixelBufferGetBaseAddress(pixelBuffer) {
-            let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-            let height = CVPixelBufferGetHeight(pixelBuffer)
-            memset(base, 0, bytesPerRow * height)
-        }
-        CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
-
-        var formatDescription: CMFormatDescription?
-        CMVideoFormatDescriptionCreateForImageBuffer(
-            allocator: kCFAllocatorDefault,
-            imageBuffer: pixelBuffer,
-            formatDescriptionOut: &formatDescription
-        )
-        guard let formatDescription else { return }
-
-        let timestamp = CMClockGetTime(CMClockGetHostTimeClock())
-        var timing = CMSampleTimingInfo(
-            duration: Self.frameDuration,
-            presentationTimeStamp: timestamp,
-            decodeTimeStamp: .invalid
-        )
-
-        var sampleBuffer: CMSampleBuffer?
-        let createStatus = CMSampleBufferCreateReadyWithImageBuffer(
-            allocator: kCFAllocatorDefault,
-            imageBuffer: pixelBuffer,
-            formatDescription: formatDescription,
-            sampleTiming: &timing,
-            sampleBufferOut: &sampleBuffer
-        )
-        guard createStatus == noErr, let sampleBuffer else { return }
-
-        sequenceNumber &+= 1
-        stream.send(
-            sampleBuffer,
-            discontinuity: [],
-            hostTimeInNanoseconds: UInt64(timestamp.seconds * Double(NSEC_PER_SEC))
-        )
+        if streamingCounter > 0 { streamingCounter -= 1 }
     }
 }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStreamSink.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStreamSink.swift
@@ -1,6 +1,12 @@
 import Foundation
 import CoreMediaIO
 import CoreMedia
+import os.log
+
+private let logger = Logger(
+    subsystem: "com.ericwillis.avpainreliever.CameraExtension",
+    category: "Sink"
+)
 
 /// The .sink direction stream — what the host app writes to via
 /// `CMSimpleQueueEnqueue`. Despite the protocol name
@@ -80,16 +86,22 @@ final class CameraExtensionStreamSink: NSObject, CMIOExtensionStreamSource {
         throws {}
 
     func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool {
+        logger.info("authorizedToStartStream")
         self.client = client
         return true
     }
 
     func startStream() throws {
-        guard let client else { return }
+        logger.info("startStream")
+        guard let client else {
+            logger.error("startStream called without client")
+            return
+        }
         device?.sinkStartedStreaming(client: client)
     }
 
     func stopStream() throws {
+        logger.info("stopStream")
         device?.sinkStoppedStreaming()
         client = nil
     }

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStreamSink.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStreamSink.swift
@@ -1,0 +1,96 @@
+import Foundation
+import CoreMediaIO
+import CoreMedia
+
+/// The .sink direction stream — what the host app writes to via
+/// `CMSimpleQueueEnqueue`. Despite the protocol name
+/// `CMIOExtensionStreamSource`, this stream is a sink (consumer of
+/// frames), not a source. Naming inherited from CMIO.
+///
+/// The host opens "AV Pain Reliever" as a CMIO device, finds this
+/// stream, gets its `CMSimpleQueue` via `CMIOStreamCopyBufferQueue`,
+/// then calls `CMIODeviceStartStream` and starts enqueueing
+/// `CMSampleBuffer`s. The kernel's CMIO subsystem handles
+/// cross-process IOSurface sharing — no XPC needed.
+///
+/// `CameraExtensionDeviceSource` reads frames out of here via
+/// `stream.consumeSampleBuffer(from: client)` and forwards each
+/// to the source stream that AVCapture clients watch.
+final class CameraExtensionStreamSink: NSObject, CMIOExtensionStreamSource {
+    private(set) var stream: CMIOExtensionStream!
+    private let streamFormat: CMIOExtensionStreamFormat
+    weak var device: CameraExtensionDeviceSource?
+
+    /// The CMIO client that started this sink. Captured in
+    /// `authorizedToStartStream` so the device source can pass it
+    /// to `consumeSampleBuffer(from:)`.
+    var client: CMIOExtensionClient?
+
+    init(
+        localizedName: String,
+        streamID: UUID,
+        streamFormat: CMIOExtensionStreamFormat
+    ) {
+        self.streamFormat = streamFormat
+        super.init()
+        self.stream = CMIOExtensionStream(
+            localizedName: localizedName,
+            streamID: streamID,
+            direction: .sink,
+            clockType: .hostTime,
+            source: self
+        )
+    }
+
+    var formats: [CMIOExtensionStreamFormat] { [streamFormat] }
+
+    var availableProperties: Set<CMIOExtensionProperty> {
+        [
+            .streamActiveFormatIndex,
+            .streamFrameDuration,
+            .streamSinkBufferQueueSize,
+            .streamSinkBuffersRequiredForStartup,
+            .streamSinkBufferUnderrunCount,
+            .streamSinkEndOfData,
+        ]
+    }
+
+    func streamProperties(forProperties properties: Set<CMIOExtensionProperty>)
+        throws -> CMIOExtensionStreamProperties
+    {
+        let p = CMIOExtensionStreamProperties(dictionary: [:])
+        if properties.contains(.streamActiveFormatIndex) {
+            p.activeFormatIndex = 0
+        }
+        if properties.contains(.streamFrameDuration) {
+            p.frameDuration = CameraExtensionStreamSource.frameDuration
+        }
+        // Queue size of 1 keeps latency minimal — we drain on every
+        // consume tick, no need to buffer more.
+        if properties.contains(.streamSinkBufferQueueSize) {
+            p.sinkBufferQueueSize = 1
+        }
+        if properties.contains(.streamSinkBuffersRequiredForStartup) {
+            p.sinkBuffersRequiredForStartup = 1
+        }
+        return p
+    }
+
+    func setStreamProperties(_ streamProperties: CMIOExtensionStreamProperties)
+        throws {}
+
+    func authorizedToStartStream(for client: CMIOExtensionClient) -> Bool {
+        self.client = client
+        return true
+    }
+
+    func startStream() throws {
+        guard let client else { return }
+        device?.sinkStartedStreaming(client: client)
+    }
+
+    func stopStream() throws {
+        device?.sinkStoppedStreaming()
+        client = nil
+    }
+}

--- a/Sources/AVPainRelieverCameraExtension/main.swift
+++ b/Sources/AVPainRelieverCameraExtension/main.swift
@@ -1,5 +1,13 @@
 import Foundation
 import CoreMediaIO
+import os.log
+
+private let mainLogger = Logger(
+    subsystem: "com.ericwillis.avpainreliever.CameraExtension",
+    category: "Main"
+)
+
+mainLogger.info("Camera Extension process starting up")
 
 // Camera Extension entry point. Lives in its own process — this
 // binary is wrapped as `.systemextension` by
@@ -20,5 +28,7 @@ import CoreMediaIO
 // IOSurfaces between processes for free, no XPC involved.
 
 let providerSource = CameraExtensionProviderSource(clientQueue: nil)
+mainLogger.info("Provider source initialised, calling CMIOExtensionProvider.startService")
 CMIOExtensionProvider.startService(provider: providerSource.provider)
+mainLogger.info("Service started, entering CFRunLoopRun")
 CFRunLoopRun()

--- a/Sources/AVPainRelieverCameraExtension/main.swift
+++ b/Sources/AVPainRelieverCameraExtension/main.swift
@@ -9,11 +9,15 @@ import CoreMediaIO
 // macOS launches this on demand when the host app activates the
 // extension via OSSystemExtensionRequest, then keeps it running as
 // long as any AVCapture client (Zoom, FaceTime, Slack, ...) has the
-// "AV Pain Reliever" camera selected.
+// "AV Pain Reliever" camera selected, OR while the host app has
+// the sink stream open and is pushing frames in.
 //
-// M1 scope: vend a black 1280x720 frame at 30 fps. No source-camera
-// switching, no XPC. Just enough to prove the activation/embedding/
-// signing plumbing end-to-end.
+// Architecture: the extension owns a CMIO device with two streams.
+// The .source stream is what AVCapture clients read from. The
+// .sink stream is what the host app writes frames into via
+// CMSimpleQueueEnqueue. The device source pumps frames sink →
+// source via `consumeSampleBuffer`. macOS's CMIO subsystem passes
+// IOSurfaces between processes for free, no XPC involved.
 
 let providerSource = CameraExtensionProviderSource(clientQueue: nil)
 CMIOExtensionProvider.startService(provider: providerSource.provider)

--- a/Sources/AVPainRelieverCameraExtension/main.swift
+++ b/Sources/AVPainRelieverCameraExtension/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreMediaIO
+
+// Camera Extension entry point. Lives in its own process — this
+// binary is wrapped as `.systemextension` by
+// scripts/make-app-with-virtual-camera.sh and embedded inside
+// AVPainReliever.app at Contents/Library/SystemExtensions/.
+//
+// macOS launches this on demand when the host app activates the
+// extension via OSSystemExtensionRequest, then keeps it running as
+// long as any AVCapture client (Zoom, FaceTime, Slack, ...) has the
+// "AV Pain Reliever" camera selected.
+//
+// M1 scope: vend a black 1280x720 frame at 30 fps. No source-camera
+// switching, no XPC. Just enough to prove the activation/embedding/
+// signing plumbing end-to-end.
+
+let providerSource = CameraExtensionProviderSource(clientQueue: nil)
+CMIOExtensionProvider.startService(provider: providerSource.provider)
+CFRunLoopRun()

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -537,6 +537,74 @@ struct AddProfileViewModelTests {
         #expect(vm.selectedDeviceIDs.isEmpty)
         #expect(vm.willMatchAnywhere == true)
     }
+
+    // MARK: - Virtual camera filtering
+
+    @Test("hides AV Pain Reliever from the camera picker")
+    func filtersVirtualCameraFromList() {
+        let camera = FakeCamera(cameras: [
+            "Logitech BRIO",
+            "AV Pain Reliever",
+            "MacBook Pro Camera",
+        ])
+        let vm = AddProfileViewModel(
+            watcher: FakeWatcher(),
+            audioController: FakeAudio(devices: []),
+            cameraController: camera,
+            configURL: URL(fileURLWithPath: "/tmp/x.toml"),
+            virtualCameraEnabled: true,
+            onSaved: {}
+        )
+        let names = vm.cameras.map(\.name)
+        // The virtual camera is an *output*; the per-profile picker
+        // is for choosing the real source camera.
+        #expect(!names.contains("AV Pain Reliever"))
+        #expect(names.contains("Logitech BRIO"))
+        #expect(names.contains("MacBook Pro Camera"))
+    }
+
+    @Test("clears a saved camera value that points at the virtual camera (legacy profiles)")
+    func sanitizesLegacyVirtualCameraSelection() {
+        let editing = Profile(
+            name: "home-office",
+            fingerprint: [],
+            camera: "AV Pain Reliever"
+        )
+        let vm = AddProfileViewModel(
+            watcher: FakeWatcher(),
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: ["Logitech BRIO"]),
+            configURL: URL(fileURLWithPath: "/tmp/x.toml"),
+            editing: editing,
+            virtualCameraEnabled: true,
+            onSaved: {}
+        )
+        // Legacy profile shouldn't pre-fill a now-hidden value.
+        #expect(vm.camera == nil)
+    }
+
+    @Test("currentPreferredName fallback skips the virtual camera")
+    func preFillSkipsVirtualCamera() {
+        // Mirrors a real machine where userPreferredCamera was set
+        // to the virtual camera by ProfileApplier under the new
+        // override semantics.
+        let camera = FakeCamera(
+            cameras: ["Logitech BRIO"],
+            currentPreferred: "AV Pain Reliever"
+        )
+        let vm = AddProfileViewModel(
+            watcher: FakeWatcher(),
+            audioController: FakeAudio(devices: []),
+            cameraController: camera,
+            configURL: URL(fileURLWithPath: "/tmp/x.toml"),
+            virtualCameraEnabled: true,
+            onSaved: {}
+        )
+        // Pre-fill should land on nil (the picker's "Don't change"
+        // entry) rather than auto-selecting a value the user can't
+        // see in the list.
+        #expect(vm.camera == nil)
+    }
 }
 
 // MARK: - Test fakes
@@ -564,7 +632,14 @@ private struct FakeAudio: AudioController {
 
 private struct FakeCamera: CameraController {
     let cameras: [String]
+    let currentPreferred: String?
+
+    init(cameras: [String], currentPreferred: String? = nil) {
+        self.cameras = cameras
+        self.currentPreferred = currentPreferred
+    }
+
     func setPreferred(named: String) -> CameraApplyResult { .ok }
     func availableCameras() -> [CameraSummary] { cameras.map { CameraSummary(name: $0) } }
-    func currentPreferredName() -> String? { nil }
+    func currentPreferredName() -> String? { currentPreferred }
 }

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -24,6 +24,10 @@ struct SettingsStoreTests {
         // Launch-at-login defaults off — fresh users opt in, per
         // macOS background-task etiquette.
         #expect(store.launchAtLogin == false)
+        // Virtual camera defaults off — installs a system extension,
+        // so opt-in is mandatory both for principle and for
+        // notarization etiquette.
+        #expect(store.virtualCameraEnabled == false)
     }
 
     @Test("launchAtLogin persists across reloads")
@@ -83,5 +87,16 @@ struct SettingsStoreTests {
         }
         let reopened = SettingsStore(defaults: defaults)
         #expect(reopened.suppressedWelcome == true)
+    }
+
+    @Test("virtualCameraEnabled persists across reloads")
+    func virtualCameraEnabledPersists() {
+        let defaults = makeSuite()
+        do {
+            let store = SettingsStore(defaults: defaults)
+            store.virtualCameraEnabled = true
+        }
+        let reopened = SettingsStore(defaults: defaults)
+        #expect(reopened.virtualCameraEnabled == true)
     }
 }

--- a/Tests/AVPainRelieverAppTests/UpdaterGatingTests.swift
+++ b/Tests/AVPainRelieverAppTests/UpdaterGatingTests.swift
@@ -68,4 +68,45 @@ struct UpdaterGatingTests {
         // they must update both places. This guard catches the drift.
         #expect(Updater.publicKeyPlaceholder == "__SPARKLE_PUBLIC_KEY__")
     }
+
+    // MARK: - Experimental version classifier
+    //
+    // Mirrors the workflow's tag-prefix dispatch:
+    // v0.0.x / v0.1.x → stable, anything else → experimental.
+
+    @Test("0.1.x versions are stable")
+    func zeroOneIsStable() {
+        #expect(Updater.isExperimentalVersion("0.1.0") == false)
+        #expect(Updater.isExperimentalVersion("0.1.15") == false)
+    }
+
+    @Test("0.2.x versions are experimental")
+    func zeroTwoIsExperimental() {
+        #expect(Updater.isExperimentalVersion("0.2.0") == true)
+        #expect(Updater.isExperimentalVersion("0.2.0.2") == true)
+    }
+
+    @Test("0.0.x dryrun versions are stable")
+    func zeroZeroIsStable() {
+        #expect(Updater.isExperimentalVersion("0.0.0-dryrun") == false)
+    }
+
+    @Test("1.x and beyond is experimental until graduated")
+    func futureMajorVersionsAreExperimental() {
+        #expect(Updater.isExperimentalVersion("1.0.0") == true)
+        #expect(Updater.isExperimentalVersion("2.5.7") == true)
+    }
+
+    @Test("malformed version strings classify as stable (defensive)")
+    func malformedVersionsAreStable() {
+        #expect(Updater.isExperimentalVersion("") == false)
+        #expect(Updater.isExperimentalVersion("garbage") == false)
+        #expect(Updater.isExperimentalVersion("0") == false)
+    }
+
+    @Test("iter-suffixed dev versions match their numeric prefix")
+    func iterSuffixedVersionsParse() {
+        #expect(Updater.isExperimentalVersion("0.2.0-iter-m3") == true)
+        #expect(Updater.isExperimentalVersion("0.1.14-rc1") == false)
+    }
 }

--- a/Tests/AVPainRelieverTests/ProfileApplierTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileApplierTests.swift
@@ -51,6 +51,20 @@ struct ProfileApplierTests {
         func currentPreferredName() -> String? { currentPreferredNameStub }
     }
 
+    final class MockVirtualCameraSource: VirtualCameraSourceController {
+        struct Call: Equatable {
+            let name: String
+        }
+        private(set) var calls: [Call] = []
+        var resultsByName: [String: CameraApplyResult] = [:]
+        var defaultResult: CameraApplyResult = .ok
+
+        func setSource(named: String) -> CameraApplyResult {
+            calls.append(Call(name: named))
+            return resultsByName[named] ?? defaultResult
+        }
+    }
+
     final class MockLogger: ApplierLogger {
         private(set) var infos: [String] = []
         private(set) var warns: [String] = []
@@ -235,6 +249,87 @@ struct ProfileApplierTests {
         applier.apply(Self.homeOffice) // no camera field set
 
         #expect(camera.calls.isEmpty)
+    }
+
+    // MARK: - Virtual camera source
+
+    @Test("drives virtual camera source with the same name as the system camera")
+    func appliesVirtualCameraSource() {
+        let camera = MockCamera()
+        let source = MockVirtualCameraSource()
+        let log = MockLogger()
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            camera: camera,
+            virtualCameraSource: source,
+            logger: log
+        )
+        let p = Profile(
+            name: "home",
+            fingerprint: [],
+            camera: "LG UltraFine Display Camera"
+        )
+
+        applier.apply(p)
+
+        #expect(camera.calls == [.init(name: "LG UltraFine Display Camera")])
+        #expect(source.calls == [.init(name: "LG UltraFine Display Camera")])
+        #expect(log.infos.contains { $0.contains("set virtual camera source: LG UltraFine") })
+    }
+
+    @Test("warns when virtual camera source is not currently attached")
+    func warnsWhenVirtualCameraSourceMissing() {
+        let source = MockVirtualCameraSource()
+        source.resultsByName["LG UltraFine Display Camera"] = .notFound
+        let log = MockLogger()
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            virtualCameraSource: source,
+            logger: log
+        )
+        let p = Profile(
+            name: "home",
+            fingerprint: [],
+            camera: "LG UltraFine Display Camera"
+        )
+
+        applier.apply(p)
+
+        #expect(log.warns.contains {
+            $0.contains("virtual camera source") && $0.contains("not found")
+        })
+    }
+
+    @Test("silently skips virtual camera source when not configured")
+    func skipsVirtualCameraSourceWithoutController() {
+        let log = MockLogger()
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            virtualCameraSource: nil,
+            logger: log
+        )
+        let p = Profile(
+            name: "home",
+            fingerprint: [],
+            camera: "Some Camera"
+        )
+
+        applier.apply(p)
+
+        #expect(!log.warns.contains { $0.contains("virtual camera source") })
+    }
+
+    @Test("does not touch virtual camera source when profile.camera is nil")
+    func skipsNilVirtualCameraSource() {
+        let source = MockVirtualCameraSource()
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            virtualCameraSource: source,
+            logger: MockLogger()
+        )
+        applier.apply(Self.homeOffice) // no camera field
+
+        #expect(source.calls.isEmpty)
     }
 
     @Test("applying a different profile after a no-op fires side effects again")

--- a/Tests/AVPainRelieverTests/ProfileApplierTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileApplierTests.swift
@@ -58,6 +58,7 @@ struct ProfileApplierTests {
         private(set) var calls: [Call] = []
         var resultsByName: [String: CameraApplyResult] = [:]
         var defaultResult: CameraApplyResult = .ok
+        var preferredCameraOverride: String? = nil
 
         func setSource(named: String) -> CameraApplyResult {
             calls.append(Call(name: named))
@@ -342,6 +343,76 @@ struct ProfileApplierTests {
         applier.apply(Self.laptop)     // change
 
         // 2 input/output calls per non-no-op apply × 2 actual applies = 4
+        #expect(audio.calls.count == 4)
+    }
+
+    // MARK: - Preferred-camera override
+
+    @Test("when virtual camera reports an override, system preferred camera uses it; source still gets profile.camera")
+    func virtualCameraOverrideRoutesPreferred() {
+        let camera = MockCamera()
+        let source = MockVirtualCameraSource()
+        source.preferredCameraOverride = "AV Pain Reliever"
+        let log = MockLogger()
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            camera: camera,
+            virtualCameraSource: source,
+            logger: log
+        )
+        let p = Profile(
+            name: "home",
+            fingerprint: [],
+            camera: "Logitech BRIO"
+        )
+
+        applier.apply(p)
+
+        // System-wide preferred goes to the virtual camera so
+        // FaceTime/Safari route through it the same way Zoom does.
+        #expect(camera.calls == [.init(name: "AV Pain Reliever")])
+        // Virtual camera's *source* still gets the real camera —
+        // that's the actual webcam frames feed.
+        #expect(source.calls == [.init(name: "Logitech BRIO")])
+    }
+
+    @Test("nil override falls back to profile.camera for both calls")
+    func nilOverridePreservesLegacyBehavior() {
+        let camera = MockCamera()
+        let source = MockVirtualCameraSource()
+        // Override left at default nil — represents virtual camera
+        // off / activating / failed.
+        let applier = ProfileApplier(
+            audio: MockAudio(),
+            camera: camera,
+            virtualCameraSource: source,
+            logger: MockLogger()
+        )
+        let p = Profile(
+            name: "home",
+            fingerprint: [],
+            camera: "Logitech BRIO"
+        )
+
+        applier.apply(p)
+
+        #expect(camera.calls == [.init(name: "Logitech BRIO")])
+        #expect(source.calls == [.init(name: "Logitech BRIO")])
+    }
+
+    // MARK: - Forced re-apply
+
+    @Test("invalidateLastApplied lets the next apply re-fire side effects on the same profile")
+    func invalidateLastAppliedReFiresOnSameProfile() {
+        let audio = MockAudio()
+        let applier = ProfileApplier(audio: audio, logger: MockLogger())
+
+        applier.apply(Self.homeOffice)
+        applier.apply(Self.homeOffice) // dedupe → no-op
+        applier.invalidateLastApplied()
+        applier.apply(Self.homeOffice) // re-fires
+
+        // 2 calls per real apply × 2 real applies = 4
         #expect(audio.calls.count == 4)
     }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,10 +1,19 @@
 # Releasing AV Pain Reliever
 
 The release pipeline is defined in `.github/workflows/release.yml` and
-triggered by pushing a `v*.*.*` git tag. Until the seven GitHub Secrets
-listed below are populated, every step that depends on Apple credentials
-or the Sparkle private key skips with a warning, so a `v0.0.0-dryrun`
-tag can verify the workflow shape without exposing anything sensitive.
+triggered by pushing a `v*.*.*` git tag. The workflow picks the build
+script from the tag prefix:
+
+- **v0.1.x** tags build with `scripts/make-app.sh` — the original
+  no-virtual-camera bundle. Keeps shipping unblocked from `main`.
+- **v0.2.x+** tags build with `scripts/make-app-with-virtual-camera.sh`
+  — the bundle that embeds the CMIO Camera Extension. Tagged from
+  `feature/virtual-camera`.
+
+Until the GitHub Secrets listed below are populated, every step that
+depends on Apple credentials or the Sparkle private key skips with a
+warning, so a `v0.0.0-dryrun` tag can verify the workflow shape
+without exposing anything sensitive.
 
 This doc is the runbook for getting from "secrets unset" to "first
 real signed release."
@@ -71,17 +80,25 @@ file** once it's safe.
 ### 3. GitHub Secrets
 
 In the repo: **Settings → Secrets and variables → Actions → New
-repository secret**. Add these seven:
+repository secret**. Add these eight:
 
 | Name                          | Source                                                                 |
 | ----------------------------- | ---------------------------------------------------------------------- |
 | `MACOS_CERTIFICATE`           | `base64 -i cert.p12 \| pbcopy` — paste                                  |
 | `MACOS_CERTIFICATE_PASSWORD`  | The password you set when exporting the `.p12`                          |
 | `MACOS_KEYCHAIN_PASSWORD`     | Random — `openssl rand -base64 32 \| pbcopy`                            |
+| `MACOS_PROVISIONING_PROFILE`  | `base64 -i AVPainReliever.provisionprofile \| pbcopy` — only required for v0.2.x+ |
 | `APPLE_ID`                    | Your developer Apple ID email (the one you used to enrol in the Developer Program) |
 | `APPLE_ID_PASSWORD`           | App-specific password from step 4 above                                 |
 | `APPLE_TEAM_ID`               | 10-char Team ID from step 5 above                                       |
 | `SPARKLE_PRIVATE_KEY`         | `cat sparkle-private-key.txt \| pbcopy` — paste raw (no extra newlines) |
+
+`MACOS_PROVISIONING_PROFILE` is only consulted for tags that match
+v0.2.x or later (the virtual-camera build); v0.1.x patch releases
+skip the decode step entirely. Generate the profile at
+developer.apple.com → Profiles → New → Developer ID, bound to the
+host App ID (`com.ericwillis.avpainreliever`) with the System
+Extension capability enabled.
 
 Or via `gh` (run from the repo root once `gh auth login` is set up):
 
@@ -89,6 +106,7 @@ Or via `gh` (run from the repo root once `gh auth login` is set up):
 gh secret set MACOS_CERTIFICATE          < <(base64 -i cert.p12)
 gh secret set MACOS_CERTIFICATE_PASSWORD --body 'your-p12-password'
 gh secret set MACOS_KEYCHAIN_PASSWORD    --body "$(openssl rand -base64 32)"
+gh secret set MACOS_PROVISIONING_PROFILE < <(base64 -i AVPainReliever.provisionprofile)
 gh secret set APPLE_ID                   --body 'you@example.com'
 gh secret set APPLE_ID_PASSWORD          --body 'xxxx-xxxx-xxxx-xxxx'
 gh secret set APPLE_TEAM_ID              --body 'XXXXXXXXXX'

--- a/docs/VIRTUAL_CAMERA_DEV.md
+++ b/docs/VIRTUAL_CAMERA_DEV.md
@@ -17,35 +17,47 @@ workflow if you need it for some reason.
 ### 1. App IDs at developer.apple.com
 
 Sign in to [developer.apple.com](https://developer.apple.com) with
-the Apple ID for your developer account (the personal account
-e@ericwillis.com — *not* the BACtrack one).
+the personal Apple ID account (e@ericwillis.com).
 
-Go to **Certificates, Identifiers & Profiles → Identifiers**:
+Go to **Certificates, Identifiers & Profiles → Identifiers**.
+Register two App IDs:
 
-- **`com.ericwillis.avpainreliever`** (the host app):
-    - Should already exist from v0.1.x. If not, create it as type
-      "App IDs / App."
-    - Edit it. Under **Capabilities**, check **System Extension**.
-      Save.
-- **`com.ericwillis.avpainreliever.CameraExtension`** (the
-  extension):
-    - Create it as type "App IDs / App."
-    - No special capabilities needed beyond the defaults.
+- **`com.ericwillis.avpainreliever`** (host app):
+    - Description: "AV Pain Reliever"
+    - Capabilities: tick **System Extension** and **App Groups**.
+- **`com.ericwillis.avpainreliever.CameraExtension`** (extension):
+    - Description: "AV Pain Reliever Camera Extension"
+    - Capabilities: tick **App Groups**.
 
-The bundle IDs must be a parent/child pair — if the host app's ID
-changes, the extension's ID has to change to match.
+Bundle IDs must be a parent/child pair — if the host changes, the
+extension's ID has to change to match.
 
-### 2. Provisioning profile
+### 2. App Group
 
-Still at developer.apple.com, go to **Profiles → New**:
+Still in **Identifiers**, click **+** → **App Groups** →
+Continue:
+
+- Description: "AV Pain Reliever Group"
+- Identifier: `group.com.ericwillis.avpainreliever`
+
+Apple requires the `group.` prefix on new App Groups. The
+team-prefixed form (`HLH4LEWS9S.group.com.ericwillis.avpainreliever`)
+is what ends up in entitlements and the extension's
+`CMIOExtensionMachServiceName`.
+
+Then go back to each App ID, click **Configure** next to App
+Groups, and select the newly registered group. Save.
+
+### 3. Provisioning profile
+
+**Profiles → New**:
 
 - Type: **Developer ID** (under Distribution).
 - App ID: `com.ericwillis.avpainreliever`.
 - Certificate: your Developer ID Application cert (the same one
   v0.1.x uses).
-- Name: something descriptive like
-  "AV Pain Reliever Developer ID."
-- Download the `.provisionprofile` file.
+- Name: "AV Pain Reliever Developer ID" or similar.
+- Download.
 
 Drop it into the repo at:
 
@@ -56,7 +68,10 @@ Resources/AVPainReliever.provisionprofile
 This path is gitignored — it's team-specific and regenerable, no
 need to commit. Each developer / CI runner provisions their own.
 
-### 3. Confirm your signing identity is in keychain
+If you later add or change a capability on the host App ID, the
+profile invalidates — re-download and overwrite.
+
+### 4. Confirm your signing identity is in keychain
 
 The build script reads `$MAC_CERT_NAME` to pick the cert. Same one
 you use for v0.1.x. Verify it's in keychain:
@@ -68,6 +83,22 @@ security find-identity -v -p codesigning | grep "Developer ID Application"
 You should see the cert with your team ID in parens. Note the
 exact display name — that's what `MAC_CERT_NAME` should be set to.
 
+### 5. Notarization keychain profile
+
+System extensions can't be activated by macOS without a notarized
+bundle, even with valid Developer ID signing. The build script
+runs notarization via `xcrun notarytool` against a keychain
+profile you've already set up for v0.1.x — see
+`docs/RELEASING.md` for the one-time
+`xcrun notarytool store-credentials avpain-notary` step.
+
+If you've ever notarized a v0.1.x release locally, you have it.
+Confirm:
+
+```sh
+xcrun notarytool history --keychain-profile avpain-notary
+```
+
 ## Build + install loop
 
 ### Build the bundle
@@ -76,6 +107,7 @@ From the repo root:
 
 ```sh
 MAC_CERT_NAME="Developer ID Application: Eric Willis (TEAMID)" \
+    NOTARIZE_KEYCHAIN_PROFILE=avpain-notary \
     scripts/make-app-with-virtual-camera.sh
 ```
 
@@ -83,13 +115,19 @@ Replace the cert name with whatever `security find-identity`
 showed you. The script:
 1. Builds both Swift products (universal arm64+x86_64).
 2. Assembles `AVPainReliever.app` and the embedded
-   `.systemextension` bundle.
+   `.systemextension` bundle, substituting the team ID into the
+   extension's `CMIOExtensionMachServiceName`.
 3. Embeds Sparkle.framework + the provisioning profile.
 4. Signs inside-out: Sparkle nested → Sparkle.framework →
    Camera Extension → host app.
+5. Notarizes via `xcrun notarytool` and staples the ticket.
 
-Output: `dist/AVPainReliever.app`. The script will fail loudly if
-the provisioning profile is missing.
+Output: `dist/AVPainReliever.app`. Notarization adds ~30s–2 min
+per build. If you're iterating on something that doesn't need
+fresh activation, omit `NOTARIZE_KEYCHAIN_PROFILE` to skip — the
+script will warn that the build can't activate as a system
+extension. The script will fail loudly if the provisioning
+profile is missing.
 
 ### Move into /Applications
 
@@ -105,17 +143,25 @@ ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
 ### Activate
 
 The activation is gated by an env var so it doesn't fire on every
-launch:
+launch. **Important**: pass it via `--env`, not the shell-prefix
+form — `open` strips the calling shell's environment when handing
+off to launchd.
 
 ```sh
-AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
+open --env AVPR_ACTIVATE_VIRTUAL_CAMERA=1 /Applications/AVPainReliever.app
 ```
 
-macOS will prompt for approval in System Settings → Privacy &
-Security → "Allow extension from AV Pain Reliever." Click Allow.
+macOS prompts you to approve in **System Settings → General →
+Login Items & Extensions → Camera Extensions**. Find "AV Pain
+Reliever Camera Extension" and toggle it on.
 
-Watch Console.app filtered by "AVPR" for activation lifecycle
-messages.
+Watch sysextd state transitions:
+
+```sh
+log stream --predicate 'process == "sysextd"' --style compact
+```
+
+Healthy sequence: `validating → validating_by_category → activated_waiting_for_user → activated_enabled` after you click Allow.
 
 Verify it's registered:
 
@@ -140,15 +186,18 @@ other AVCapture-modern client also work.
 After code changes:
 
 ```sh
-MAC_CERT_NAME="…" scripts/make-app-with-virtual-camera.sh
+pkill -f AVPainRelieverApp
+MAC_CERT_NAME="…" NOTARIZE_KEYCHAIN_PROFILE=avpain-notary \
+    scripts/make-app-with-virtual-camera.sh
+rm -rf /Applications/AVPainReliever.app
 ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
-# Optional: re-activate if the extension was uninstalled
-AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
+# Re-activate if the extension was uninstalled or the bundle ID changed:
+open --env AVPR_ACTIVATE_VIRTUAL_CAMERA=1 /Applications/AVPainReliever.app
 ```
 
 macOS handles in-place upgrades transparently when the bundle ID
-matches and the new build is properly signed — no need to
-uninstall first for routine code changes.
+matches and the new build is properly signed and notarized — no
+need to uninstall first for routine code changes.
 
 ## Uninstall / clean slate
 
@@ -173,31 +222,43 @@ in the sidebar.
 
 ## Common failure modes
 
-- **"Code signature missing entitlements"** on activation: host app
-  is missing `com.apple.developer.system-extension.install`. Either
-  the v0.2.0 entitlements file
-  (`Resources/AVPainReliever-WithVirtualCamera.entitlements`) wasn't
-  used by the build script, or the provisioning profile doesn't
-  declare the entitlement. Confirm both.
+Each error below is the message you'll see in the `sysextd` log
+stream, followed by what to fix.
+
+- **"system extension does not appear to belong to any extension
+  categories"**: the extension's Info.plist is missing the
+  `CMIOExtension` dict. The build script substitutes
+  `__TEAM_ID__` into the Mach service name; if you see literal
+  `__TEAM_ID__` in the bundle, `MAC_CERT_NAME` parsing failed.
+- **"bundle code signature is not valid - does not satisfy
+  requirement: -67050"** with **"Error checking with
+  notarization daemon"**: the build wasn't notarized. Set
+  `NOTARIZE_KEYCHAIN_PROFILE=avpain-notary` and rebuild.
+- **"invalid mach service name or is not signed, the value must
+  be prefixed with one of the App Groups in the entitlement"**:
+  the App Group in the extension's entitlements doesn't match the
+  prefix of the `CMIOExtensionMachServiceName`. Both should be
+  `HLH4LEWS9S.group.com.ericwillis.avpainreliever`.
+- **"Failed to parse entitlements: AMFIUnserializeXML: syntax
+  error"** during codesign: the entitlements plist contains XML
+  comments. AMFI's parser rejects them — strip all `<!-- -->`
+  blocks.
+- **State stuck at `activated_waiting_for_user`**: open System
+  Settings → General → Login Items & Extensions → Camera
+  Extensions and toggle the extension on. The state advances to
+  `activated_enabled` after you approve.
 - **"No matching profile found"** at codesign: the App ID in the
-  profile doesn't match the bundle's CFBundleIdentifier. Check the
-  profile is bound to `com.ericwillis.avpainreliever`, not some
-  other ID.
-- **"Extension does not appear in Zoom"**: check
-  `systemextensionsctl list`. If it's listed but Zoom can't see it,
-  quit and relaunch Zoom — Zoom caches its device list. If it's
-  not listed, re-run the activation step and check Console for
-  `[AVPR]` log lines.
-- **"Activation request never returns"**: usually means the user
-  approval prompt is waiting in System Settings → Privacy &
-  Security. Check that pane and click Allow.
-- **"App can't be activated because it's not in /Applications"**:
-  see the "Move into /Applications" step above.
-- **"Extension found but not in /Library/SystemExtensions"** in
-  Console: macOS tried to copy the extension out of the app bundle
-  and failed — usually because the app was launched from a
-  non-`/Applications` path or the user rejected the approval
-  prompt. Uninstall, fix the path, re-activate.
+  provisioning profile doesn't match the bundle's
+  CFBundleIdentifier. Check the profile is bound to
+  `com.ericwillis.avpainreliever` and includes the App Groups
+  capability.
+- **Extension is `[activated enabled]` but doesn't appear in
+  Zoom**: quit and relaunch Zoom — its camera-device cache is
+  populated at process start. FaceTime and browsers re-enumerate
+  per call.
+- **App didn't get the env var**: the shell-prefix form
+  (`AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open ...`) sets the var only
+  for `open` itself. Use `open --env AVPR_ACTIVATE_VIRTUAL_CAMERA=1`.
 
 ## Fallback: ad-hoc + developer mode (only if you really must)
 

--- a/docs/VIRTUAL_CAMERA_DEV.md
+++ b/docs/VIRTUAL_CAMERA_DEV.md
@@ -5,25 +5,68 @@ Extension on a development Mac. Distribution flow lives in
 `docs/RELEASING.md` once we get there; for now this is the loop
 used while the feature is on `feature/virtual-camera`.
 
+The recommended path uses your normal Developer ID Application
+certificate and a Developer ID provisioning profile — same trust
+chain end users will see in the eventual public release. No SIP
+disable, no developer mode, no ad-hoc shenanigans. There's a
+fallback at the bottom for the ad-hoc + developer-mode + SIP-off
+workflow if you need it for some reason.
+
 ## One-time setup
 
-### 1. Enable system-extension developer mode
+### 1. App IDs at developer.apple.com
 
-```sh
-sudo systemextensionsctl developer on
+Sign in to [developer.apple.com](https://developer.apple.com) with
+the Apple ID for your developer account (the personal account
+e@ericwillis.com — *not* the BACtrack one).
+
+Go to **Certificates, Identifiers & Profiles → Identifiers**:
+
+- **`com.ericwillis.avpainreliever`** (the host app):
+    - Should already exist from v0.1.x. If not, create it as type
+      "App IDs / App."
+    - Edit it. Under **Capabilities**, check **System Extension**.
+      Save.
+- **`com.ericwillis.avpainreliever.CameraExtension`** (the
+  extension):
+    - Create it as type "App IDs / App."
+    - No special capabilities needed beyond the defaults.
+
+The bundle IDs must be a parent/child pair — if the host app's ID
+changes, the extension's ID has to change to match.
+
+### 2. Provisioning profile
+
+Still at developer.apple.com, go to **Profiles → New**:
+
+- Type: **Developer ID** (under Distribution).
+- App ID: `com.ericwillis.avpainreliever`.
+- Certificate: your Developer ID Application cert (the same one
+  v0.1.x uses).
+- Name: something descriptive like
+  "AV Pain Reliever Developer ID."
+- Download the `.provisionprofile` file.
+
+Drop it into the repo at:
+
+```
+Resources/AVPainReliever.provisionprofile
 ```
 
-This relaxes the production-entitlement requirement so locally-
-signed extensions (no Apple-issued provisioning profile, no
-notarization) can install and run. Check status with
-`systemextensionsctl developer`. Leave it on for the duration of
-v0.2.0 development.
+This path is gitignored — it's team-specific and regenerable, no
+need to commit. Each developer / CI runner provisions their own.
 
-### 2. Confirm SIP is on
+### 3. Confirm your signing identity is in keychain
 
-System extensions need SIP **on**, not off. Check with
-`csrutil status`. Disabling SIP for kext development is unrelated
-and would actually break the system-extension flow.
+The build script reads `$MAC_CERT_NAME` to pick the cert. Same one
+you use for v0.1.x. Verify it's in keychain:
+
+```sh
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+You should see the cert with your team ID in parens. Note the
+exact display name — that's what `MAC_CERT_NAME` should be set to.
 
 ## Build + install loop
 
@@ -32,18 +75,27 @@ and would actually break the system-extension flow.
 From the repo root:
 
 ```sh
-scripts/make-app-with-virtual-camera.sh
+MAC_CERT_NAME="Developer ID Application: Eric Willis (TEAMID)" \
+    scripts/make-app-with-virtual-camera.sh
 ```
 
-Produces `dist/AVPainReliever.app` with the embedded extension at
-`Contents/Library/SystemExtensions/com.ericwillis.avpainreliever.CameraExtension.systemextension`.
-Ad-hoc-signed unless `MAC_CERT_NAME` is set — fine for dev.
+Replace the cert name with whatever `security find-identity`
+showed you. The script:
+1. Builds both Swift products (universal arm64+x86_64).
+2. Assembles `AVPainReliever.app` and the embedded
+   `.systemextension` bundle.
+3. Embeds Sparkle.framework + the provisioning profile.
+4. Signs inside-out: Sparkle nested → Sparkle.framework →
+   Camera Extension → host app.
+
+Output: `dist/AVPainReliever.app`. The script will fail loudly if
+the provisioning profile is missing.
 
 ### Move into /Applications
 
-System extensions can only be activated by apps living in
-`/Applications/`. The OS rejects activation requests from
-elsewhere with an unhelpful error.
+System extensions can only be activated by apps running from
+`/Applications`. macOS rejects activation requests from elsewhere
+with an unhelpful error.
 
 ```sh
 rm -rf /Applications/AVPainReliever.app
@@ -59,10 +111,11 @@ launch:
 AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
 ```
 
+macOS will prompt for approval in System Settings → Privacy &
+Security → "Allow extension from AV Pain Reliever." Click Allow.
+
 Watch Console.app filtered by "AVPR" for activation lifecycle
-messages. macOS may prompt for approval in System Settings →
-Privacy & Security → "Allow extension from AV Pain Reliever" — click
-Allow.
+messages.
 
 Verify it's registered:
 
@@ -70,8 +123,7 @@ Verify it's registered:
 systemextensionsctl list
 ```
 
-You should see one entry under
-`com.apple.cmio.cmioextension` for
+You should see one entry under `com.apple.cmio.cmioextension` for
 `com.ericwillis.avpainreliever.CameraExtension` with state
 `activated enabled`.
 
@@ -88,27 +140,24 @@ other AVCapture-modern client also work.
 After code changes:
 
 ```sh
-scripts/make-app-with-virtual-camera.sh
+MAC_CERT_NAME="…" scripts/make-app-with-virtual-camera.sh
 ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
 # Optional: re-activate if the extension was uninstalled
 AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
 ```
 
 macOS handles in-place upgrades transparently when the bundle ID
-matches and developer mode is on — no need to uninstall first for
-routine code changes.
+matches and the new build is properly signed — no need to
+uninstall first for routine code changes.
 
 ## Uninstall / clean slate
 
 ```sh
-systemextensionsctl uninstall - com.ericwillis.avpainreliever.CameraExtension
+systemextensionsctl uninstall <TEAMID> com.ericwillis.avpainreliever.CameraExtension
 ```
 
-The leading `-` is the team identifier placeholder for ad-hoc
-builds. For Developer-ID-signed builds, replace with your team ID
-(e.g., `ABC1234DEF`).
-
-Confirm with `systemextensionsctl list` — entry should be gone.
+Replace `<TEAMID>` with your Apple Developer team ID. Confirm with
+`systemextensionsctl list` — entry should be gone.
 
 ## Logs
 
@@ -125,10 +174,15 @@ in the sidebar.
 ## Common failure modes
 
 - **"Code signature missing entitlements"** on activation: host app
-  is missing `com.apple.developer.system-extension.install`. The
-  v0.2.0 entitlements file
-  (`Resources/AVPainReliever-WithVirtualCamera.entitlements`)
-  declares it; confirm the build script picked the right one.
+  is missing `com.apple.developer.system-extension.install`. Either
+  the v0.2.0 entitlements file
+  (`Resources/AVPainReliever-WithVirtualCamera.entitlements`) wasn't
+  used by the build script, or the provisioning profile doesn't
+  declare the entitlement. Confirm both.
+- **"No matching profile found"** at codesign: the App ID in the
+  profile doesn't match the bundle's CFBundleIdentifier. Check the
+  profile is bound to `com.ericwillis.avpainreliever`, not some
+  other ID.
 - **"Extension does not appear in Zoom"**: check
   `systemextensionsctl list`. If it's listed but Zoom can't see it,
   quit and relaunch Zoom — Zoom caches its device list. If it's
@@ -138,5 +192,33 @@ in the sidebar.
   approval prompt is waiting in System Settings → Privacy &
   Security. Check that pane and click Allow.
 - **"App can't be activated because it's not in /Applications"**:
-  see the "Move into /Applications" step above. System extensions
-  refuse to load from anywhere else.
+  see the "Move into /Applications" step above.
+- **"Extension found but not in /Library/SystemExtensions"** in
+  Console: macOS tried to copy the extension out of the app bundle
+  and failed — usually because the app was launched from a
+  non-`/Applications` path or the user rejected the approval
+  prompt. Uninstall, fix the path, re-activate.
+
+## Fallback: ad-hoc + developer mode (only if you really must)
+
+If you don't want to (or can't) provision properly — say you're
+quickly testing on a machine that isn't yours and Apple ID setup
+isn't worth it — you can use ad-hoc signing with developer mode
+enabled. Cost: SIP has to be **disabled**, which is a real
+security tradeoff. Don't do this on your daily driver unless you
+plan to re-enable SIP afterward and remember to.
+
+1. Reboot to Recovery (hold Power on Apple Silicon, ⌘R on Intel).
+2. In Recovery Terminal: `csrutil disable`.
+3. Reboot back to macOS.
+4. `sudo systemextensionsctl developer on`.
+5. Build without `MAC_CERT_NAME`:
+   `scripts/make-app-with-virtual-camera.sh`.
+6. Continue with the normal install + activate steps above.
+7. When done with v0.2.0 dev: Recovery → `csrutil enable` →
+   reboot. Don't skip this.
+
+The ad-hoc path bypasses Path A's provisioning checks but means
+your build doesn't represent what end users will run, so anything
+that worked here might still break in distribution. Use Path A
+unless there's a specific reason not to.

--- a/docs/VIRTUAL_CAMERA_DEV.md
+++ b/docs/VIRTUAL_CAMERA_DEV.md
@@ -1,0 +1,142 @@
+# Virtual Camera — local dev workflow
+
+Recipe for building, activating, and testing the v0.2.0 Camera
+Extension on a development Mac. Distribution flow lives in
+`docs/RELEASING.md` once we get there; for now this is the loop
+used while the feature is on `feature/virtual-camera`.
+
+## One-time setup
+
+### 1. Enable system-extension developer mode
+
+```sh
+sudo systemextensionsctl developer on
+```
+
+This relaxes the production-entitlement requirement so locally-
+signed extensions (no Apple-issued provisioning profile, no
+notarization) can install and run. Check status with
+`systemextensionsctl developer`. Leave it on for the duration of
+v0.2.0 development.
+
+### 2. Confirm SIP is on
+
+System extensions need SIP **on**, not off. Check with
+`csrutil status`. Disabling SIP for kext development is unrelated
+and would actually break the system-extension flow.
+
+## Build + install loop
+
+### Build the bundle
+
+From the repo root:
+
+```sh
+scripts/make-app-with-virtual-camera.sh
+```
+
+Produces `dist/AVPainReliever.app` with the embedded extension at
+`Contents/Library/SystemExtensions/com.ericwillis.avpainreliever.CameraExtension.systemextension`.
+Ad-hoc-signed unless `MAC_CERT_NAME` is set — fine for dev.
+
+### Move into /Applications
+
+System extensions can only be activated by apps living in
+`/Applications/`. The OS rejects activation requests from
+elsewhere with an unhelpful error.
+
+```sh
+rm -rf /Applications/AVPainReliever.app
+ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
+```
+
+### Activate
+
+The activation is gated by an env var so it doesn't fire on every
+launch:
+
+```sh
+AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
+```
+
+Watch Console.app filtered by "AVPR" for activation lifecycle
+messages. macOS may prompt for approval in System Settings →
+Privacy & Security → "Allow extension from AV Pain Reliever" — click
+Allow.
+
+Verify it's registered:
+
+```sh
+systemextensionsctl list
+```
+
+You should see one entry under
+`com.apple.cmio.cmioextension` for
+`com.ericwillis.avpainreliever.CameraExtension` with state
+`activated enabled`.
+
+### Test in Zoom (or any AVCapture client)
+
+Open Zoom → Settings → Video → Camera dropdown. "AV Pain Reliever"
+should appear. Selecting it shows a black 1280×720 frame at 30 fps.
+
+FaceTime, Photo Booth, Safari `getUserMedia` test pages, and any
+other AVCapture-modern client also work.
+
+## Iteration loop
+
+After code changes:
+
+```sh
+scripts/make-app-with-virtual-camera.sh
+ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
+# Optional: re-activate if the extension was uninstalled
+AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app
+```
+
+macOS handles in-place upgrades transparently when the bundle ID
+matches and developer mode is on — no need to uninstall first for
+routine code changes.
+
+## Uninstall / clean slate
+
+```sh
+systemextensionsctl uninstall - com.ericwillis.avpainreliever.CameraExtension
+```
+
+The leading `-` is the team identifier placeholder for ad-hoc
+builds. For Developer-ID-signed builds, replace with your team ID
+(e.g., `ABC1234DEF`).
+
+Confirm with `systemextensionsctl list` — entry should be gone.
+
+## Logs
+
+Extension log output goes to the unified logging system under
+the extension's bundle ID. Tail with:
+
+```sh
+log stream --predicate 'subsystem == "com.ericwillis.avpainreliever.CameraExtension"' --style compact
+```
+
+Or open Console.app, select "AV Pain Reliever Camera Extension"
+in the sidebar.
+
+## Common failure modes
+
+- **"Code signature missing entitlements"** on activation: host app
+  is missing `com.apple.developer.system-extension.install`. The
+  v0.2.0 entitlements file
+  (`Resources/AVPainReliever-WithVirtualCamera.entitlements`)
+  declares it; confirm the build script picked the right one.
+- **"Extension does not appear in Zoom"**: check
+  `systemextensionsctl list`. If it's listed but Zoom can't see it,
+  quit and relaunch Zoom — Zoom caches its device list. If it's
+  not listed, re-run the activation step and check Console for
+  `[AVPR]` log lines.
+- **"Activation request never returns"**: usually means the user
+  approval prompt is waiting in System Settings → Privacy &
+  Security. Check that pane and click Allow.
+- **"App can't be activated because it's not in /Applications"**:
+  see the "Move into /Applications" step above. System extensions
+  refuse to load from anywhere else.

--- a/scripts/make-app-with-virtual-camera.sh
+++ b/scripts/make-app-with-virtual-camera.sh
@@ -57,6 +57,7 @@ FINAL_ZIP="$DIST_DIR/$APP_NAME.app.zip"
 
 APP_ENTITLEMENTS="Resources/AVPainReliever-WithVirtualCamera.entitlements"
 EXT_ENTITLEMENTS="Resources/AVPainRelieverCameraExtension.entitlements"
+APP_PROVISIONING_PROFILE="Resources/AVPainReliever.provisionprofile"
 
 # ---------- 1. clean ----------
 echo "==> cleaning $DIST_DIR/"
@@ -122,7 +123,49 @@ fi
 echo "==> embedding Sparkle.framework"
 cp -R "$SPARKLE_FRAMEWORK_SRC" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 
-# ---------- 6. sign (inside-out) ----------
+# ---------- 6. embed provisioning profile ----------
+# System extensions activated outside `systemextensionsctl developer
+# on` mode must be backed by a provisioning profile that grants the
+# `com.apple.developer.system-extension.install` entitlement to the
+# host app. The profile is generated once at developer.apple.com
+# (Profiles → New → Developer ID, bound to the host App ID with the
+# System Extension capability enabled) and dropped into Resources/.
+# It is gitignored — each developer / CI environment ships its own.
+#
+# We require it for Developer-ID-signed builds and warn (but allow)
+# ad-hoc builds without it, since the ad-hoc path is for the
+# fallback developer-mode workflow that doesn't honour profiles
+# anyway. See docs/VIRTUAL_CAMERA_DEV.md.
+if [[ -n "${MAC_CERT_NAME:-}" ]]; then
+    if [[ ! -f "$APP_PROVISIONING_PROFILE" ]]; then
+        cat <<EOF >&2
+error: MAC_CERT_NAME is set but no provisioning profile is present at:
+         $APP_PROVISIONING_PROFILE
+
+Developer-ID-signed builds that bundle a system extension MUST
+embed a provisioning profile carrying the
+'com.apple.developer.system-extension.install' entitlement, or the
+extension activation request will fail at runtime.
+
+Generate one at developer.apple.com:
+  - Identifiers: ensure App ID 'com.ericwillis.avpainreliever' has
+    the 'System Extension' capability enabled.
+  - Profiles: New → Developer ID → select the App ID → download.
+
+Save the .provisionprofile at the path above (it's gitignored).
+See docs/VIRTUAL_CAMERA_DEV.md for the full walkthrough.
+EOF
+        exit 1
+    fi
+    echo "==> embedding provisioning profile"
+    cp "$APP_PROVISIONING_PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
+elif [[ -f "$APP_PROVISIONING_PROFILE" ]]; then
+    # Ad-hoc + profile present is a misconfiguration — codesign will
+    # accept it but macOS won't honour an unsigned profile at runtime.
+    echo "warning: ad-hoc sign with provisioning profile present — profile will be ignored. Set MAC_CERT_NAME for a properly-signed build." >&2
+fi
+
+# ---------- 7. sign (inside-out) ----------
 if [[ -n "${MAC_CERT_NAME:-}" ]]; then
     SIGN_IDENTITY="$MAC_CERT_NAME"
     SIGN_OPTS=(--options runtime --timestamp)
@@ -130,7 +173,7 @@ if [[ -n "${MAC_CERT_NAME:-}" ]]; then
 else
     SIGN_IDENTITY="-"
     SIGN_OPTS=()
-    echo "==> ad-hoc sign (MAC_CERT_NAME unset; dev-only — needs systemextensionsctl developer on)"
+    echo "==> ad-hoc sign (MAC_CERT_NAME unset; needs systemextensionsctl developer on + SIP off — see docs/VIRTUAL_CAMERA_DEV.md fallback)"
 fi
 
 sign_path() {
@@ -165,7 +208,7 @@ echo "==> verify codesign"
 codesign --verify --strict --verbose=2 "$APP_BUNDLE"
 codesign --verify --strict --verbose=2 "$EXT_BUNDLE"
 
-# ---------- 7. move into dist/ + zip ----------
+# ---------- 8. move into dist/ + zip ----------
 echo "==> moving signed bundle to $FINAL_BUNDLE"
 ditto "$APP_BUNDLE" "$FINAL_BUNDLE"
 

--- a/scripts/make-app-with-virtual-camera.sh
+++ b/scripts/make-app-with-virtual-camera.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Build a v0.2.0+ AVPainReliever.app with the Camera Extension
+# embedded. The default v0.1.x pipeline (`scripts/make-app.sh`) is
+# untouched — that script keeps shipping the no-virtual-camera build
+# from `main` while v0.2.0 is built from `feature/virtual-camera`.
+#
+# This script is the parallel-track v0.2.0 builder. Same SPM build,
+# additional Camera Extension target, additional embedding step,
+# different entitlements file.
+#
+# Run from the repo root:
+#
+#   scripts/make-app-with-virtual-camera.sh                       # ad-hoc dev build
+#   VERSION=0.2.0 scripts/make-app-with-virtual-camera.sh         # stamp version
+#   MAC_CERT_NAME="Developer ID Application: Eric Willis (TEAMID)" \
+#     VERSION=0.2.0 scripts/make-app-with-virtual-camera.sh       # signed release build
+#
+# Output:
+#   dist/AVPainReliever.app          — bundle with embedded camera extension
+#   dist/AVPainReliever.app.zip      — ditto'd zip
+#
+# Dev workflow note: ad-hoc-signed builds will only activate on a
+# machine with `systemextensionsctl developer on`. See
+# docs/VIRTUAL_CAMERA_DEV.md for the full local-test recipe.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# ---------- inputs ----------
+APP_NAME="AVPainReliever"
+EXEC_NAME="AVPainRelieverApp"
+BUNDLE_ID="com.ericwillis.avpainreliever"
+
+EXT_PRODUCT="AVPainRelieverCameraExtension"
+EXT_BUNDLE_ID="${BUNDLE_ID}.CameraExtension"
+EXT_DIR_NAME="${EXT_BUNDLE_ID}.systemextension"
+
+if [[ -z "${VERSION:-}" ]]; then
+    if VERSION="$(git describe --tags --always --dirty 2>/dev/null)"; then
+        VERSION="${VERSION#v}"
+    else
+        VERSION="0.0.0-dev"
+    fi
+fi
+
+BUILD_VERSION="${BUILD_VERSION:-$VERSION}"
+
+DIST_DIR="dist"
+
+WORK_DIR="$(mktemp -d -t avpainreliever)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+APP_BUNDLE="$WORK_DIR/$APP_NAME.app"
+EXT_BUNDLE="$APP_BUNDLE/Contents/Library/SystemExtensions/$EXT_DIR_NAME"
+FINAL_BUNDLE="$DIST_DIR/$APP_NAME.app"
+FINAL_ZIP="$DIST_DIR/$APP_NAME.app.zip"
+
+APP_ENTITLEMENTS="Resources/AVPainReliever-WithVirtualCamera.entitlements"
+EXT_ENTITLEMENTS="Resources/AVPainRelieverCameraExtension.entitlements"
+
+# ---------- 1. clean ----------
+echo "==> cleaning $DIST_DIR/"
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+# ---------- 2. build both products ----------
+echo "==> swift build (release, universal arm64+x86_64, both products)"
+swift build -c release \
+    --arch arm64 --arch x86_64 \
+    --product "$EXEC_NAME"
+swift build -c release \
+    --arch arm64 --arch x86_64 \
+    --product "$EXT_PRODUCT"
+
+BIN_PATH="$(swift build -c release --arch arm64 --arch x86_64 --product "$EXEC_NAME" --show-bin-path)"
+APP_BINARY="$BIN_PATH/$EXEC_NAME"
+EXT_BINARY="$BIN_PATH/$EXT_PRODUCT"
+
+[[ -f "$APP_BINARY" ]] || { echo "error: app binary not built at $APP_BINARY" >&2; exit 1; }
+[[ -f "$EXT_BINARY" ]] || { echo "error: extension binary not built at $EXT_BINARY" >&2; exit 1; }
+
+# ---------- 3. assemble main app bundle ----------
+echo "==> assembling $APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+mkdir -p "$APP_BUNDLE/Contents/Library/SystemExtensions"
+
+cp "$APP_BINARY" "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME"
+chmod +x "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME"
+
+install_name_tool -add_rpath \
+    "@executable_path/../Frameworks" \
+    "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME"
+
+cp Resources/AppIcon.icns "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
+
+sed \
+    -e "s|__MARKETING_VERSION__|$VERSION|g" \
+    -e "s|__BUILD_VERSION__|$BUILD_VERSION|g" \
+    Resources/Info.plist > "$APP_BUNDLE/Contents/Info.plist"
+
+# ---------- 4. assemble Camera Extension bundle ----------
+echo "==> assembling $EXT_DIR_NAME"
+mkdir -p "$EXT_BUNDLE/Contents/MacOS"
+
+cp "$EXT_BINARY" "$EXT_BUNDLE/Contents/MacOS/$EXT_PRODUCT"
+chmod +x "$EXT_BUNDLE/Contents/MacOS/$EXT_PRODUCT"
+
+sed \
+    -e "s|__MARKETING_VERSION__|$VERSION|g" \
+    -e "s|__BUILD_VERSION__|$BUILD_VERSION|g" \
+    Resources/AVPainRelieverCameraExtension-Info.plist \
+    > "$EXT_BUNDLE/Contents/Info.plist"
+
+# ---------- 5. embed Sparkle (same as v0.1.x) ----------
+SPARKLE_FRAMEWORK_SRC=".build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FRAMEWORK_SRC" ]]; then
+    echo "error: Sparkle framework not found at $SPARKLE_FRAMEWORK_SRC — run 'swift package resolve' first" >&2
+    exit 1
+fi
+echo "==> embedding Sparkle.framework"
+cp -R "$SPARKLE_FRAMEWORK_SRC" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+
+# ---------- 6. sign (inside-out) ----------
+if [[ -n "${MAC_CERT_NAME:-}" ]]; then
+    SIGN_IDENTITY="$MAC_CERT_NAME"
+    SIGN_OPTS=(--options runtime --timestamp)
+    echo "==> codesign with Developer ID: $SIGN_IDENTITY"
+else
+    SIGN_IDENTITY="-"
+    SIGN_OPTS=()
+    echo "==> ad-hoc sign (MAC_CERT_NAME unset; dev-only — needs systemextensionsctl developer on)"
+fi
+
+sign_path() {
+    local path="$1"
+    shift
+    xattr -cr "$path" 2>/dev/null || true
+    xattr -d com.apple.FinderInfo "$path" 2>/dev/null || true
+    codesign --force --sign "$SIGN_IDENTITY" ${SIGN_OPTS[@]+"${SIGN_OPTS[@]}"} "$@" "$path"
+}
+
+# Sparkle nested bundles (inside-out, same as make-app.sh)
+SPARKLE_DIR="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B"
+SPARKLE_NESTED=(
+    "$SPARKLE_DIR/XPCServices/Downloader.xpc"
+    "$SPARKLE_DIR/XPCServices/Installer.xpc"
+    "$SPARKLE_DIR/Updater.app"
+    "$SPARKLE_DIR/Autoupdate"
+)
+for path in "${SPARKLE_NESTED[@]}"; do
+    [[ -e "$path" ]] && sign_path "$path"
+done
+sign_path "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+
+# Camera Extension — signed before the host app so the host's
+# signature covers a finalized extension bundle.
+sign_path "$EXT_BUNDLE" --entitlements "$EXT_ENTITLEMENTS"
+
+# Main app, with v0.2.0 entitlements (system-extension.install).
+sign_path "$APP_BUNDLE" --entitlements "$APP_ENTITLEMENTS"
+
+echo "==> verify codesign"
+codesign --verify --strict --verbose=2 "$APP_BUNDLE"
+codesign --verify --strict --verbose=2 "$EXT_BUNDLE"
+
+# ---------- 7. move into dist/ + zip ----------
+echo "==> moving signed bundle to $FINAL_BUNDLE"
+ditto "$APP_BUNDLE" "$FINAL_BUNDLE"
+
+echo "==> ditto $FINAL_ZIP"
+ditto -c -k --sequesterRsrc --keepParent "$FINAL_BUNDLE" "$FINAL_ZIP"
+
+echo
+echo "✓ built $FINAL_BUNDLE"
+echo "  version:   $VERSION  (build $BUILD_VERSION)"
+echo "  extension: $EXT_DIR_NAME"
+echo "  zip:       $FINAL_ZIP ($(stat -f%z "$FINAL_ZIP") bytes)"
+echo
+echo "next: see docs/VIRTUAL_CAMERA_DEV.md for activation + Zoom test"

--- a/scripts/make-app-with-virtual-camera.sh
+++ b/scripts/make-app-with-virtual-camera.sh
@@ -46,6 +46,24 @@ fi
 
 BUILD_VERSION="${BUILD_VERSION:-$VERSION}"
 
+# Team ID is parsed out of MAC_CERT_NAME for the extension's
+# CMIOExtensionMachServiceName, which must be "<TEAMID>.<bundleID>".
+# Apple's CodeSigningHelper validates the registered service name
+# against the bundle's signing identity at activation time.
+if [[ -n "${MAC_CERT_NAME:-}" ]]; then
+    TEAM_ID="$(printf '%s' "$MAC_CERT_NAME" | sed -nE 's/.*\(([A-Z0-9]+)\)$/\1/p')"
+    if [[ -z "$TEAM_ID" ]]; then
+        echo "error: could not parse team ID from MAC_CERT_NAME='$MAC_CERT_NAME'" >&2
+        echo "       expected format: 'Developer ID Application: Name (TEAMID)'" >&2
+        exit 1
+    fi
+else
+    # Ad-hoc builds won't activate properly anyway; placeholder keeps
+    # the substitution from leaving the literal __TEAM_ID__ in the
+    # plist and confusing diagnostics later.
+    TEAM_ID="ADHOC"
+fi
+
 DIST_DIR="dist"
 
 WORK_DIR="$(mktemp -d -t avpainreliever)"
@@ -111,6 +129,7 @@ chmod +x "$EXT_BUNDLE/Contents/MacOS/$EXT_PRODUCT"
 sed \
     -e "s|__MARKETING_VERSION__|$VERSION|g" \
     -e "s|__BUILD_VERSION__|$BUILD_VERSION|g" \
+    -e "s|__TEAM_ID__|$TEAM_ID|g" \
     Resources/AVPainRelieverCameraExtension-Info.plist \
     > "$EXT_BUNDLE/Contents/Info.plist"
 
@@ -208,7 +227,36 @@ echo "==> verify codesign"
 codesign --verify --strict --verbose=2 "$APP_BUNDLE"
 codesign --verify --strict --verbose=2 "$EXT_BUNDLE"
 
-# ---------- 8. move into dist/ + zip ----------
+# ---------- 8. notarize (required for system extension activation) ----------
+# Even with valid Developer ID signing, macOS refuses to activate a
+# system extension whose bundle isn't notarized. The validation
+# error in sysextd surfaces as "bundle code signature is not valid
+# - does not satisfy requirement: -67050" with "Error checking with
+# notarization daemon."
+#
+# Gated by NOTARIZE_KEYCHAIN_PROFILE so quick iteration builds
+# (e.g., compile-only sanity checks) can skip the round trip. The
+# CI pipeline uses APPLE_ID + APPLE_ID_PASSWORD + APPLE_TEAM_ID
+# instead — set NOTARIZE_KEYCHAIN_PROFILE locally to use the
+# `avpain-notary` keychain profile instead of typing the password.
+if [[ -n "${NOTARIZE_KEYCHAIN_PROFILE:-}" ]]; then
+    echo "==> notarizing (keychain profile: $NOTARIZE_KEYCHAIN_PROFILE)"
+    NOTARIZE_ZIP="$WORK_DIR/notarize.zip"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$NOTARIZE_ZIP"
+    xcrun notarytool submit "$NOTARIZE_ZIP" \
+        --keychain-profile "$NOTARIZE_KEYCHAIN_PROFILE" \
+        --wait
+    echo "==> stapling notarization ticket"
+    # Staple the app first; the embedded extension inherits the
+    # ticket through the bundle structure.
+    xcrun stapler staple "$APP_BUNDLE"
+elif [[ -n "${MAC_CERT_NAME:-}" ]]; then
+    echo "warning: signed build without notarization. System-extension"
+    echo "         activation will fail with sysextd code -67050."
+    echo "         Set NOTARIZE_KEYCHAIN_PROFILE=avpain-notary to fix." >&2
+fi
+
+# ---------- 9. move into dist/ + zip ----------
 echo "==> moving signed bundle to $FINAL_BUNDLE"
 ditto "$APP_BUNDLE" "$FINAL_BUNDLE"
 

--- a/scripts/sign-appcast.sh
+++ b/scripts/sign-appcast.sh
@@ -14,6 +14,13 @@
 #   - $RELEASE_NOTES_HTML  Pre-rendered HTML embedded as the item's
 #                          <description>. Sparkle uses this to populate
 #                          its "What's New" panel.
+#   - $CHANNEL             Sparkle release channel tag. Empty (default)
+#                          omits the <sparkle:channel> element entirely,
+#                          which is how stable releases stay visible to
+#                          every install. Set to "experimental" for
+#                          v0.2.x virtual-camera builds; only installs
+#                          that have allowlisted that channel will see
+#                          the item as an upgrade.
 #
 # Outputs to stdout:
 #   - The full <item> block (URL placeholder included; replace before
@@ -71,11 +78,21 @@ ${RELEASE_NOTES_HTML}
 "
 fi
 
+# Optional channel tag. When unset, Sparkle treats the item as
+# stable — every install considers it. When set (e.g.
+# "experimental"), only installs whose Updater has allowlisted
+# that channel will pick it up.
+CHANNEL_BLOCK=""
+if [[ -n "${CHANNEL:-}" ]]; then
+    CHANNEL_BLOCK="            <sparkle:channel>${CHANNEL}</sparkle:channel>
+"
+fi
+
 cat <<XML
         <item>
             <title>Version $VERSION</title>
 ${DESCRIPTION_BLOCK}            <pubDate>$PUBDATE</pubDate>
-            <sparkle:version>$VERSION</sparkle:version>
+${CHANNEL_BLOCK}            <sparkle:version>$VERSION</sparkle:version>
             <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="$ASSET_URL"


### PR DESCRIPTION
## Summary

M1 of the V2 virtual-camera plan (see `SWIFT_PORT.md` → "V2 plan: native virtual camera"). Adds the project skeleton for a native CMIO Camera Extension so apps with their own camera picker (Zoom, Slack, Teams) can finally follow profile changes — replaces the previously-considered "route through OBS" approach with an in-app, self-contained alternative.

This PR is a **draft, long-lived feature branch**. It will *not* merge until M2–M6 land. `main` continues to ship v0.1.x patch releases independently — the default `make-app.sh` is byte-for-byte unchanged here.

## What landed

- `AVPainRelieverCameraExtension` SPM target — provider, device, stream. Black-frame vendor (1280×720 BGRA at 30 fps) for plumbing-only.
- Parallel build script `scripts/make-app-with-virtual-camera.sh` that assembles the host app, the `.systemextension` bundle, embeds, and signs inside-out.
- v0.2.0-only entitlements file (`Resources/AVPainReliever-WithVirtualCamera.entitlements`) declaring `com.apple.developer.system-extension.install`. The default v0.1.x entitlements file is untouched.
- Env-var-gated activation via `VirtualCameraActivator.activateIfRequested()` in `AppDelegate.applicationDidFinishLaunching`. No-op on v0.1.x builds (entitlement absent).
- `docs/VIRTUAL_CAMERA_DEV.md` — local-test recipe (`systemextensionsctl developer on`, build, ditto into `/Applications`, env-var launch, Zoom verification, uninstall, common failures).

## Test plan

- [ ] `swift build` and `swift test` both green (verified locally — 161 tests pass).
- [ ] `scripts/make-app.sh` still produces a working v0.1.x bundle (no changes to that script or its inputs).
- [ ] `sudo systemextensionsctl developer on` once on test machine.
- [ ] `scripts/make-app-with-virtual-camera.sh` produces `dist/AVPainReliever.app` with the embedded extension.
- [ ] `ditto dist/AVPainReliever.app /Applications/AVPainReliever.app`.
- [ ] `AVPR_ACTIVATE_VIRTUAL_CAMERA=1 open /Applications/AVPainReliever.app` → approve in System Settings if prompted.
- [ ] `systemextensionsctl list` shows the extension as `activated enabled`.
- [ ] "AV Pain Reliever" appears in Zoom's camera picker → selecting it shows a black frame at 30 fps.
- [ ] Same verified in FaceTime and a `getUserMedia` browser test page.

## Out of scope (deferred to later milestones)

- Source-camera switching (M2)
- XPC service for source commands (M3)
- `ProfileApplier` integration + Settings toggle to install/uninstall (M4)
- Apple entitlement request for distribution (M5)
- Sparkle replacement-flow verification + v0.2.0 tag (M6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)