### PR TITLE
appcast: mark v0.2.0 as experimental channel

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -189,6 +189,7 @@
 <p>That's the update. Virtual camera, profile-driven, hold-last-frame, universal format support. v0.1.x will keep getting patch releases in parallel for anyone who doesn't need any of this. <strong>Money.</strong></p>
 ]]></description>
             <pubDate>Tue, 05 May 2026 01:02:59 +0000</pubDate>
+            <sparkle:channel>experimental</sparkle:channel>
             <sparkle:version>0.2.0</sparkle:version>
             <sparkle:shortVersionString>0.2.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
## Summary

- Adds `<sparkle:channel>experimental</sparkle:channel>` to the v0.2.0 item in appcast.xml so existing v0.1.13 installs stop seeing it as an upgrade.
- Sparkle 2's default `feedURLAllowedChannels` is empty: items with no channel tag are treated as stable, items with a channel tag are excluded unless the host allowlists that channel.
- This is the urgent first step. A follow-up PR adds a "Receive experimental updates" toggle in Settings → General that wires `feedURLAllowedChannels = ["experimental"]` so users can explicitly opt in to v0.2.x. That ships as v0.1.14.

## Why now

v0.2.0 just shipped (https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0) but the virtual camera is opt-in and has known quirks (the in-session toggle off→on issue). Pushing it to v0.1.x users as the default upgrade would surprise them with a non-trivial new feature requiring System Settings approval. Better to gate it.

## Test plan

- [ ] Sparkle 2 docs confirm channel-tagged items are excluded by default — no app changes needed for v0.1.13 users to stop being prompted.
- [ ] After this lands and v0.1.14 ships with the toggle, verify a v0.1.14 install with the toggle ON sees v0.2.0 as an available upgrade.