### PR TITLE
USBWatcher: fall back to kUSBSerialNumberString for IOKit serials

### DIFF
--- a/Sources/AVPainReliever/Engine/USBWatcher.swift
+++ b/Sources/AVPainReliever/Engine/USBWatcher.swift
@@ -275,16 +275,24 @@ public final class IOKitUSBWatcher: USBWatcher {
     }
 
     private static func serialNumber(_ entry: io_object_t) -> String? {
-        guard let raw = IORegistryEntryCreateCFProperty(
-            entry, "USB Serial Number" as CFString, kCFAllocatorDefault, 0
-        ) else {
-            return nil
+        // Try the friendly "USB Serial Number" key first — many
+        // devices expose it as a mirror of the underlying
+        // `kUSBSerialNumberString`. Some devices (e.g., the
+        // 0x1e4e:0x701f HDMI-to-USB capture cards we ship in the
+        // home-office profile) only expose the raw key, so we have
+        // to fall back. Without the fallback, fingerprints with a
+        // pinned serial silently fail to match those devices and
+        // the engine resolves to the implicit-fallback profile
+        // instead of the configured one.
+        for key in ["USB Serial Number", "kUSBSerialNumberString"] {
+            guard let raw = IORegistryEntryCreateCFProperty(
+                entry, key as CFString, kCFAllocatorDefault, 0
+            ) else { continue }
+            guard let serial = raw.takeRetainedValue() as? String,
+                  !serial.isEmpty else { continue }
+            return serial
         }
-        guard let serial = raw.takeRetainedValue() as? String,
-              !serial.isEmpty else {
-            return nil
-        }
-        return serial
+        return nil
     }
 
     private static func productName(_ entry: io_object_t) -> String? {


### PR DESCRIPTION
## Summary

Fixes a real-world fingerprint-matching bug. The friendly `"USB Serial Number"` IOKit property isn't exposed on every USB device. Some devices (confirmed in the wild: HDMI-to-USB capture cards with `vid=0x1e4e/pid=0x701f`) only set the raw `kUSBSerialNumberString` key.

Without this fallback, fingerprints with a pinned serial silently fail to match those devices, and the engine resolves to the implicit-fallback profile (e.g. `laptop`) instead of the configured one (e.g. `home-office`).

## Reproduction

User reported: relaunched AV Pain Reliever while docked at home-office. Engine logged `evaluation → laptop` instead of `home-office`. Both fingerprint devices visible in `ioreg`:

- `CalDigit Thunderbolt 3 Audio` (no serial in fingerprint, no serial on device)
- `HDMI to U3 capture` (fingerprint requires `serialNumber = "20000130041415"`, device exposes only `kUSBSerialNumberString = "20000130041415"`)

## Fix

Try `"USB Serial Number"` first (no behavior change for devices that expose both), fall through to `"kUSBSerialNumberString"` when the friendly key is missing.

## Test plan

- [x] swift build clean
- [x] swift test — 162/162 pass
- [ ] After v0.1.15 ships, relaunch the user's docked Mac, verify the engine resolves to `home-office` instead of `laptop`.