### PR TITLE
Wizard: priority tier + 'Suggested.' indicator on auto-filled names

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -59,11 +59,14 @@ struct AddProfileView: View {
                         // Hint defaults to brief instructions; switches
                         // to a quiet preview the moment a name is being
                         // typed so the user sees how it'll appear in
-                        // the menu bar.
+                        // the menu bar. When the name was auto-filled
+                        // from a recognised dock signature (e.g.
+                        // CalDigit → "Home Office"), prefix the hint
+                        // with "Suggested." so the auto-fill behavior
+                        // is discoverable rather than feeling like the
+                        // wizard read the user's mind.
                         if !viewModel.prettyPreview.isEmpty {
-                            Text("Will appear as “\(viewModel.prettyPreview)”")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            namePreviewCaption
                         } else {
                             Text("Pick anything human — letters, spaces, punctuation are fine.")
                                 .font(.caption)
@@ -244,6 +247,27 @@ struct AddProfileView: View {
             Text(title)
         } icon: {
             Image(systemName: symbol)
+        }
+    }
+
+    /// Caption under the Name field that previews the slug-cased
+    /// version. When the name was auto-filled from a recognised
+    /// dock signature (e.g. CalDigit → "Home Office"), prefix with
+    /// a bolded "Suggested." so the user knows the wizard guessed
+    /// rather than thinking the field magically populated itself.
+    /// The flag clears the moment the user edits the field, so any
+    /// human edit drops the prefix.
+    @ViewBuilder
+    private var namePreviewCaption: some View {
+        let preview = Text("Will appear as “\(viewModel.prettyPreview)”")
+        if viewModel.nameWasAutoSuggested {
+            (Text("Suggested. ").fontWeight(.medium) + preview)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            preview
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -31,7 +31,25 @@ struct PendingCollision: Identifiable, Equatable {
 final class AddProfileViewModel: ObservableObject {
     // MARK: - Form state
 
-    @Published var name: String = ""
+    @Published var name: String = "" {
+        didSet {
+            // Any user edit to the name field clears the
+            // auto-suggest flag — the value is no longer the
+            // suggestion, so the "Suggested" caption must drop.
+            // Guard against the trivial set-to-self case (refresh()
+            // re-running the same suggestion).
+            if name != oldValue && nameWasAutoSuggested {
+                nameWasAutoSuggested = false
+            }
+        }
+    }
+    /// True when the current `name` value was filled in by
+    /// `ProfileIcon.suggestedName(forDeviceNames:)` rather than typed
+    /// by the user. Drives a small "Suggested." caption in the wizard
+    /// so the auto-fill behavior is discoverable instead of looking
+    /// like the wizard guessed the user's mind. Reset by `name`'s
+    /// `didSet` the moment the user edits the field.
+    @Published private(set) var nameWasAutoSuggested: Bool = false
     @Published var audioInput: String? = nil
     @Published var audioOutput: String? = nil
     @Published var camera: String? = nil
@@ -223,6 +241,11 @@ final class AddProfileViewModel: ObservableObject {
             let deviceNames = liveSnapshot.compactMap { $0.name }
             if let suggested = ProfileIcon.suggestedName(forDeviceNames: deviceNames) {
                 name = PrettyName.format(suggested)
+                // Set AFTER the assignment — `name`'s didSet clears
+                // the flag, so we have to re-set true here for the
+                // wizard to know the value came from us, not the
+                // user.
+                nameWasAutoSuggested = true
             }
         }
     }
@@ -235,30 +258,39 @@ final class AddProfileViewModel: ObservableObject {
         audioDevices.filter(\.supportsOutput)
     }
 
-    /// Two-tier sort for the wizard's live device list. Top tier
-    /// holds devices that aren't flagged by `DevicePortability` —
-    /// mics, speakers, cameras, docks, hubs, capture cards, displays
-    /// — i.e. the hardware that defines a location. Bottom tier
-    /// holds the portable peripherals the wizard already suggests
-    /// unticking (keyboards, mice, phones, headphones, watches).
+    /// Three-tier sort for the wizard's live device list.
+    ///
+    /// - **Top: priority** — devices flagged by
+    ///   `DevicePortability.priorityCategory` (mics, speakers,
+    ///   cameras, capture cards, audio interfaces, displays). The
+    ///   hardware most likely to define a location.
+    /// - **Middle: neutral** — anything we don't classify either way
+    ///   (docks, hubs, card readers, control surfaces, brand-named
+    ///   peripherals our keyword lists don't catch).
+    /// - **Bottom: portable** — devices flagged by
+    ///   `DevicePortability.portabilityCategory` (keyboards, mice,
+    ///   phones, headphones, watches). Same predicate that powers
+    ///   the row's "Suggested: untick" pill, so the visual signal
+    ///   and the spatial signal agree.
+    ///
     /// Within each tier, items sort alphabetically by `displayName`
     /// so the order is stable across re-renders.
-    ///
-    /// Using the same predicate the row's "Suggested: untick" pill
-    /// uses keeps the visual signal (pill) and the spatial signal
-    /// (row position) in agreement — single source of truth in
-    /// `DevicePortability`.
     private static func sortedByTier(_ devices: [NamedUSBDevice])
         -> [NamedUSBDevice]
     {
-        devices.sorted { lhs, rhs in
-            let lhsPortable = DevicePortability
-                .portabilityCategory(deviceName: lhs.name) != nil
-            let rhsPortable = DevicePortability
-                .portabilityCategory(deviceName: rhs.name) != nil
-            if lhsPortable != rhsPortable {
-                return !lhsPortable
+        func tier(of device: NamedUSBDevice) -> Int {
+            if DevicePortability.priorityCategory(deviceName: device.name) != nil {
+                return 0
             }
+            if DevicePortability.portabilityCategory(deviceName: device.name) != nil {
+                return 2
+            }
+            return 1
+        }
+        return devices.sorted { lhs, rhs in
+            let lhsTier = tier(of: lhs)
+            let rhsTier = tier(of: rhs)
+            if lhsTier != rhsTier { return lhsTier < rhsTier }
             return lhs.displayName < rhs.displayName
         }
     }

--- a/Sources/AVPainRelieverApp/DevicePortability.swift
+++ b/Sources/AVPainRelieverApp/DevicePortability.swift
@@ -77,4 +77,44 @@ enum DevicePortability {
         // Wearables
         "airpods", "watch", "headphones", "headset", "earbuds", "buds",
     ]
+
+    /// Short label for high-priority "this defines a location"
+    /// devices — microphones, speakers, cameras, capture cards,
+    /// audio interfaces, displays. Mirror of `portabilityCategory`
+    /// but for the OTHER end of the importance scale: the wizard's
+    /// device-list sort floats these to the top so a user adding a
+    /// profile sees the hardware that distinguishes their dock
+    /// before they see anything generic.
+    ///
+    /// Conservative same as the portability matcher — only words
+    /// that are reliably tied to location-defining hardware
+    /// regardless of brand. "Microphone" is safer than "blue"
+    /// (could be a vendor name); "audio" is safer than "stream"
+    /// (Stream Deck is a control deck, not audio).
+    static func priorityCategory(deviceName: String?) -> String? {
+        guard let name = deviceName?.lowercased(), !name.isEmpty else {
+            return nil
+        }
+        if name.contains("microphone") || name.contains("podcast") {
+            return "microphone"
+        }
+        if name.contains("camera") || name.contains("capture") || name.contains("webcam") {
+            return "camera"
+        }
+        if name.contains("speaker") {
+            return "speaker"
+        }
+        // "audio" is broad — covers "Audio Interface", "Display Audio",
+        // "Thunderbolt 3 Audio". Useful but means we group docks-with-
+        // audio in with mics/speakers. Acceptable for sort priority;
+        // the alternative (more specific keywords) misses too many
+        // real-world products.
+        if name.contains("audio") || name.contains("dac") {
+            return "audio"
+        }
+        if name.contains("display") || name.contains("monitor") {
+            return "display"
+        }
+        return nil
+    }
 }

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -329,12 +329,11 @@ struct AddProfileViewModelTests {
         #expect(Set(loaded.map(\.name)) == ["home-studio"])
     }
 
-    @Test("device list sorts non-portable items above portable ones")
-    func deviceListPriorityTier() {
+    @Test("device list sorts priority above neutral above portable")
+    func deviceListThreeTierSort() {
         let watcher = FakeWatcher()
-        // Mix of portable and non-portable devices, deliberately
-        // out of order so the sort has work to do regardless of
-        // the watcher's own ordering.
+        // One device per tier, plus an extra priority device, all
+        // deliberately out of order so the sort has work to do.
         watcher.named = [
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x05ac, productID: 0x0265),
@@ -343,15 +342,19 @@ struct AddProfileViewModelTests {
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x2188, productID: 0x6533),
                 name: "CalDigit Thunderbolt 3 Audio"
-            ), // non-portable
+            ), // priority (matches "audio")
             NamedUSBDevice(
-                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
-                name: "Keychron K3"
-            ), // portable
+                device: USBDevice(vendorID: 0x0fd9, productID: 0x0080),
+                name: "Stream Deck MK.2"
+            ), // neutral
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x1e4e, productID: 0x701f),
                 name: "HDMI to U3 capture"
-            ), // non-portable
+            ), // priority (matches "capture")
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x046d, productID: 0x0ab7),
+                name: "Blue Microphones"
+            ), // priority (matches "microphone")
         ]
         let vm = AddProfileViewModel(
             watcher: watcher,
@@ -363,11 +366,57 @@ struct AddProfileViewModelTests {
         )
         let names = vm.attachedDevices.map(\.name)
         #expect(names == [
-            "CalDigit Thunderbolt 3 Audio",  // non-portable, alphabetical
-            "HDMI to U3 capture",             // non-portable, alphabetical
-            "Keychron K3",                    // portable, alphabetical
-            "Magic Trackpad",                 // portable, alphabetical
+            "Blue Microphones",              // priority, alphabetical
+            "CalDigit Thunderbolt 3 Audio",  // priority, alphabetical
+            "HDMI to U3 capture",            // priority, alphabetical
+            "Stream Deck MK.2",              // neutral
+            "Magic Trackpad",                // portable
         ])
+    }
+
+    @Test("nameWasAutoSuggested is true after first refresh on a recognized dock")
+    func nameAutoSuggestSetsFlag() {
+        let watcher = FakeWatcher()
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x6533),
+                name: "CalDigit Thunderbolt 3 Audio"
+            )
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/sug.toml"),
+            editing: nil,
+            onSaved: {}
+        )
+        // CalDigit triggers the "home-office" suggestion in
+        // ProfileIcon.suggestedName.
+        #expect(vm.name == "Home Office")
+        #expect(vm.nameWasAutoSuggested == true)
+    }
+
+    @Test("editing the name clears the auto-suggested flag")
+    func editingNameClearsAutoSuggestedFlag() {
+        let watcher = FakeWatcher()
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x6533),
+                name: "CalDigit Thunderbolt 3 Audio"
+            )
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/edit.toml"),
+            editing: nil,
+            onSaved: {}
+        )
+        #expect(vm.nameWasAutoSuggested == true)
+        vm.name = "Custom Name"
+        #expect(vm.nameWasAutoSuggested == false)
     }
 
     @Test("willMatchAnywhere is true when no devices are ticked")


### PR DESCRIPTION
## Summary

Two follow-ups to the wizard refinements that landed in v0.1.16. Real-world feedback from a user running v0.1.16 / v0.2.0.4 with a CalDigit dock attached:

1. The new sort wasn't visibly different — mics, audio, capture cards still appeared in alphabetical position. Reason: `DevicePortability.portabilityCategory` is purely a *negative* classifier (matches "keyboard"/"trackpad"/"iphone" only). Devices that *should* be priority don't trigger the classifier in either direction, so they fall through to alphabetical.
2. The auto-filled profile name ("Home Office" appearing the moment the wizard opens against a CalDigit dock) read as the wizard guessing the user's mind. The pre-fill is a real feature (`ProfileIcon.suggestedName`) but it's silent — no UI cue.

## Fix

**Priority tier:** new `DevicePortability.priorityCategory(deviceName:)` matches names containing "microphone", "audio", "speaker", "camera", "capture", "display". `AddProfileViewModel.sortedByTier` becomes three-tier (priority → neutral → portable), alphabetical within each tier. Same name-only data we already have, no new IOKit reads.

**"Suggested." caption:** new `nameWasAutoSuggested` flag on the view model is set when `refresh()` accepts a suggestion from `ProfileIcon.suggestedName`, reset by `name`'s `didSet` the moment the user edits. The slug-preview caption prefixes with a bolded **"Suggested."** while the flag is true.

## Test plan

- [x] swift build clean
- [x] swift test — 166/166 (1 updated tier test, 2 new auto-suggest tests covering set + reset paths)
- [ ] Hands-on with CalDigit + Blue Mic + Stream Deck + Keychron attached: open Add Profile, expect Blue Microphones / CalDigit Thunderbolt 3 Audio at the very top, Stream Deck and hubs in the middle, Magic Trackpad / iPhone at the bottom (Keychron lands neutral because its name doesn't trigger the portable classifier — separate follow-up if we want brand-specific matching)
- [ ] Open Add Profile fresh: name field shows "Home Office", caption reads "**Suggested.** Will appear as 'Home Office'"
- [ ] Edit the name to anything: caption drops to "Will appear as '...'"