### PR TITLE
Settings: opt-in toggle for experimental updates

### DIFF
--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -167,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             bundleIdentifier: Bundle.main.bundleIdentifier,
             publicKey: Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
         ) {
-            updater = Updater()
+            updater = Updater(settings: settings)
         }
         maybeShowWelcomeWindow()
     }

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -19,6 +19,7 @@ final class SettingsStore: ObservableObject {
         static let profileSwitchCount = "profileSwitchCount"
         static let suppressedWelcome = "suppressedWelcome"
         static let launchAtLogin = "launchAtLogin"
+        static let experimentalUpdates = "experimentalUpdates"
     }
 
     /// Toast on profile change?  Default on — the at-a-glance signal
@@ -84,6 +85,18 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Opt-in to updates from the `experimental` Sparkle channel.
+    /// Default off — only stable releases reach the user. When on,
+    /// the Updater's allowedChannels delegate hook returns
+    /// `["experimental"]`, so feed items tagged
+    /// `<sparkle:channel>experimental</sparkle:channel>` become
+    /// eligible upgrades. Used to gate the v0.2.x virtual-camera
+    /// builds behind a deliberate user choice while the feature is
+    /// still maturing.
+    @Published var experimentalUpdates: Bool {
+        didSet { defaults.set(experimentalUpdates, forKey: Key.experimentalUpdates) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -100,6 +113,7 @@ final class SettingsStore: ObservableObject {
         self.profileSwitchCount = (defaults.object(forKey: Key.profileSwitchCount) as? Int) ?? 0
         self.suppressedWelcome = (defaults.object(forKey: Key.suppressedWelcome) as? Bool) ?? false
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool) ?? false
+        self.experimentalUpdates = (defaults.object(forKey: Key.experimentalUpdates) as? Bool) ?? false
     }
 
     func incrementSwitchCount() {

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -111,6 +111,16 @@ private struct GeneralSettingsTab: View {
             } header: {
                 Label("Detection", systemImage: "cable.connector")
             }
+
+            Section {
+                Toggle("Receive experimental updates", isOn: $settings.experimentalUpdates)
+                Text("Opt in to early-access builds. Experimental releases include unfinished features (the virtual camera in v0.2.x) and may be less stable than the regular release line. Off by default.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Label("Updates", systemImage: "arrow.down.circle")
+            }
         }
         .formStyle(.grouped)
         .padding(8)

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -59,16 +59,21 @@ final class Updater {
         return true
     }
 
-    init() {
+    /// Sparkle holds a weak reference to its delegates, so we keep a
+    /// strong one here so the channel-allowlist callback survives.
+    private let channelDelegate: ChannelGatingDelegate
+
+    init(settings: SettingsStore) {
         // `startingUpdater: true` kicks off the scheduled-check loop
-        // immediately. Delegates are nil — Sparkle's defaults are
-        // fine for a single-channel public release: it'll fetch the
-        // appcast, prompt the user on first launch, and run
-        // background checks per the Info.plist's SUScheduledCheckInterval
-        // (omitted = 24h default).
+        // immediately. The delegate's `allowedChannels(for:)` hook is
+        // re-queried on every check, so flipping the experimental-
+        // updates toggle takes effect on the next scheduled tick or
+        // user-initiated check — no Updater rebuild needed.
+        let channelDelegate = ChannelGatingDelegate(settings: settings)
+        self.channelDelegate = channelDelegate
         let controller = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: channelDelegate,
             userDriverDelegate: nil
         )
         self.controller = controller
@@ -112,5 +117,30 @@ final class Updater {
     func checkForUpdates() {
         NSApp.activate(ignoringOtherApps: true)
         controller.checkForUpdates(nil)
+    }
+}
+
+/// Sparkle delegate that controls which release channels the user is
+/// willing to receive. Default-empty allow-list means Sparkle only
+/// considers feed items WITHOUT a `<sparkle:channel>` tag — i.e.
+/// stable. When the user opts in via Settings, we return
+/// `["experimental"]` and items tagged with that channel become
+/// eligible. Multiple channels can be allowed simultaneously; for
+/// now there's only one experimental channel.
+///
+/// Held strongly by `Updater` because Sparkle stores its delegates
+/// as weak references — without our retention, the delegate would
+/// deallocate immediately after init and Sparkle would silently fall
+/// back to its default (no-channel-filtering) behaviour.
+private final class ChannelGatingDelegate: NSObject, SPUUpdaterDelegate {
+    private let settings: SettingsStore
+
+    init(settings: SettingsStore) {
+        self.settings = settings
+        super.init()
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        settings.experimentalUpdates ? ["experimental"] : []
     }
 }

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -24,6 +24,9 @@ struct SettingsStoreTests {
         // Launch-at-login defaults off — fresh users opt in, per
         // macOS background-task etiquette.
         #expect(store.launchAtLogin == false)
+        // Experimental updates default off — only the stable channel
+        // is consumed unless the user explicitly opts in.
+        #expect(store.experimentalUpdates == false)
     }
 
     @Test("launchAtLogin persists across reloads")
@@ -83,5 +86,16 @@ struct SettingsStoreTests {
         }
         let reopened = SettingsStore(defaults: defaults)
         #expect(reopened.suppressedWelcome == true)
+    }
+
+    @Test("experimentalUpdates persists across reloads")
+    func experimentalUpdatesPersists() {
+        let defaults = makeSuite()
+        do {
+            let store = SettingsStore(defaults: defaults)
+            store.experimentalUpdates = true
+        }
+        let reopened = SettingsStore(defaults: defaults)
+        #expect(reopened.experimentalUpdates == true)
     }
 }


### PR DESCRIPTION
## Summary

- Adds a **Receive experimental updates** toggle to Settings → General → Updates. Default off.
- When on, the Sparkle Updater's `allowedChannels(for:)` delegate returns `["experimental"]` so feed items tagged `<sparkle:channel>experimental</sparkle:channel>` (right now: v0.2.0) become eligible upgrades.
- Pairs with #12 (which marks v0.2.0 in appcast.xml as the experimental channel).

## How users experience this

- **Existing v0.1.13 users** — get an automatic upgrade to v0.1.14 (no channel tag = stable, normal flow). They gain the toggle in Settings but aren't prompted to v0.2.0 unless they flip it on.
- **Users who flip it on** — Sparkle's `allowedChannels` hook returns `["experimental"]` on the next check, the v0.2.0 item becomes visible, and they're prompted to upgrade with the full Vince-Vaughn release notes.
- **Users who flip it off** — Sparkle returns to the empty allowlist; v0.2.0 stops being visible. They're already on v0.1.14, and any future v0.1.x patches still flow normally.

## Test plan

- [x] swift build clean
- [x] swift test — 162/162 pass, including the new experimentalUpdates persists case + the default check.
- [ ] After merge, tag v0.1.14, smoke-test that a v0.1.13 install upgrades to v0.1.14 silently (no v0.2.0 prompt).
- [ ] Flip the toggle ON in v0.1.14, click Check for Updates, verify v0.2.0 surfaces.
- [ ] Flip the toggle OFF, click Check for Updates, verify Sparkle reports you're up to date.

## Why now

v0.2.0 ships the virtual camera but it's opt-in (system extension, in-session toggle quirk). Pushing it as the default upgrade for v0.1.x users is a surprise change. Channel-gating gives users an explicit choice.