### PR TITLE
Virtual camera: stop host from opening its own output as a source

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3331,6 +3331,66 @@ Pieces left untouched:
   Reliever once" instruction stays the contract; we don't
   over-ride to be helpful.
 
+### Self-source feedback loop on late consumer connect (2026-05-05)
+
+User report: virtual camera frozen on one frame intermittently
+when sourcing from the office Neat Bar. FaceTime as the
+source worked fine. Frames showed flowing in the log, just
+all the same frame.
+
+Two interacting bugs from the prior two days landed us here:
+
+1. **`preferredCameraOverride` set `userPreferredCamera` to
+   the virtual camera** (the right call for Zoom/FaceTime
+   parity, see prior section). But
+   `CameraCaptureSession.pickInitialDevice` reads
+   `userPreferredCamera` first — so the host opened its own
+   output as a capture source. Self-source: the host writes
+   whatever it just read; the extension forwards it back; the
+   only "real" frame is whatever the extension had cached at
+   the loop's first iteration. Frozen frame, but with
+   `Consumed` / `Forwarded` / `Enqueued` cycling at 30 fps in
+   the log so it wasn't obviously broken.
+2. **Lazy capture dropped pending `setSource` requests.**
+   When a profile applied while no consumer was connected,
+   `VirtualCameraActivator.setSource` no-op'd silently and
+   forgot the requested name. So when Zoom connected later,
+   the host had no idea the active profile wanted "Neat Bar
+   Pro" and fell through to `userPreferredCamera` — bug #1.
+
+Why "sometimes": the failure mode depends on Zoom-vs-dock
+ordering. Open Zoom first, then dock → engine resolves the
+office profile → `setSource` runs against the live session →
+`switchSource` swaps inputs → real frames. Dock first, then
+open Zoom → `setSource` is a no-op + dropped → consumer
+connects → host self-sources → frozen.
+
+Fix:
+
+- `CameraCaptureSession.pickInitialDevice` rejects the
+  virtual camera at every fallback step (userPreferred,
+  systemPreferred, first discovered). New
+  `isVirtualCamera(_:)` helper that matches on
+  `VirtualCameraActivator.virtualCameraUID`. `findDevice`
+  also rejects defensively so a profile that names "AV
+  Pain Reliever" can't reopen the loop from the swap path.
+- `CameraCaptureSession` gains an `initialSourceName: String?`
+  init param. When set, it's the first thing
+  `pickInitialDevice` tries.
+- `VirtualCameraActivator.setSource` now stores the
+  requested name in `pendingSourceName` even when the
+  capture pipeline isn't running. `startCapturePipeline`
+  passes it through to `CameraCaptureSession.init`. Cleared
+  on disable + on the visibility-check failure path so the
+  next enable starts clean.
+
+Lesson: any time a capture pipeline can be torn down and
+re-created mid-session (lazy capture, sleep/wake, error
+recovery), the "what does the user want right now" state
+has to live OUTSIDE the pipeline — otherwise it's lost on
+every restart and the pipeline restarts with system defaults
+that may not match the active profile.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -43,8 +43,20 @@ final class CameraCaptureSession: NSObject {
     private var currentInput: AVCaptureDeviceInput?
     private var currentDeviceUniqueID: String?
 
-    init(sink: CMIOSinkWriter) {
+    /// Camera the active profile wanted as the source at session-
+    /// boot time. The activator remembers the most recent
+    /// `setSource(named:)` request and passes it here so that when
+    /// lazy capture starts up late (a Zoom client connects after a
+    /// profile-driven setSource fired against a then-nil session),
+    /// we open the right device on the first attempt instead of
+    /// falling through to `userPreferredCamera` — which under the
+    /// new override semantics is the virtual camera itself, and
+    /// would create a self-source feedback loop.
+    private let initialSourceName: String?
+
+    init(sink: CMIOSinkWriter, initialSourceName: String? = nil) {
         self.sink = sink
+        self.initialSourceName = initialSourceName
         super.init()
         NotificationCenter.default.addObserver(
             self,
@@ -168,14 +180,47 @@ final class CameraCaptureSession: NSObject {
         logger.info("sink.start() returned \(self.sinkStarted, privacy: .public)")
     }
 
-    /// Initial source pick before any profile has resolved. Mirrors
-    /// `AVFoundationCameraController.currentPreferredName`'s fallback
-    /// chain so the virtual camera's first frames match whatever the
-    /// system would naturally deliver to a fresh AVCapture client.
+    /// Initial source pick. Priority:
+    ///
+    /// 1. `initialSourceName` if the activator passed one — i.e. the
+    ///    active profile already named a source camera before the
+    ///    consumer connected and we'd otherwise have lost it.
+    /// 2. Fallback chain: userPreferred → systemPreferred → first
+    ///    discovered.
+    ///
+    /// In every case, the embedded virtual camera is rejected. If
+    /// the host opened its own output as a source we'd close a
+    /// feedback loop — host writes whatever it just read, the
+    /// extension forwards it back, frozen frame forever. Under the
+    /// `preferredCameraOverride` semantics `userPreferredCamera`
+    /// regularly *is* the virtual camera, which is exactly what we
+    /// want for AVFoundation-modern apps but exactly what we don't
+    /// want here.
     private func pickInitialDevice() -> AVCaptureDevice? {
-        if let user = AVCaptureDevice.userPreferredCamera { return user }
-        if let system = AVCaptureDevice.systemPreferredCamera { return system }
-        return Self.discoverySession().devices.first
+        if let name = initialSourceName,
+           let device = Self.findDevice(named: name)
+        {
+            return device
+        }
+        if let user = AVCaptureDevice.userPreferredCamera,
+           !Self.isVirtualCamera(user)
+        {
+            return user
+        }
+        if let system = AVCaptureDevice.systemPreferredCamera,
+           !Self.isVirtualCamera(system)
+        {
+            return system
+        }
+        return Self.discoverySession().devices
+            .first { !Self.isVirtualCamera($0) }
+    }
+
+    /// True iff `device` is the embedded AV Pain Reliever virtual
+    /// camera. Used to keep the host from ever opening its own
+    /// output as a capture source.
+    private static func isVirtualCamera(_ device: AVCaptureDevice) -> Bool {
+        device.uniqueID == VirtualCameraActivator.virtualCameraUID
     }
 
     /// Add an `AVCaptureDeviceInput` for `device` to the session.
@@ -246,7 +291,9 @@ final class CameraCaptureSession: NSObject {
     }
 
     private static func findDevice(named name: String) -> AVCaptureDevice? {
-        discoverySession().devices.first { $0.localizedName == name }
+        discoverySession().devices.first {
+            $0.localizedName == name && !isVirtualCamera($0)
+        }
     }
 
     private static func discoverySession() -> AVCaptureDevice.DiscoverySession {

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -105,6 +105,15 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     private var sinkWriter: CMIOSinkWriter?
     private var captureSession: CameraCaptureSession?
 
+    /// Most recent source-camera name a profile asked us to route.
+    /// Held across the "no consumer yet" window so that when lazy
+    /// capture finally spins up (consumer connects after a profile
+    /// applied), the new `CameraCaptureSession` opens the camera
+    /// the profile actually wants — not the system-preferred one,
+    /// which post-override is the virtual camera itself and would
+    /// close a self-source feedback loop.
+    private var pendingSourceName: String?
+
     /// True after a successful `disable()` until the host process
     /// is relaunched. Re-enabling within the same process hits the
     /// macOS "queued for uninstall on reboot" CMIO quirk where the
@@ -190,6 +199,7 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         stopGraceTimer?.cancel()
         stopGraceTimer = nil
         consumerActive = false
+        pendingSourceName = nil
         stopCapturePipeline()
         Self.restoreUserPreferredCameraIfVirtual()
 
@@ -234,11 +244,14 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
             width: 1280,
             height: 720
         )
-        let session = CameraCaptureSession(sink: writer)
+        let session = CameraCaptureSession(
+            sink: writer,
+            initialSourceName: pendingSourceName
+        )
         session.start()
         sinkWriter = writer
         captureSession = session
-        logger.info("Started host-side capture + CMIO sink writer")
+        logger.info("Started host-side capture + CMIO sink writer (initialSource=\(self.pendingSourceName ?? "<system-default>", privacy: .public))")
     }
 
     private func stopCapturePipeline() {
@@ -263,6 +276,12 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     }
 
     func setSource(named: String) -> CameraApplyResult {
+        // Always remember — even when the capture pipeline isn't
+        // running yet — so a consumer that connects later opens the
+        // right camera as its initial source instead of falling
+        // through to userPreferredCamera (which is the virtual
+        // camera itself under the override semantics).
+        pendingSourceName = named
         guard let captureSession else {
             // Toggle off OR mid-activation with capture not yet
             // running. Treat as silent no-op (.ok) so the engine's
@@ -301,6 +320,7 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
             self.stopGraceTimer?.cancel()
             self.stopGraceTimer = nil
             self.consumerActive = false
+            self.pendingSourceName = nil
             self.stopCapturePipeline()
             self.state = .requiresRelaunch
         }


### PR DESCRIPTION
## Summary
- Self-source feedback loop produced the \"frozen on one frame\" symptom users hit when sourcing from cameras like the Neat Bar. With the new \`preferredCameraOverride\` semantics, \`userPreferredCamera\` is the virtual camera — and \`CameraCaptureSession.pickInitialDevice\` happily returned it, opening the host's own output as a source.
- Lazy capture compounded it: \`setSource\` no-ops when the pipeline isn't running silently dropped the requested source name, so the late-connect path had no idea the profile wanted Neat Bar Pro and fell through to the (poisoned) userPreferred.
- Fix: pickInitialDevice + findDevice reject the virtual camera at every step. setSource remembers pending requests; startCapturePipeline opens the right camera on first try.

## Test plan
- [ ] Dock at the office (Neat Bar) BEFORE opening Zoom. Open Zoom, pick AV Pain Reliever. Live Neat Bar frames flow on first attempt — no frozen frame.
- [ ] Open Zoom first, then dock. Engine swaps source mid-call as before. Hold-last-frame covers the gap.
- [ ] Toggle virtual camera off → on. Pending source state resets cleanly.
- [ ] Existing FaceTime-at-home flow (toggle on, undocked profile with no camera, Zoom open): still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)