### PR TITLE
Wizard: flip defaults so Important = ticked, everything else = unticked

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -298,7 +298,7 @@ struct AddProfileView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
         } else {
-            Text("Uncheck peripherals that aren't unique to this location (keyboards, mice, phones). The profile matches when every checked device is attached.")
+            Text("Important hardware (mics, cameras, capture cards, audio interfaces) is pre-selected. Tick anything else that uniquely identifies this location. The profile matches when every ticked device is attached.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -330,16 +330,32 @@ struct AddProfileView: View {
                                     // location. Yellow pill makes
                                     // the unavailable state obvious.
                                     pill(text: "Not connected", tint: Theme.Color.warn)
+                                } else if DevicePortability
+                                    .portabilityCategory(deviceName: entry.name) != nil {
+                                    // Muted gray "Travels with you"
+                                    // pill on portable peripherals
+                                    // (keyboards, mice, phones,
+                                    // AirPods, watches, headphones).
+                                    // These are auto-unticked by the
+                                    // view model — the pill is
+                                    // informational, explaining why
+                                    // the row is shown unticked. Tone
+                                    // is descriptive, not directive.
+                                    pill(text: "Travels with you", tint: Theme.Color.muted)
                                 } else if let category = DevicePortability
-                                    .portabilityCategory(deviceName: entry.name) {
-                                    // Yellow "Suggested: untick" pill so
-                                    // the user immediately spots the
-                                    // travelling peripherals (keyboards,
-                                    // mice, phones) that shouldn't go in
-                                    // a location fingerprint. Hint, not
-                                    // an instruction — the user is free
-                                    // to keep them ticked.
-                                    pill(text: "Suggested: untick (\(category))", tint: Theme.Color.warn)
+                                    .importantCategory(deviceName: entry.name) {
+                                    // Green "Important" pill on the
+                                    // headline hardware that's most
+                                    // likely defining this location —
+                                    // dedicated mics, cameras, capture
+                                    // cards, audio interfaces.
+                                    // Auto-ticked by the view model;
+                                    // pill confirms the auto-selection
+                                    // and explains why. Mutually
+                                    // exclusive with "Travels with you"
+                                    // by classifier construction
+                                    // (their keywords don't overlap).
+                                    pill(text: "Important: \(category)", tint: Theme.Color.success)
                                 }
                             }
                             Text(idLine(for: entry.device))

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -122,6 +122,15 @@ final class AddProfileViewModel: ObservableObject {
     private let configURL: URL
     private let onSaved: () -> Void
     private let editingSlug: String?
+    /// Slugs of all profiles that already exist in the user's
+    /// config. The wizard consults this to suppress
+    /// `ProfileIcon.suggestedName` when its proposed slug is
+    /// already taken — auto-filling "home-office" when the user
+    /// already has a Home Office profile would just create a
+    /// pre-loaded collision they'd have to resolve at save time.
+    /// Empty set means "don't suppress" (used by tests + the
+    /// pre-collision-check codepath).
+    private let existingProfileSlugs: Set<String>
 
     /// Saved fingerprint from the profile being edited — preserved
     /// verbatim across `refresh()` so saved-but-disconnected devices
@@ -140,6 +149,7 @@ final class AddProfileViewModel: ObservableObject {
         cameraController: CameraController,
         configURL: URL,
         editing: Profile? = nil,
+        existingProfileSlugs: Set<String> = [],
         onSaved: @escaping () -> Void
     ) {
         self.watcher = watcher
@@ -148,6 +158,7 @@ final class AddProfileViewModel: ObservableObject {
         self.configURL = configURL
         self.onSaved = onSaved
         self.editingSlug = editing?.name
+        self.existingProfileSlugs = existingProfileSlugs
 
         if let profile = editing {
             // Pre-populate from the existing profile so the user can
@@ -211,15 +222,32 @@ final class AddProfileViewModel: ObservableObject {
             + disconnected.sorted { $0.displayName < $1.displayName }
         disconnectedDeviceIDs = disconnectedIDs
 
-        // Default selection: every currently-attached device,
-        // including unnamed hub legs. Capturing more is the safer
-        // default — the user knows what's plugged in right now and
-        // can uncheck peripherals (keyboards/mice/phones) that
-        // aren't location-specific. Including hub legs is fine
-        // because they're stable parts of the dock. (Skipped when
-        // editing — the saved fingerprint pre-populates selection.)
-        if selectedDeviceIDs.isEmpty {
-            selectedDeviceIDs = Set(liveSnapshot.map(\.device))
+        // Default selection: only the headline hardware classified
+        // as Important (mics, cameras, capture cards, dedicated
+        // audio interfaces). Earlier versions auto-ticked every
+        // attached device and required the user to deliberately
+        // untick the peripherals that travel — but that loaded
+        // cognitive work onto the user and produced over-broad
+        // fingerprints (a Magic Keyboard quietly winds up in a
+        // home-office fingerprint because the user forgot to
+        // untick it).
+        //
+        // Now: tick only the things we have a confident "this
+        // defines the location" signal on. The user actively ticks
+        // anything else they want in the fingerprint (hub legs,
+        // displays, Stream Decks, etc. — all visible but unticked).
+        // Skipped when editing: the saved fingerprint already
+        // populated `selectedDeviceIDs` before refresh() runs, so
+        // the empty-check fails and existing selections survive.
+        if selectedDeviceIDs.isEmpty && editingSlug == nil {
+            selectedDeviceIDs = Set(
+                liveSnapshot
+                    .filter {
+                        DevicePortability
+                            .importantCategory(deviceName: $0.name) != nil
+                    }
+                    .map(\.device)
+            )
         }
         audioDevices = audioController.availableDevices()
         cameras = cameraController.availableCameras()
@@ -239,7 +267,15 @@ final class AddProfileViewModel: ObservableObject {
         // editing keeps the existing name. The user can always rename.
         if name.isEmpty && editingSlug == nil {
             let deviceNames = liveSnapshot.compactMap { $0.name }
-            if let suggested = ProfileIcon.suggestedName(forDeviceNames: deviceNames) {
+            if let suggested = ProfileIcon.suggestedName(forDeviceNames: deviceNames),
+               !existingProfileSlugs.contains(suggested)
+            {
+                // Skip the auto-fill when a profile by the suggested
+                // slug already exists. The user clicking "Add Profile"
+                // is asking for a NEW location, not a recapture of
+                // the existing one — pre-loading the same name would
+                // just queue up a save-time collision they'd have to
+                // resolve.
                 name = PrettyName.format(suggested)
                 // Set AFTER the assignment — `name`'s didSet clears
                 // the flag, so we have to re-set true here for the
@@ -258,39 +294,36 @@ final class AddProfileViewModel: ObservableObject {
         audioDevices.filter(\.supportsOutput)
     }
 
-    /// Three-tier sort for the wizard's live device list.
+    /// Two-tier sort for the wizard's live device list. Top tier
+    /// holds devices that aren't flagged by `DevicePortability` —
+    /// docks, hubs, mics, speakers, cameras, capture cards,
+    /// displays, etc. — i.e. the location-bound hardware. Bottom
+    /// tier holds the portable peripherals the wizard already
+    /// suggests unticking (keyboards, mice, phones, headphones,
+    /// watches). Within each tier, items sort alphabetically by
+    /// `displayName` so the order is stable across re-renders.
     ///
-    /// - **Top: priority** — devices flagged by
-    ///   `DevicePortability.priorityCategory` (mics, speakers,
-    ///   cameras, capture cards, audio interfaces, displays). The
-    ///   hardware most likely to define a location.
-    /// - **Middle: neutral** — anything we don't classify either way
-    ///   (docks, hubs, card readers, control surfaces, brand-named
-    ///   peripherals our keyword lists don't catch).
-    /// - **Bottom: portable** — devices flagged by
-    ///   `DevicePortability.portabilityCategory` (keyboards, mice,
-    ///   phones, headphones, watches). Same predicate that powers
-    ///   the row's "Suggested: untick" pill, so the visual signal
-    ///   and the spatial signal agree.
-    ///
-    /// Within each tier, items sort alphabetically by `displayName`
-    /// so the order is stable across re-renders.
+    /// Important devices (mics, cameras, capture cards, dedicated
+    /// audio interfaces) get a green **Important** pill in the
+    /// row UI rather than being lifted to a separate tier — earlier
+    /// experimentation showed that for sophisticated docks almost
+    /// every device qualifies as "important," which collapsed the
+    /// tier and gave no visible benefit over alphabetical. The pill
+    /// gives the same signal without disturbing the row order.
+    /// Single source of truth for both pills:
+    /// `DevicePortability.importantCategory` /
+    /// `DevicePortability.portabilityCategory`.
     private static func sortedByTier(_ devices: [NamedUSBDevice])
         -> [NamedUSBDevice]
     {
-        func tier(of device: NamedUSBDevice) -> Int {
-            if DevicePortability.priorityCategory(deviceName: device.name) != nil {
-                return 0
+        devices.sorted { lhs, rhs in
+            let lhsPortable = DevicePortability
+                .portabilityCategory(deviceName: lhs.name) != nil
+            let rhsPortable = DevicePortability
+                .portabilityCategory(deviceName: rhs.name) != nil
+            if lhsPortable != rhsPortable {
+                return !lhsPortable
             }
-            if DevicePortability.portabilityCategory(deviceName: device.name) != nil {
-                return 2
-            }
-            return 1
-        }
-        return devices.sorted { lhs, rhs in
-            let lhsTier = tier(of: lhs)
-            let rhsTier = tier(of: rhs)
-            if lhsTier != rhsTier { return lhsTier < rhsTier }
             return lhs.displayName < rhs.displayName
         }
     }

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -449,6 +449,7 @@ private struct WizardForm: View {
             cameraController: deps.cameraController,
             configURL: deps.configURL,
             editing: deps.editing,
+            existingProfileSlugs: deps.existingProfileSlugs,
             onSaved: deps.onSaved
         ))
     }

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -16,6 +16,12 @@ struct AddProfileDependencies {
     let cameraController: CameraController
     let configURL: URL
     let editing: Profile?
+    /// Slugs of profiles already saved in the user's config. The
+    /// wizard's auto-suggest path consults this to suppress
+    /// `ProfileIcon.suggestedName` when the proposed name is
+    /// already taken — preventing the wizard from pre-loading a
+    /// duplicate name that would collide at save time.
+    let existingProfileSlugs: Set<String>
     let onSaved: () -> Void
 }
 
@@ -389,12 +395,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     func addProfileDependencies() -> AddProfileDependencies {
         let editing = profileBeingEdited
         profileBeingEdited = nil
+        // Snapshot the current profile slugs at wizard-open time so
+        // the auto-suggest can avoid proposing a name the user
+        // already has. When editing, exclude the editing profile's
+        // own slug so its name doesn't suppress its own suggestion
+        // (the wizard's name field is pre-populated from the
+        // editing profile separately).
+        let existing = Set(availableProfiles.map(\.name))
+            .subtracting([editing?.name].compactMap { $0 })
         return AddProfileDependencies(
             watcher: IOKitUSBWatcher(),
             audioController: CoreAudioController(),
             cameraController: AVFoundationCameraController(),
             configURL: Self.profilesTOMLURL,
             editing: editing,
+            existingProfileSlugs: existing,
             onSaved: { [weak self] in
                 // Saving any profile is taken as the user being
                 // committed — no need to keep showing the welcome

--- a/Sources/AVPainRelieverApp/DevicePortability.swift
+++ b/Sources/AVPainRelieverApp/DevicePortability.swift
@@ -78,42 +78,56 @@ enum DevicePortability {
         "airpods", "watch", "headphones", "headset", "earbuds", "buds",
     ]
 
-    /// Short label for high-priority "this defines a location"
-    /// devices — microphones, speakers, cameras, capture cards,
-    /// audio interfaces, displays. Mirror of `portabilityCategory`
-    /// but for the OTHER end of the importance scale: the wizard's
-    /// device-list sort floats these to the top so a user adding a
-    /// profile sees the hardware that distinguishes their dock
-    /// before they see anything generic.
+    /// Short label for "headline hardware" — the standalone,
+    /// dedicated devices a user is most likely to pick as their
+    /// audio in/out/camera defaults at this location. Drives the
+    /// wizard's green "Important: \(category)" pill. Mirror of
+    /// `portabilityCategory` but on the opposite end of the
+    /// importance scale.
     ///
-    /// Conservative same as the portability matcher — only words
-    /// that are reliably tied to location-defining hardware
-    /// regardless of brand. "Microphone" is safer than "blue"
-    /// (could be a vendor name); "audio" is safer than "stream"
-    /// (Stream Deck is a control deck, not audio).
-    static func priorityCategory(deviceName: String?) -> String? {
+    /// Specifically excludes display sub-components (LG UltraFine
+    /// Display Audio / Camera / Controls). Those are real,
+    /// functional USB devices — a Thunderbolt monitor exposes its
+    /// built-in camera, audio, and HID controls as separate USB
+    /// endpoints — but they're sub-components of a larger display,
+    /// not the dedicated hardware most users default to. A user
+    /// with the LG UltraFine plus an external webcam almost
+    /// always picks the external. Keeping display sub-components
+    /// off the Important list preserves the pill's signal value.
+    /// Users who DO default to a display's built-in camera can
+    /// still tick it manually — the pill is informational, not
+    /// gating.
+    static func importantCategory(deviceName: String?) -> String? {
         guard let name = deviceName?.lowercased(), !name.isEmpty else {
+            return nil
+        }
+        // Display / monitor hub-leg sub-components: skip even when
+        // they technically contain audio / camera keywords. The
+        // "ultrafine" check catches the LG UltraFine line whose
+        // camera/audio/controls all contain "UltraFine" in their
+        // product names; future monitors with similar branding
+        // would need their brand added here.
+        if name.contains("display") || name.contains("ultrafine") {
             return nil
         }
         if name.contains("microphone") || name.contains("podcast") {
             return "microphone"
         }
-        if name.contains("camera") || name.contains("capture") || name.contains("webcam") {
+        if name.contains("camera") || name.contains("webcam") {
             return "camera"
+        }
+        if name.contains("capture") {
+            return "capture card"
         }
         if name.contains("speaker") {
             return "speaker"
         }
-        // "audio" is broad — covers "Audio Interface", "Display Audio",
-        // "Thunderbolt 3 Audio". Useful but means we group docks-with-
-        // audio in with mics/speakers. Acceptable for sort priority;
-        // the alternative (more specific keywords) misses too many
-        // real-world products.
+        // "audio" without a display/ultrafine prefix is reliable
+        // shorthand for a dedicated audio interface (CalDigit
+        // Thunderbolt 3 Audio, RME, Apollo, etc.). The earlier
+        // exclusion drops display-audio sub-components.
         if name.contains("audio") || name.contains("dac") {
-            return "audio"
-        }
-        if name.contains("display") || name.contains("monitor") {
-            return "display"
+            return "audio interface"
         }
         return nil
     }

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -28,6 +28,13 @@ enum Theme {
         /// icon. System red, same as Apple's own destructive action
         /// styling.
         static let error = SwiftUI.Color.red
+        /// Quiet, informational pills — "Travels with you" tag on
+        /// portable peripherals in the wizard. Lower visual volume
+        /// than the warn / success / error tints so the
+        /// informational signal doesn't compete with the actionable
+        /// pills (green Important, yellow error banners). System
+        /// gray adapts to light/dark mode automatically.
+        static let muted = SwiftUI.Color.gray
     }
 
     enum Symbol {

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -329,11 +329,9 @@ struct AddProfileViewModelTests {
         #expect(Set(loaded.map(\.name)) == ["home-studio"])
     }
 
-    @Test("device list sorts priority above neutral above portable")
-    func deviceListThreeTierSort() {
+    @Test("device list sorts non-portable items above portable ones")
+    func deviceListTwoTierSort() {
         let watcher = FakeWatcher()
-        // One device per tier, plus an extra priority device, all
-        // deliberately out of order so the sort has work to do.
         watcher.named = [
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x05ac, productID: 0x0265),
@@ -342,19 +340,15 @@ struct AddProfileViewModelTests {
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x2188, productID: 0x6533),
                 name: "CalDigit Thunderbolt 3 Audio"
-            ), // priority (matches "audio")
+            ), // non-portable
             NamedUSBDevice(
-                device: USBDevice(vendorID: 0x0fd9, productID: 0x0080),
-                name: "Stream Deck MK.2"
-            ), // neutral
+                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
+                name: "Magic Keyboard"
+            ), // portable
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x1e4e, productID: 0x701f),
                 name: "HDMI to U3 capture"
-            ), // priority (matches "capture")
-            NamedUSBDevice(
-                device: USBDevice(vendorID: 0x046d, productID: 0x0ab7),
-                name: "Blue Microphones"
-            ), // priority (matches "microphone")
+            ), // non-portable
         ]
         let vm = AddProfileViewModel(
             watcher: watcher,
@@ -365,13 +359,42 @@ struct AddProfileViewModelTests {
             onSaved: {}
         )
         let names = vm.attachedDevices.map(\.name)
+        // Non-portable items above portable, alphabetical within
+        // each tier. Important devices are signaled via the green
+        // "Important" pill in the row UI (see DevicePortability
+        // tests), not by floating to a separate tier.
         #expect(names == [
-            "Blue Microphones",              // priority, alphabetical
-            "CalDigit Thunderbolt 3 Audio",  // priority, alphabetical
-            "HDMI to U3 capture",            // priority, alphabetical
-            "Stream Deck MK.2",              // neutral
-            "Magic Trackpad",                // portable
+            "CalDigit Thunderbolt 3 Audio",  // non-portable, alphabetical
+            "HDMI to U3 capture",            // non-portable, alphabetical
+            "Magic Keyboard",                // portable, alphabetical
+            "Magic Trackpad",                // portable, alphabetical
         ])
+    }
+
+    @Test("auto-suggest is suppressed when the proposed name already exists")
+    func autoSuggestSuppressedOnSlugCollision() {
+        let watcher = FakeWatcher()
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x6533),
+                name: "CalDigit Thunderbolt 3 Audio"
+            )
+        ]
+        // CalDigit would suggest "home-office" — but the user
+        // already has one. The wizard must NOT auto-fill in that
+        // case; it should leave the name field empty so the user
+        // explicitly names their new profile.
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/coll.toml"),
+            editing: nil,
+            existingProfileSlugs: ["home-office"],
+            onSaved: {}
+        )
+        #expect(vm.name == "")
+        #expect(vm.nameWasAutoSuggested == false)
     }
 
     @Test("nameWasAutoSuggested is true after first refresh on a recognized dock")
@@ -423,13 +446,13 @@ struct AddProfileViewModelTests {
     func willMatchAnywhereOnEmptySelection() {
         let url = URL(fileURLWithPath: "/tmp/wma.toml")
         let watcher = FakeWatcher()
-        // Watcher returns one attached device so the selection is
-        // non-default — the auto-tick logic in refresh() picks it up,
-        // exercising both states of the property.
+        // Watcher returns one Important device so it gets auto-
+        // ticked by refresh(). Lets the test exercise both states
+        // (something ticked → false; everything cleared → true).
         watcher.named = [
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x2188, productID: 0x6533),
-                name: "CalDigit"
+                name: "CalDigit Thunderbolt 3 Audio"
             )
         ]
         let vm = AddProfileViewModel(
@@ -440,13 +463,78 @@ struct AddProfileViewModelTests {
             editing: nil,
             onSaved: {}
         )
-        // With one auto-ticked device, willMatchAnywhere is false.
+        // With one auto-ticked Important device, willMatchAnywhere
+        // is false.
         #expect(vm.selectedDeviceIDs.isEmpty == false)
         #expect(vm.willMatchAnywhere == false)
 
         // Untick everything. Now this profile is the implicit
         // fallback at save time — the wizard hint covers this state.
         vm.selectedDeviceIDs.removeAll()
+        #expect(vm.willMatchAnywhere == true)
+    }
+
+    @Test("default tick selects only Important devices, not all live ones")
+    func defaultTickFiltersToImportantOnly() {
+        let watcher = FakeWatcher()
+        let importantDevice = USBDevice(vendorID: 0x2188, productID: 0x6533)
+        let portableDevice = USBDevice(vendorID: 0x05ac, productID: 0x024f)
+        let neutralDevice = USBDevice(vendorID: 0x0fd9, productID: 0x0080)
+        watcher.named = [
+            NamedUSBDevice(
+                device: importantDevice,
+                name: "CalDigit Thunderbolt 3 Audio"
+            ), // Important (matches "audio")
+            NamedUSBDevice(
+                device: portableDevice,
+                name: "Magic Keyboard"
+            ), // Portable
+            NamedUSBDevice(
+                device: neutralDevice,
+                name: "Stream Deck MK.2"
+            ), // Neutral
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/auto.toml"),
+            editing: nil,
+            onSaved: {}
+        )
+        // Only the Important device is auto-ticked. The portable
+        // and neutral devices appear in the list (visible to the
+        // user, with their respective pills) but unticked by
+        // default. The user actively ticks anything else they want
+        // in the fingerprint.
+        #expect(vm.selectedDeviceIDs == [importantDevice])
+    }
+
+    @Test("default tick yields empty selection when nothing Important is attached")
+    func defaultTickEmptyWhenNoImportantDevices() {
+        let watcher = FakeWatcher()
+        watcher.named = [
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
+                name: "Magic Keyboard"
+            ), // Portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x0fd9, productID: 0x0080),
+                name: "Stream Deck MK.2"
+            ), // Neutral
+        ]
+        let vm = AddProfileViewModel(
+            watcher: watcher,
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: URL(fileURLWithPath: "/tmp/empty.toml"),
+            editing: nil,
+            onSaved: {}
+        )
+        // No Important hardware → nothing auto-ticks → the
+        // wizard's "Fallback profile" hint kicks in via
+        // willMatchAnywhere = true.
+        #expect(vm.selectedDeviceIDs.isEmpty)
         #expect(vm.willMatchAnywhere == true)
     }
 }

--- a/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
+++ b/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
@@ -43,4 +43,65 @@ struct DevicePortabilityTests {
         #expect(DevicePortability.portabilityCategory(deviceName: "Apple Watch") == "watch")
         #expect(DevicePortability.portabilityCategory(deviceName: "CalDigit") == nil)
     }
+
+    // MARK: - Important pill classifier
+    //
+    // The headline-hardware classifier the wizard uses to render
+    // its green "Important: <category>" pill. Tighter than
+    // "anything that could matter" — display sub-components are
+    // explicitly excluded so the pill stays visually distinct on
+    // sophisticated docks.
+
+    @Test("standalone mics, cameras, capture cards, and audio interfaces are flagged")
+    func importantHeadlineHardware() {
+        #expect(DevicePortability.importantCategory(deviceName: "Yeti Stereo Microphone") == "microphone")
+        #expect(DevicePortability.importantCategory(deviceName: "Shure MV7 podcast mic") == "microphone")
+        #expect(DevicePortability.importantCategory(deviceName: "FaceTime HD Camera") == "camera")
+        #expect(DevicePortability.importantCategory(deviceName: "Logitech webcam") == "camera")
+        #expect(DevicePortability.importantCategory(deviceName: "HDMI to U3 capture") == "capture card")
+        #expect(DevicePortability.importantCategory(deviceName: "CalDigit Thunderbolt 3 Audio") == "audio interface")
+        #expect(DevicePortability.importantCategory(deviceName: "External DAC") == "audio interface")
+    }
+
+    @Test("display sub-components are NOT flagged as Important")
+    func importantExcludesDisplaySubcomponents() {
+        // The LG UltraFine line exposes its built-in audio,
+        // camera, and HID controls as separate USB devices. They
+        // are real, functional devices but they're not the
+        // dedicated hardware most users default to. Excluding
+        // them keeps the Important pill exclusive on docks
+        // where the user has both a monitor and dedicated
+        // peripherals.
+        #expect(DevicePortability.importantCategory(deviceName: "LG UltraFine Display Audio") == nil)
+        #expect(DevicePortability.importantCategory(deviceName: "LG UltraFine Display Camera") == nil)
+        #expect(DevicePortability.importantCategory(deviceName: "LG UltraFine Display Controls") == nil)
+        // Generic "Display" prefixing also excludes:
+        #expect(DevicePortability.importantCategory(deviceName: "Pro Display XDR Speakers") == nil)
+    }
+
+    @Test("Important and portability classifiers are mutually exclusive")
+    func importantAndPortableMutuallyExclusive() {
+        // A device that's flagged portable (Magic Trackpad,
+        // iPhone, etc.) must NOT also be flagged Important.
+        // The pill UI assumes mutual exclusivity — the row's
+        // pill slot only holds one tag.
+        let portableNames = ["Magic Keyboard", "Magic Trackpad", "iPhone", "AirPods", "Apple Watch"]
+        for name in portableNames {
+            #expect(DevicePortability.portabilityCategory(deviceName: name) != nil)
+            #expect(DevicePortability.importantCategory(deviceName: name) == nil)
+        }
+    }
+
+    @Test("nil and empty names yield nil Important")
+    func importantNilEmpty() {
+        #expect(DevicePortability.importantCategory(deviceName: nil) == nil)
+        #expect(DevicePortability.importantCategory(deviceName: "") == nil)
+    }
+
+    @Test("hub legs and generic peripherals don't get the Important pill")
+    func importantSkipsGenericPeripherals() {
+        #expect(DevicePortability.importantCategory(deviceName: "USB2.1 Hub") == nil)
+        #expect(DevicePortability.importantCategory(deviceName: "Stream Deck MK.2") == nil)
+        #expect(DevicePortability.importantCategory(deviceName: "Card Reader") == nil)
+    }
 }


### PR DESCRIPTION
## Summary

Three coordinated wizard changes that together rework how the user is handed a starting fingerprint:

1. **Auto-tick filters to Important devices only.** Previously every currently-attached USB device was auto-ticked and the user had to actively untick portable peripherals. That loaded cognitive work and produced over-broad fingerprints. Now the wizard ticks only what `DevicePortability.importantCategory` flags as headline hardware (microphones, cameras, capture cards, dedicated audio interfaces); the user actively ticks anything else.
2. **Three-state pill model:**
   - 🟢 **"Important: \<category\>"** — auto-ticked, location-defining hardware
   - ⚪ **"Travels with you"** — auto-unticked portable peripherals (replaces the old yellow "Suggested: untick"; the nudge is redundant once the device is unticked by default)
   - ⊘ no pill — neutral devices (hub legs, displays, card readers, Stream Decks). Quietly available.
3. **Auto-suggest collision suppression.** When `ProfileIcon.suggestedName` would propose a name that already exists as a profile, suppress the auto-fill. The wizard caller passes `existingProfileSlugs` to the view model.

## How users experience this

Open Add Profile against a docked Mac with CalDigit + Blue Mic + HDMI capture + LG UltraFine + Magic Keyboard:

| Row | Pill | Ticked? |
|---|---|---|
| Generic — Blue Microphones | 🟢 Important: microphone | ✅ |
| CalDigit, Inc. — CalDigit Thunderbolt 3 Audio | 🟢 Important: audio interface | ✅ |
| Video Grabber — HDMI to U3 capture | 🟢 Important: capture card | ✅ |
| LG Electronics Inc. — LG UltraFine Display Audio / Camera / Controls | (none) | ◯ |
| (unnamed device) hub legs | (none) | ◯ |
| Apple Inc. — Magic Keyboard | ⚪ Travels with you | ◯ |

Helper text under the section: "Important hardware is pre-selected. Tick anything else that uniquely identifies this location. The profile matches when every ticked device is attached."

If a profile named "Home Office" already exists, the Name field stays empty rather than pre-filling a guaranteed collision.

## Edit Profile mode

Unchanged behavior — the saved fingerprint pre-populates `selectedDeviceIDs` before `refresh()` runs, so the empty-check fails and existing selections survive. A user editing an old over-broad fingerprint still sees their full saved selection; nothing is silently dropped.

## Test plan

- [x] swift build clean
- [x] swift test — 174/174 (new cases: default-tick filters to Important, default-tick yields empty when nothing Important is attached, Important classifier mutual exclusivity with portability, slug-collision suppression)
- [x] Hands-on verification on docked Mac — visual layout matches expectations, name field empty (Home Office already exists), three Important pills auto-tick, helper text reads as updated, "Fallback profile" hint appears when all Important devices unticked, Edit Profile preserves saved fingerprint

## What's deliberately not in this change

- **No "Consider ticking" pill on neutral devices.** Decided against in design discussion: pilling all neutrals creates noise; pilling some requires a heuristic we don't have. Quietly-available with no pill preserves signal value of the pills we DO show.
- **No virtual-camera reference in the camera-section caption.** The virtual camera is still experimental-track only. We'll update the caption to mention it once v0.2.x graduates to stable. Tracked separately.