### PR TITLE
Wizard: priority-tier sort for the USB-fingerprint device list

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -182,12 +182,15 @@ final class AddProfileViewModel: ObservableObject {
             }
         let disconnectedIDs = Set(disconnected.map(\.device))
 
-        // Live devices first (sorted as the watcher returned them),
-        // then disconnected entries pushed to the bottom by name so
-        // the active hardware stays grouped at the top of the list.
-        attachedDevices = liveSnapshot + disconnected.sorted {
-            $0.displayName < $1.displayName
-        }
+        // Two-tier sort for live devices: location-defining hardware
+        // (mics, speakers, cameras, capture cards, displays, docks,
+        // hubs — anything not flagged by `DevicePortability`) at the
+        // top, portable peripherals (keyboards, mice, phones,
+        // headphones, watches) at the bottom. Disconnected entries
+        // pushed to the very bottom by name so the active hardware
+        // stays grouped at the top.
+        attachedDevices = Self.sortedByTier(liveSnapshot)
+            + disconnected.sorted { $0.displayName < $1.displayName }
         disconnectedDeviceIDs = disconnectedIDs
 
         // Default selection: every currently-attached device,
@@ -230,6 +233,34 @@ final class AddProfileViewModel: ObservableObject {
 
     var outputDevices: [AudioDevice] {
         audioDevices.filter(\.supportsOutput)
+    }
+
+    /// Two-tier sort for the wizard's live device list. Top tier
+    /// holds devices that aren't flagged by `DevicePortability` —
+    /// mics, speakers, cameras, docks, hubs, capture cards, displays
+    /// — i.e. the hardware that defines a location. Bottom tier
+    /// holds the portable peripherals the wizard already suggests
+    /// unticking (keyboards, mice, phones, headphones, watches).
+    /// Within each tier, items sort alphabetically by `displayName`
+    /// so the order is stable across re-renders.
+    ///
+    /// Using the same predicate the row's "Suggested: untick" pill
+    /// uses keeps the visual signal (pill) and the spatial signal
+    /// (row position) in agreement — single source of truth in
+    /// `DevicePortability`.
+    private static func sortedByTier(_ devices: [NamedUSBDevice])
+        -> [NamedUSBDevice]
+    {
+        devices.sorted { lhs, rhs in
+            let lhsPortable = DevicePortability
+                .portabilityCategory(deviceName: lhs.name) != nil
+            let rhsPortable = DevicePortability
+                .portabilityCategory(deviceName: rhs.name) != nil
+            if lhsPortable != rhsPortable {
+                return !lhsPortable
+            }
+            return lhs.displayName < rhs.displayName
+        }
     }
 
     // MARK: - Name handling

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -329,6 +329,47 @@ struct AddProfileViewModelTests {
         #expect(Set(loaded.map(\.name)) == ["home-studio"])
     }
 
+    @Test("device list sorts non-portable items above portable ones")
+    func deviceListPriorityTier() {
+        let watcher = FakeWatcher()
+        // Mix of portable and non-portable devices, deliberately
+        // out of order so the sort has work to do regardless of
+        // the watcher's own ordering.
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x05ac, productID: 0x0265),
+                name: "Magic Trackpad"
+            ), // portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x6533),
+                name: "CalDigit Thunderbolt 3 Audio"
+            ), // non-portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
+                name: "Keychron K3"
+            ), // portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x1e4e, productID: 0x701f),
+                name: "HDMI to U3 capture"
+            ), // non-portable
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/tier.toml"),
+            editing: nil,
+            onSaved: {}
+        )
+        let names = vm.attachedDevices.map(\.name)
+        #expect(names == [
+            "CalDigit Thunderbolt 3 Audio",  // non-portable, alphabetical
+            "HDMI to U3 capture",             // non-portable, alphabetical
+            "Keychron K3",                    // portable, alphabetical
+            "Magic Trackpad",                 // portable, alphabetical
+        ])
+    }
+
     @Test("willMatchAnywhere is true when no devices are ticked")
     func willMatchAnywhereOnEmptySelection() {
         let url = URL(fileURLWithPath: "/tmp/wma.toml")


### PR DESCRIPTION
## Summary

The wizard's USB-fingerprint section was sorting every connected device alphabetically by display name — which buried mics, speakers, cameras, and capture cards underneath alphabetically-earlier peripherals. A user adding a profile saw "Apple Inc. — Magic Keyboard" near the top and "Yeti Stereo Microphone" near the bottom: exactly the wrong order for a wizard whose job is to help users keep location-defining hardware ticked.

This PR introduces a two-tier sort that reuses the existing `DevicePortability.portabilityCategory(deviceName:)` predicate (the same one that powers the yellow "Suggested: untick" pill on portable rows):

```
✓ CalDigit Thunderbolt 3 Audio        ┐
✓ HDMI to U3 capture                   │  Top tier — non-portable,
✓ LG UltraFine Display Camera          │  alphabetical.
✓ Yeti Stereo Microphone              ┘
✓ Magic Trackpad     Suggested: untick (pointing device)  ┐
✓ Keychron K3        Suggested: untick (keyboard)          │  Bottom tier —
✓ iPhone             Suggested: untick (phone / wearable)  │  portable,
                                                            ┘  alphabetical.
  (disconnected saved devices, alphabetical)
```

Single source of truth: the pill (visual) and the row position (spatial) now agree by construction.

## What's deliberately not in this change

- **No new positive-match keyword list** ("microphone", "speaker", "camera"). Tempting, but it would be a parallel classifier to maintain alongside `DevicePortability`. Two tiers using the existing predicate is sufficient and keeps the configuration surface small.
- **No USB-class IOKit reads** (`bDeviceClass` = 0x01 audio / 0x0E video / 0x03 HID). More accurate but more mechanical. Defer until name-based tiering proves insufficient.
- **No watcher-layer change.** The engine library (`AVPainReliever`) stays free of wizard-specific UX policy. The watcher's own alphabetical sort still serves any future non-wizard consumer.

## Test plan

- [x] swift build clean
- [x] swift test — 164/164 (one new `deviceListPriorityTier` view-model case asserts both rules: tier first, alphabetical within tier)
- [ ] Hands-on: open Add Profile while docked → confirm mics/speakers/cameras/dock at the top, keyboards/mice/phones at the bottom with their existing pills
- [ ] Repeat in Edit Profile mode — same order; disconnected devices still pinned to the very bottom

## Pairs with #16

#16 just landed the "Fallback profile" hint when zero devices are ticked. This PR is the second half of that wizard refinement — together they ship as v0.1.16.