### PR TITLE
ci: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot keeps the GitHub Actions versions in our workflows
+# fresh. Swift packages are intentionally NOT included — Sparkle is
+# pinned `upToNextMinor` in Package.swift for notarization-stability
+# reasons (see the comment there); auto-PRs would directly contradict
+# that rule. TOMLKit is pre-1.0; every bump is potentially breaking.
+# Both are bumped manually as deliberate decisions.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configured to bump GitHub Actions versions weekly (cap of 5 open PRs, `ci:` commit prefix).
- Deliberately excludes Swift packages — Sparkle is pinned `upToNextMinor` for notarization-stability reasons (see Package.swift), and TOMLKit is pre-1.0 where every bump is potentially breaking. Both stay manual.

## Test plan
- [ ] Merge and wait one weekly cycle; confirm Dependabot opens PRs against any out-of-date action versions in `release.yml` / `test.yml`.
- [ ] Flip on Dependabot alerts in Settings → Code security & analysis (separate from this config — handles CVE notifications for Swift packages without auto-PRing version bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)