### PR TITLE
Wizard: 'Fallback profile' hint when no devices are ticked

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -85,11 +85,7 @@ struct AddProfileView: View {
                     // strip even with `.frame(maxWidth: .infinity)`.
                     // As a row inside the section body it spans the
                     // section's full content width naturally.
-                    Text("Uncheck peripherals that aren't unique to this location (keyboards, mice, phones). The profile matches when every checked device is attached.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .fixedSize(horizontal: false, vertical: true)
+                    fingerprintHint
                 } header: {
                     HStack {
                         sectionHeader("USB fingerprint", symbol: Theme.Symbol.usbSection)
@@ -248,6 +244,41 @@ struct AddProfileView: View {
             Text(title)
         } icon: {
             Image(systemName: symbol)
+        }
+    }
+
+    /// Section-body row that explains the fingerprint state. Two
+    /// modes:
+    ///
+    /// - When at least one device is ticked: standard "uncheck the
+    ///   peripherals that aren't unique" caption.
+    /// - When zero devices are ticked: "implicit fallback" hint with
+    ///   an info glyph, signaling that this profile will match any
+    ///   USB state at specificity 0. That's the right setup for a
+    ///   "laptop, undocked" fallback, but it's a misconfiguration if
+    ///   the user meant to capture a docked location and accidentally
+    ///   unticked everything. The hint makes the semantic
+    ///   discoverable so a user doesn't ship a fingerprint they
+    ///   didn't intend.
+    @ViewBuilder
+    private var fingerprintHint: some View {
+        if viewModel.willMatchAnywhere {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "info.circle.fill")
+                    .foregroundStyle(.tint)
+                (Text("Fallback profile. ").bold()
+                    + Text("With no devices ticked, this profile matches whenever no other profile does — useful for a laptop-undocked default. Tick devices above to make it specific to a location."))
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+            Text("Uncheck peripherals that aren't unique to this location (keyboards, mice, phones). The profile matches when every checked device is attached.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -49,6 +49,21 @@ final class AddProfileViewModel: ObservableObject {
     @Published private(set) var attachedDevices: [NamedUSBDevice] = []
     /// Subset of `attachedDevices` IDs the user has checked.
     @Published var selectedDeviceIDs: Set<USBDevice> = []
+
+    /// True when the user has zero devices ticked, which makes the
+    /// profile an *implicit fallback*: the resolver treats an empty
+    /// fingerprint as matching any USB state with specificity 0, so
+    /// it wins only when no more-specific profile matches. The wizard
+    /// surfaces this state with a tailored hint so a user who saves
+    /// without realizing what they did doesn't end up with (a) an
+    /// always-matching profile that drowns out their other locations
+    /// or (b) the inverse — a many-device fingerprint accidentally
+    /// captured on a profile they meant to be the fallback. The
+    /// canonical user case for this hint is the default "laptop"
+    /// profile: empty fingerprint, kicks in when undocked.
+    var willMatchAnywhere: Bool {
+        selectedDeviceIDs.isEmpty
+    }
     /// Devices in `attachedDevices` that came from the editing
     /// profile's fingerprint but are NOT currently plugged in. The
     /// view shows these with a yellow "Not connected" badge and

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -328,6 +328,37 @@ struct AddProfileViewModelTests {
         let loaded = try ConfigLoader().loadProfiles(from: url)
         #expect(Set(loaded.map(\.name)) == ["home-studio"])
     }
+
+    @Test("willMatchAnywhere is true when no devices are ticked")
+    func willMatchAnywhereOnEmptySelection() {
+        let url = URL(fileURLWithPath: "/tmp/wma.toml")
+        let watcher = FakeWatcher()
+        // Watcher returns one attached device so the selection is
+        // non-default — the auto-tick logic in refresh() picks it up,
+        // exercising both states of the property.
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x6533),
+                name: "CalDigit"
+            )
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: url,
+            editing: nil,
+            onSaved: {}
+        )
+        // With one auto-ticked device, willMatchAnywhere is false.
+        #expect(vm.selectedDeviceIDs.isEmpty == false)
+        #expect(vm.willMatchAnywhere == false)
+
+        // Untick everything. Now this profile is the implicit
+        // fallback at save time — the wizard hint covers this state.
+        vm.selectedDeviceIDs.removeAll()
+        #expect(vm.willMatchAnywhere == true)
+    }
 }
 
 // MARK: - Test fakes


### PR DESCRIPTION
## Summary

When the wizard's USB-fingerprint section has zero ticked devices, the saved profile becomes an *implicit fallback* — empty fingerprint, matches any USB state with specificity 0, wins only when nothing more specific does. That's the right setup for "laptop, undocked." But the wizard's previous helper text didn't make this discoverable.

This PR replaces the generic "uncheck peripherals" caption with a labeled **Fallback profile** hint when the selection is empty. Info glyph + bold lead so it reads as a deliberate state, not a warning.

## Why now

Real-world misconfig: a user's `laptop` profile got saved with the full home-office dock attached, capturing 15 USB devices into its fingerprint. Once docked, the laptop fingerprint matched MORE specifically (15 entries) than the actual home-office profile (2 entries), so the resolver picked laptop every time. Engine was working as designed; the config was the problem.

This hint can't fix profiles that were already saved that way, but it makes the implicit-fallback semantic obvious so the same drift doesn't happen on the next profile a user creates.

## Test plan

- [x] swift build clean
- [x] swift test — 163/163 (one new `willMatchAnywhere` view-model case)
- [ ] Hands-on: open Add Profile, untick all devices → caption flips to "Fallback profile. With no devices ticked, this profile matches whenever no other profile does…"
- [ ] Tick a device again → caption returns to the standard "uncheck peripherals…" guidance.