### PR TITLE
Stats: local usage stats screen under new Advanced tab

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3391,6 +3391,58 @@ has to live OUTSIDE the pipeline — otherwise it's lost on
 every restart and the pipeline restarts with system defaults
 that may not match the active profile.
 
+### Local stats screen + privacy-first opt-in (2026-05-05)
+
+User wanted a "fun nerdy stats" surface — counts of profile
+switches, per-profile activations, streaks, unique USB
+devices recognized. Discussed and ruled out anything
+duration-based (camera-on time, frames piped, meeting
+length) as too close to "tracking my work."
+
+Shipped under a new **Advanced** Settings tab as the first
+of what'll likely become a small home for diagnostic /
+power-user settings.
+
+Privacy stance: tracking is **off by default**. Every
+recording method on `SettingsStore` (`incrementSwitchCount`,
+`incrementManualOverrideCount`, `recordSwitch`,
+`recordDevicesSeen`) early-returns when
+`statsTrackingEnabled == false`. No `UserDefaults` writes
+happen until the user explicitly opts in. Existing values
+freeze (don't reset) when the user later disables — a
+separate Reset Stats button wipes everything on demand.
+
+Stat list (Balanced bundle):
+
+- Total auto-switches (existing `profileSwitchCount`,
+  surfaced)
+- Per-profile activation counts → most-used location
+  highlight + ranked list
+- Tracking-since date (stamped on first opt-in, NOT on
+  app first-launch, so the "47 days strong" number is
+  honest about what's actually been recorded)
+- Last switched (relative time + profile slug)
+- Manual overrides (count of menu-driven `applyManually`
+  calls)
+- Current streak / Longest streak / Active days
+- Unique USB devices recognized (count only, hashed as
+  `"<vid>:<pid>"`)
+
+Engine plumbing: new `Engine.onDevicesEvaluated:
+((Set<USBDevice>) -> Void)?` callback, fires inside
+`evaluateAndApply` after the watcher poll, regardless of
+profile change. Lets `AppDelegate` feed the unique-devices
+set without spinning up its own watcher.
+
+Lesson: privacy-first defaults are easy to bolt on with a
+single gate flag, but only if you push the gate into the
+domain object (`SettingsStore`) instead of every caller.
+Putting `guard statsTrackingEnabled else { return }` at the
+top of each `record*` method means callers in `AppDelegate`
+don't carry the conditional, and the easter-egg menu line
+("Switched N times…") naturally freezes on opt-out without
+any view-level changes.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3399,9 +3399,12 @@ devices recognized. Discussed and ruled out anything
 duration-based (camera-on time, frames piped, meeting
 length) as too close to "tracking my work."
 
-Shipped under a new **Advanced** Settings tab as the first
-of what'll likely become a small home for diagnostic /
-power-user settings.
+Shipped under a new **Stats** Settings tab. Originally
+planned as "Advanced" with stats inside, but the menu bar
+already exposes an Advanced submenu — two surfaces with the
+same name read as a UI bug. Renamed to "Stats" to match
+the actual content; future advanced/diagnostic settings can
+get their own home if and when they show up.
 
 Privacy stance: tracking is **off by default**. Every
 recording method on `SettingsStore` (`incrementSwitchCount`,

--- a/Sources/AVPainReliever/Engine/Engine.swift
+++ b/Sources/AVPainReliever/Engine/Engine.swift
@@ -59,6 +59,13 @@ public final class Engine {
     /// (that's a known location, not a new one).
     public var onUnknownLocation: ((Set<USBDevice>) -> Void)?
 
+    /// Fires on every successful evaluate-and-apply pass with the full
+    /// set of currently-attached USB devices, regardless of which
+    /// profile resolved or whether it changed. Used by the host's
+    /// stats tracking to maintain a "unique devices ever seen" set
+    /// without spinning up a second `USBWatcher` instance.
+    public var onDevicesEvaluated: ((Set<USBDevice>) -> Void)?
+
     public init(
         watcher: USBWatcher,
         resolver: ProfileResolver,
@@ -147,6 +154,7 @@ public final class Engine {
 
     private func evaluateAndApply() {
         let attached = watcher.currentDevices()
+        onDevicesEvaluated?(attached)
         guard let profile = resolver.resolve(attached: attached) else {
             logger.warn("no profile matched the current USB state — skipping apply")
             return

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -354,6 +354,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         engine.onUnknownLocation = { [weak self] devices in
             self?.handleUnknownLocation(devices: devices)
         }
+        engine.onDevicesEvaluated = { [weak self] devices in
+            // Stats: feed the unique-devices set. SettingsStore
+            // gates on `statsTrackingEnabled` internally — when the
+            // user has tracking off, this is a no-op.
+            self?.settings.recordDevicesSeen(devices)
+        }
         engine.start()
         self.engine = engine
     }
@@ -372,6 +378,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // toast (default on; users can mute from Preferences).
         if let last = lastNotifiedName, last != profile.name {
             settings.incrementSwitchCount()
+            settings.recordSwitch(toSlug: profile.name)
             if settings.notificationsEnabled {
                 notifier.notify(
                     title: NotificationCopy.title(forSlug: profile.name),
@@ -457,6 +464,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// configuration or apply a "wrong-for-now" profile (e.g. set
     /// home-office audio defaults while undocked).
     func applyManually(_ profile: Profile) {
+        // Stats: every menu-driven force-apply increments the
+        // manual-override counter. The engine still goes on to fire
+        // `onProfileApplied`, which counts this as a regular switch
+        // too — that's correct: it IS a switch, just one the user
+        // forced. Both counters are gated on `statsTrackingEnabled`.
+        settings.incrementManualOverrideCount()
         engine?.applyManually(profile)
     }
 

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -212,6 +212,24 @@ final class SettingsStore: ObservableObject {
     /// extra published field.
     var uniqueDevicesSeenCount: Int { uniqueDeviceFingerprints.count }
 
+    /// True iff there's user-meaningful stats data (counters
+    /// non-zero, dictionaries / arrays non-empty, a last-switch
+    /// recorded). Drives both the Reset Stats section's visibility
+    /// AND the on-disable "also reset?" prompt.
+    ///
+    /// `statsStartDate` is intentionally NOT counted here — it's
+    /// internal bookkeeping (set on first opt-in, re-stamped on
+    /// reset) and a fresh opt-in / opt-out cycle leaves it set
+    /// without any data the user would recognize as "stats."
+    var hasRecordedStats: Bool {
+        profileSwitchCount > 0
+            || !perProfileCounts.isEmpty
+            || lastSwitchSlug != nil
+            || manualOverrideCount > 0
+            || activeDaysCount > 0
+            || !uniqueDeviceFingerprints.isEmpty
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import AVPainReliever
 
 /// User-tunable behavior toggles. Persisted to `UserDefaults` under the
 /// app's domain so settings survive relaunches without us writing
@@ -21,6 +22,16 @@ final class SettingsStore: ObservableObject {
         static let launchAtLogin = "launchAtLogin"
         static let virtualCameraEnabled = "virtualCameraEnabled"
         static let experimentalUpdates = "experimentalUpdates"
+        static let statsTrackingEnabled = "statsTrackingEnabled"
+        static let statsStartDate = "statsStartDate"
+        static let perProfileCounts = "perProfileCounts"
+        static let lastSwitchSlug = "lastSwitchSlug"
+        static let lastSwitchDate = "lastSwitchDate"
+        static let manualOverrideCount = "manualOverrideCount"
+        static let currentStreakDays = "currentStreakDays"
+        static let longestStreakDays = "longestStreakDays"
+        static let activeDaysCount = "activeDaysCount"
+        static let uniqueDeviceFingerprints = "uniqueDeviceFingerprints"
     }
 
     /// Toast on profile change?  Default on — the at-a-glance signal
@@ -111,6 +122,96 @@ final class SettingsStore: ObservableObject {
         didSet { defaults.set(experimentalUpdates, forKey: Key.experimentalUpdates) }
     }
 
+    /// Master gate for usage-stats tracking. **Default: off.** With
+    /// this false, every `record*` / `increment*` method early-returns
+    /// — no fields update, no `UserDefaults` writes happen, no menu
+    /// counters advance. Existing values stay frozen and visible (the
+    /// user can flip the toggle off after some history without losing
+    /// what was already collected). Surfaced in Settings → Advanced.
+    @Published var statsTrackingEnabled: Bool {
+        didSet {
+            defaults.set(statsTrackingEnabled, forKey: Key.statsTrackingEnabled)
+            // Stamp the start date the *first* time the user opts in.
+            // Off → on → off → on must NOT reset it; the user's
+            // intent is "I started keeping notes a while back" and
+            // the streak / activeDays math relies on a stable origin.
+            if statsTrackingEnabled, statsStartDate == nil {
+                statsStartDate = Date()
+            }
+        }
+    }
+
+    /// Captured the first time the user enables `statsTrackingEnabled`.
+    /// Drives the "Tracking since N days ago" line in Advanced.
+    @Published var statsStartDate: Date? {
+        didSet { defaults.set(statsStartDate, forKey: Key.statsStartDate) }
+    }
+
+    /// Count of how many times each profile (by slug) has been
+    /// applied since tracking was enabled. Powers the "most-used
+    /// location" highlight + the per-profile rankings.
+    @Published var perProfileCounts: [String: Int] {
+        didSet { defaults.set(perProfileCounts, forKey: Key.perProfileCounts) }
+    }
+
+    /// Slug of the most recently applied profile (set alongside
+    /// `lastSwitchDate`). Renders as "Last switched 2h ago to Home
+    /// Office" in Advanced.
+    @Published var lastSwitchSlug: String? {
+        didSet { defaults.set(lastSwitchSlug, forKey: Key.lastSwitchSlug) }
+    }
+
+    /// Wall-clock time of the most recent recorded switch. Used to
+    /// drive the relative-time rendering AND the streak / activeDays
+    /// day-bucket math.
+    @Published var lastSwitchDate: Date? {
+        didSet { defaults.set(lastSwitchDate, forKey: Key.lastSwitchDate) }
+    }
+
+    /// How many times the user has forced a profile from the menu's
+    /// "Switch to …" submenu (vs. the resolver auto-picking one in
+    /// response to a USB event). A high count is a soft signal that
+    /// the user's profiles aren't quite matching reality and might
+    /// want adjustment.
+    @Published var manualOverrideCount: Int {
+        didSet { defaults.set(manualOverrideCount, forKey: Key.manualOverrideCount) }
+    }
+
+    /// Consecutive calendar days with at least one recorded switch,
+    /// counting today (or the day of the most recent switch).
+    @Published var currentStreakDays: Int {
+        didSet { defaults.set(currentStreakDays, forKey: Key.currentStreakDays) }
+    }
+
+    /// All-time maximum value `currentStreakDays` has reached. Never
+    /// decreases except via `resetStats()`.
+    @Published var longestStreakDays: Int {
+        didSet { defaults.set(longestStreakDays, forKey: Key.longestStreakDays) }
+    }
+
+    /// Total count of distinct calendar days on which at least one
+    /// switch was recorded. Diverges from `currentStreakDays` once
+    /// any gap appears — a 50-active-day user with an interrupted
+    /// streak still has activeDays = 50 even if the current streak
+    /// is back to 1.
+    @Published var activeDaysCount: Int {
+        didSet { defaults.set(activeDaysCount, forKey: Key.activeDaysCount) }
+    }
+
+    /// Backing storage for the unique-device set. Each entry is the
+    /// `(vendorID, productID)` pair as `"<vid>:<pid>"` lowercase hex.
+    /// `[String]` so it round-trips cleanly through UserDefaults
+    /// without custom encoding. Surfaced as
+    /// `uniqueDevicesSeenCount` for the UI.
+    @Published var uniqueDeviceFingerprints: [String] {
+        didSet { defaults.set(uniqueDeviceFingerprints, forKey: Key.uniqueDeviceFingerprints) }
+    }
+
+    /// Convenience for the Advanced view — the count is what the UI
+    /// actually wants. Computed so it tracks the array without an
+    /// extra published field.
+    var uniqueDevicesSeenCount: Int { uniqueDeviceFingerprints.count }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -129,9 +230,118 @@ final class SettingsStore: ObservableObject {
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool) ?? false
         self.virtualCameraEnabled = (defaults.object(forKey: Key.virtualCameraEnabled) as? Bool) ?? false
         self.experimentalUpdates = (defaults.object(forKey: Key.experimentalUpdates) as? Bool) ?? false
+        // Stats tracking ships off by default for privacy. Every
+        // record / increment method early-returns when this is false.
+        self.statsTrackingEnabled = (defaults.object(forKey: Key.statsTrackingEnabled) as? Bool) ?? false
+        self.statsStartDate = defaults.object(forKey: Key.statsStartDate) as? Date
+        self.perProfileCounts = (defaults.object(forKey: Key.perProfileCounts) as? [String: Int]) ?? [:]
+        self.lastSwitchSlug = defaults.object(forKey: Key.lastSwitchSlug) as? String
+        self.lastSwitchDate = defaults.object(forKey: Key.lastSwitchDate) as? Date
+        self.manualOverrideCount = (defaults.object(forKey: Key.manualOverrideCount) as? Int) ?? 0
+        self.currentStreakDays = (defaults.object(forKey: Key.currentStreakDays) as? Int) ?? 0
+        self.longestStreakDays = (defaults.object(forKey: Key.longestStreakDays) as? Int) ?? 0
+        self.activeDaysCount = (defaults.object(forKey: Key.activeDaysCount) as? Int) ?? 0
+        self.uniqueDeviceFingerprints = (defaults.object(forKey: Key.uniqueDeviceFingerprints) as? [String]) ?? []
     }
 
+    /// Bump the lifetime switch counter that drives the easter-egg
+    /// menu line. Gated by `statsTrackingEnabled` — when off, the
+    /// counter freezes at its current value (typically 0 on a fresh
+    /// install).
     func incrementSwitchCount() {
+        guard statsTrackingEnabled else { return }
         profileSwitchCount += 1
+    }
+
+    /// Bump the count of menu-driven manual overrides. Gated.
+    func incrementManualOverrideCount() {
+        guard statsTrackingEnabled else { return }
+        manualOverrideCount += 1
+    }
+
+    /// Record one applied profile. Updates per-profile counts,
+    /// last-switched fields, and the daily streak / activeDays math.
+    /// Gated by `statsTrackingEnabled`.
+    ///
+    /// Streak rule, evaluated against `lastSwitchDate`'s calendar day
+    /// (in the user's local timezone):
+    ///
+    /// - same day → no streak/activeDays change (just refresh
+    ///   `lastSwitchDate` so the relative-time UI stays current)
+    /// - exactly one day later → `currentStreakDays += 1`,
+    ///   `activeDaysCount += 1`
+    /// - older or never → `currentStreakDays = 1`,
+    ///   `activeDaysCount += 1`
+    ///
+    /// `longestStreakDays` is `max(longestStreakDays, currentStreakDays)`
+    /// after each update.
+    func recordSwitch(toSlug slug: String, at date: Date = Date()) {
+        guard statsTrackingEnabled else { return }
+        perProfileCounts[slug, default: 0] += 1
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: date)
+        if let last = lastSwitchDate {
+            let lastDay = calendar.startOfDay(for: last)
+            let delta = calendar.dateComponents([.day], from: lastDay, to: today).day ?? 0
+            if delta == 0 {
+                // Same calendar day — no streak change.
+            } else if delta == 1 {
+                currentStreakDays += 1
+                activeDaysCount += 1
+            } else {
+                currentStreakDays = 1
+                activeDaysCount += 1
+            }
+        } else {
+            currentStreakDays = 1
+            activeDaysCount = 1
+        }
+        if currentStreakDays > longestStreakDays {
+            longestStreakDays = currentStreakDays
+        }
+        lastSwitchSlug = slug
+        lastSwitchDate = date
+    }
+
+    /// Insert any never-seen `(vendorID, productID)` fingerprints into
+    /// the unique-devices set. Gated. Writes back to UserDefaults
+    /// only when the set actually grew, so a typical USB-quiet stretch
+    /// doesn't touch defaults at all.
+    func recordDevicesSeen(_ devices: Set<USBDevice>) {
+        guard statsTrackingEnabled else { return }
+        let existing = Set(uniqueDeviceFingerprints)
+        var grown = existing
+        for device in devices {
+            grown.insert(Self.fingerprint(for: device))
+        }
+        if grown.count != existing.count {
+            uniqueDeviceFingerprints = grown.sorted()
+        }
+    }
+
+    /// Wipe every stats counter / dictionary / last-switched field.
+    /// Does NOT touch `statsTrackingEnabled` — that's a separate
+    /// privacy choice. If tracking is currently on, `statsStartDate`
+    /// is reset to "now" so future records have a fresh origin; if
+    /// tracking is off, it's set to nil (it'll re-stamp on next
+    /// opt-in). Wired to the Advanced tab's "Reset stats…" button.
+    func resetStats() {
+        profileSwitchCount = 0
+        perProfileCounts = [:]
+        lastSwitchSlug = nil
+        lastSwitchDate = nil
+        manualOverrideCount = 0
+        currentStreakDays = 0
+        longestStreakDays = 0
+        activeDaysCount = 0
+        uniqueDeviceFingerprints = []
+        statsStartDate = statsTrackingEnabled ? Date() : nil
+    }
+
+    /// Stable string fingerprint for a USB device — `"<vid>:<pid>"`
+    /// in lowercase 4-char hex. Used as the entry value in
+    /// `uniqueDeviceFingerprints`.
+    static func fingerprint(for device: USBDevice) -> String {
+        String(format: "%04x:%04x", device.vendorID, device.productID)
     }
 }

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -13,11 +13,30 @@ enum SettingsTab: Hashable {
     case stats
 }
 
-/// The Settings scene has three tabs: General (toggles + slider),
-/// Profiles (list with edit/delete), and Camera (virtual camera
-/// install/enable + status). Deliberately *no* mention of
-/// Hammerspoon, OBS, or any other third-party tool — the app must
-/// read as its own product.
+private extension View {
+    /// Shared chrome for every Settings tab body — `.formStyle(.grouped)`
+    /// + 8 pt padding around the Form's rounded card. Apply to the
+    /// `Form` at the root of each tab's body so the gray section
+    /// cards line up consistently against the window edges. Camera,
+    /// General, and Stats use this; Profiles has its own layout
+    /// (no Form) and stays bespoke for now.
+    ///
+    /// One place to change the convention. If we ever want to bump
+    /// the padding to 12 or swap to a different formStyle, edit
+    /// here and every tab follows.
+    func settingsTabContent() -> some View {
+        self
+            .formStyle(.grouped)
+            .padding(8)
+    }
+}
+
+/// The Settings scene has four tabs: General (toggles + slider),
+/// Profiles (list with edit/delete), Camera (virtual camera
+/// install/enable + status), and Stats (opt-in local usage
+/// counters). Deliberately *no* mention of Hammerspoon, OBS, or
+/// any other third-party tool — the app must read as its own
+/// product.
 ///
 /// Hosted inside SwiftUI's dedicated `Settings { ... }` scene rather
 /// than a generic `Window` scene so the TabView gets the System-
@@ -106,8 +125,7 @@ private struct CameraSettingsTab: View {
                 Label("Virtual camera", systemImage: "camera.metering.center.weighted")
             }
         }
-        .formStyle(.grouped)
-        .padding(8)
+        .settingsTabContent()
     }
 
     /// Live status row — colored dot + human-readable label that
@@ -268,8 +286,7 @@ private struct GeneralSettingsTab: View {
                 Label("Updates", systemImage: "arrow.down.circle")
             }
         }
-        .formStyle(.grouped)
-        .padding(8)
+        .settingsTabContent()
     }
 }
 
@@ -507,7 +524,7 @@ private struct StatsSettingsTab: View {
                 }
             }
         }
-        .formStyle(.grouped)
+        .settingsTabContent()
         .alert(
             "Reset all usage stats?",
             isPresented: $resetConfirmationVisible

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -10,7 +10,7 @@ enum SettingsTab: Hashable {
     case general
     case profiles
     case camera
-    case advanced
+    case stats
 }
 
 /// The Settings scene has three tabs: General (toggles + slider),
@@ -51,11 +51,11 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.camera)
 
-            AdvancedSettingsTab(settings: settings, delegate: delegate)
+            StatsSettingsTab(settings: settings, delegate: delegate)
                 .tabItem {
-                    Label("Advanced", systemImage: "slider.horizontal.3")
+                    Label("Stats", systemImage: "chart.bar.fill")
                 }
-                .tag(SettingsTab.advanced)
+                .tag(SettingsTab.stats)
         }
         .frame(width: 480, height: 380)
         .centeredOnScreen()
@@ -467,13 +467,14 @@ private struct ProfileRow: View {
     }
 }
 
-/// Advanced tab — currently houses the local stats screen behind an
-/// opt-in toggle. Future home for diagnostic/dev settings (logs,
-/// reset state, etc.). Stats tracking ships off; the Stats section
-/// collapses to just the toggle + helper text on a fresh install,
-/// avoiding "what is this stuff?" friction before the user has
-/// chosen to keep notes.
-private struct AdvancedSettingsTab: View {
+/// Stats tab — local usage tracking behind an opt-in toggle. Ships
+/// off; the Tracking section collapses to just the toggle + helper
+/// text on a fresh install, avoiding "what is this stuff?" friction
+/// before the user has chosen to keep notes. Renamed from "Advanced"
+/// to avoid colliding with the menu bar's existing Advanced submenu
+/// — and the tab only houses stats today, so the on-the-nose name
+/// reads better.
+private struct StatsSettingsTab: View {
     @ObservedObject var settings: SettingsStore
     @ObservedObject var delegate: AppDelegate
     @State private var resetConfirmationVisible = false
@@ -491,7 +492,7 @@ private struct AdvancedSettingsTab: View {
                     statsRows
                 }
             } header: {
-                Label("Stats", systemImage: "chart.bar.fill")
+                Label("Tracking", systemImage: "switch.2")
             }
 
             if hasAnyStatsValue {

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -10,6 +10,7 @@ enum SettingsTab: Hashable {
     case general
     case profiles
     case camera
+    case advanced
 }
 
 /// The Settings scene has three tabs: General (toggles + slider),
@@ -49,6 +50,12 @@ struct SettingsView: View {
                     Label("Camera", systemImage: "camera")
                 }
                 .tag(SettingsTab.camera)
+
+            AdvancedSettingsTab(settings: settings, delegate: delegate)
+                .tabItem {
+                    Label("Advanced", systemImage: "slider.horizontal.3")
+                }
+                .tag(SettingsTab.advanced)
         }
         .frame(width: 480, height: 380)
         .centeredOnScreen()
@@ -456,6 +463,146 @@ private struct ProfileRow: View {
         let separator = Text("  •  ")
         return parts.dropFirst().reduce(parts[0]) { acc, next in
             acc + separator + next
+        }
+    }
+}
+
+/// Advanced tab — currently houses the local stats screen behind an
+/// opt-in toggle. Future home for diagnostic/dev settings (logs,
+/// reset state, etc.). Stats tracking ships off; the Stats section
+/// collapses to just the toggle + helper text on a fresh install,
+/// avoiding "what is this stuff?" friction before the user has
+/// chosen to keep notes.
+private struct AdvancedSettingsTab: View {
+    @ObservedObject var settings: SettingsStore
+    @ObservedObject var delegate: AppDelegate
+    @State private var resetConfirmationVisible = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Track usage stats locally", isOn: $settings.statsTrackingEnabled)
+                Text("Counts only — what profile switched, when, and how often. No meeting content, no durations, no telemetry. Stays on this Mac.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                if settings.statsTrackingEnabled {
+                    statsRows
+                }
+            } header: {
+                Label("Stats", systemImage: "chart.bar.fill")
+            }
+
+            if hasAnyStatsValue {
+                Section {
+                    Button(role: .destructive) {
+                        resetConfirmationVisible = true
+                    } label: {
+                        Text("Reset stats…")
+                    }
+                } header: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .alert(
+            "Reset all usage stats?",
+            isPresented: $resetConfirmationVisible
+        ) {
+            Button("Reset", role: .destructive) {
+                settings.resetStats()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This wipes every counter and date on this screen. Your profiles and other settings are untouched.")
+        }
+    }
+
+    /// True iff any stats value is non-zero / non-empty. Used to show
+    /// the Reset section even when tracking is off, so a user who
+    /// disables tracking after collecting some history can still wipe.
+    private var hasAnyStatsValue: Bool {
+        settings.profileSwitchCount > 0
+            || !settings.perProfileCounts.isEmpty
+            || settings.lastSwitchSlug != nil
+            || settings.manualOverrideCount > 0
+            || settings.activeDaysCount > 0
+            || !settings.uniqueDeviceFingerprints.isEmpty
+            || settings.statsStartDate != nil
+    }
+
+    @ViewBuilder
+    private var statsRows: some View {
+        LabeledContent("Tracking since", value: trackingSinceString)
+        LabeledContent("Auto-switches", value: "\(settings.profileSwitchCount)")
+        if let lastLine = lastSwitchedString {
+            LabeledContent("Last switched", value: lastLine)
+        }
+        if let (topSlug, topCount) = topProfile {
+            LabeledContent("Most-used location", value: "\(PrettyName.format(topSlug)) (\(topCount))")
+            ForEach(otherProfiles, id: \.0) { slug, count in
+                LabeledContent(PrettyName.format(slug), value: "\(count)")
+            }
+        }
+        LabeledContent("Manual overrides", value: "\(settings.manualOverrideCount)")
+        LabeledContent("Current streak", value: streakString(settings.currentStreakDays))
+        LabeledContent("Longest streak", value: streakString(settings.longestStreakDays))
+        LabeledContent("Active days", value: "\(settings.activeDaysCount)")
+        LabeledContent("Unique USB devices recognized", value: "\(settings.uniqueDevicesSeenCount)")
+    }
+
+    /// "Today" on day 0, "Yesterday" on day 1, "N days ago" beyond.
+    /// Renders nil-state as "Not yet" so a freshly-enabled user
+    /// doesn't see "0 days ago" before any data has been collected.
+    private var trackingSinceString: String {
+        guard let start = settings.statsStartDate else { return "Not yet" }
+        let days = Calendar.current.dateComponents(
+            [.day],
+            from: Calendar.current.startOfDay(for: start),
+            to: Calendar.current.startOfDay(for: Date())
+        ).day ?? 0
+        switch days {
+        case 0: return "Today"
+        case 1: return "Yesterday (1 day)"
+        default: return "\(days) days ago"
+        }
+    }
+
+    private var lastSwitchedString: String? {
+        guard let date = settings.lastSwitchDate, let slug = settings.lastSwitchSlug
+        else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        let relative = formatter.localizedString(for: date, relativeTo: Date())
+        return "\(relative) → \(PrettyName.format(slug))"
+    }
+
+    /// Highest entry in `perProfileCounts`; nil when the dictionary
+    /// is empty.
+    private var topProfile: (String, Int)? {
+        settings.perProfileCounts.max { $0.value < $1.value }
+            .map { ($0.key, $0.value) }
+    }
+
+    /// All entries except the top one, sorted by descending count.
+    /// The top one is rendered as the "Most-used location" highlight
+    /// just above; this list adds the rankings without duplicating
+    /// the leader.
+    private var otherProfiles: [(String, Int)] {
+        guard let top = topProfile else { return [] }
+        return settings.perProfileCounts
+            .filter { $0.key != top.0 }
+            .sorted { $0.value > $1.value }
+            .map { ($0.key, $0.value) }
+    }
+
+    private func streakString(_ days: Int) -> String {
+        switch days {
+        case 0: return "—"
+        case 1: return "1 day"
+        default: return "\(days) days"
         }
     }
 }

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -517,7 +517,7 @@ private struct StatsSettingsTab: View {
                 Label("Tracking", systemImage: "switch.2")
             }
 
-            if hasAnyStatsValue {
+            if settings.hasRecordedStats {
                 Section {
                     Button(role: .destructive) {
                         resetConfirmationVisible = true
@@ -559,23 +559,10 @@ private struct StatsSettingsTab: View {
             Text("Tracking is off. Your existing counters and dates can stay in case you turn it back on later, or be wiped now.")
         }
         .onChange(of: settings.statsTrackingEnabled) { _, newValue in
-            if !newValue && hasAnyStatsValue {
+            if !newValue && settings.hasRecordedStats {
                 disableResetPromptVisible = true
             }
         }
-    }
-
-    /// True iff any stats value is non-zero / non-empty. Used to show
-    /// the Reset section even when tracking is off, so a user who
-    /// disables tracking after collecting some history can still wipe.
-    private var hasAnyStatsValue: Bool {
-        settings.profileSwitchCount > 0
-            || !settings.perProfileCounts.isEmpty
-            || settings.lastSwitchSlug != nil
-            || settings.manualOverrideCount > 0
-            || settings.activeDaysCount > 0
-            || !settings.uniqueDeviceFingerprints.isEmpty
-            || settings.statsStartDate != nil
     }
 
     @ViewBuilder

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -495,6 +495,11 @@ private struct StatsSettingsTab: View {
     @ObservedObject var settings: SettingsStore
     @ObservedObject var delegate: AppDelegate
     @State private var resetConfirmationVisible = false
+    /// Driven by an `.onChange` on the tracking toggle. Fires when
+    /// the user disables tracking AND there's data to wipe — gives
+    /// them a one-click "also reset?" affordance instead of forcing
+    /// them to remember the separate Reset button.
+    @State private var disableResetPromptVisible = false
 
     var body: some View {
         Form {
@@ -535,6 +540,28 @@ private struct StatsSettingsTab: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This wipes every counter and date on this screen. Your profiles and other settings are untouched.")
+        }
+        // Surface the "also reset?" question at the moment the user
+        // cares most: right after they flipped tracking off. Apple's
+        // pattern for similar privacy-toggle disables (iCloud Photos,
+        // Find My, Screen Time). Skipped when there's nothing worth
+        // wiping — a fresh user toggling off → on again shouldn't
+        // get a meaningless prompt.
+        .alert(
+            "Stop tracking usage stats?",
+            isPresented: $disableResetPromptVisible
+        ) {
+            Button("Reset Stats", role: .destructive) {
+                settings.resetStats()
+            }
+            Button("Keep Stats", role: .cancel) {}
+        } message: {
+            Text("Tracking is off. Your existing counters and dates can stay in case you turn it back on later, or be wiped now.")
+        }
+        .onChange(of: settings.statsTrackingEnabled) { _, newValue in
+            if !newValue && hasAnyStatsValue {
+                disableResetPromptVisible = true
+            }
         }
     }
 

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+@testable import AVPainReliever
 @testable import AVPainRelieverApp
 
 @Suite("SettingsStore")
@@ -31,6 +32,18 @@ struct SettingsStoreTests {
         // Experimental updates default off — only the stable channel
         // is consumed unless the user explicitly opts in.
         #expect(store.experimentalUpdates == false)
+        // Stats tracking ships off — privacy-first default. All
+        // counter / dictionary fields stay empty until the user opts in.
+        #expect(store.statsTrackingEnabled == false)
+        #expect(store.statsStartDate == nil)
+        #expect(store.perProfileCounts.isEmpty)
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+        #expect(store.manualOverrideCount == 0)
+        #expect(store.currentStreakDays == 0)
+        #expect(store.longestStreakDays == 0)
+        #expect(store.activeDaysCount == 0)
+        #expect(store.uniqueDevicesSeenCount == 0)
     }
 
     @Test("launchAtLogin persists across reloads")
@@ -67,11 +80,12 @@ struct SettingsStoreTests {
         #expect(reopened.debounceInterval == 2.5)
     }
 
-    @Test("incrementSwitchCount persists across reloads")
+    @Test("incrementSwitchCount persists across reloads when tracking is enabled")
     func switchCountIncrements() {
         let defaults = makeSuite()
         do {
             let store = SettingsStore(defaults: defaults)
+            store.statsTrackingEnabled = true
             store.incrementSwitchCount()
             store.incrementSwitchCount()
             store.incrementSwitchCount()
@@ -112,5 +126,173 @@ struct SettingsStoreTests {
         }
         let reopened = SettingsStore(defaults: defaults)
         #expect(reopened.experimentalUpdates == true)
+    }
+
+    // MARK: - Stats tracking
+
+    @Test("with tracking off, every record/increment method is a no-op")
+    func gatedMethodsNoOpWhenDisabled() {
+        let store = SettingsStore(defaults: makeSuite())
+        // Default state: tracking off.
+        #expect(store.statsTrackingEnabled == false)
+
+        store.incrementSwitchCount()
+        store.incrementManualOverrideCount()
+        store.recordSwitch(toSlug: "home-office")
+        store.recordDevicesSeen([USBDevice(vendorID: 0x2188, productID: 0x6533)])
+
+        #expect(store.profileSwitchCount == 0)
+        #expect(store.manualOverrideCount == 0)
+        #expect(store.perProfileCounts.isEmpty)
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+        #expect(store.currentStreakDays == 0)
+        #expect(store.longestStreakDays == 0)
+        #expect(store.activeDaysCount == 0)
+        #expect(store.uniqueDevicesSeenCount == 0)
+    }
+
+    @Test("first opt-in stamps statsStartDate; toggling off-on does not re-stamp")
+    func optInStampsStartDateOnce() {
+        let store = SettingsStore(defaults: makeSuite())
+        #expect(store.statsStartDate == nil)
+
+        let beforeFirst = Date()
+        store.statsTrackingEnabled = true
+        let stampedFirst = store.statsStartDate
+        #expect(stampedFirst != nil)
+        // Stamp must be at-or-after the pre-flip moment.
+        #expect((stampedFirst ?? .distantPast) >= beforeFirst)
+
+        // Off → on again: should NOT re-stamp.
+        store.statsTrackingEnabled = false
+        store.statsTrackingEnabled = true
+        #expect(store.statsStartDate == stampedFirst)
+    }
+
+    @Test("recordSwitch updates per-profile counts and last-switch fields")
+    func recordSwitchUpdatesBasics() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+
+        let t = Date()
+        store.recordSwitch(toSlug: "home-office", at: t)
+        store.recordSwitch(toSlug: "home-office", at: t)
+        store.recordSwitch(toSlug: "conference-room", at: t)
+
+        #expect(store.perProfileCounts["home-office"] == 2)
+        #expect(store.perProfileCounts["conference-room"] == 1)
+        #expect(store.lastSwitchSlug == "conference-room")
+        #expect(store.lastSwitchDate == t)
+    }
+
+    @Test("streak: same calendar day does not advance currentStreak or activeDays")
+    func streakSameDayNoOp() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        let morning = Calendar.current.startOfDay(for: Date()).addingTimeInterval(9 * 3600)
+        let afternoon = morning.addingTimeInterval(5 * 3600)
+
+        store.recordSwitch(toSlug: "a", at: morning)
+        #expect(store.currentStreakDays == 1)
+        #expect(store.activeDaysCount == 1)
+
+        store.recordSwitch(toSlug: "b", at: afternoon)
+        // Same day — no streak advance, no activeDays increment.
+        #expect(store.currentStreakDays == 1)
+        #expect(store.activeDaysCount == 1)
+    }
+
+    @Test("streak: consecutive days advance; gap resets; longest tracks max")
+    func streakAdvanceGapAndLongest() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        let cal = Calendar.current
+        let day0 = cal.startOfDay(for: Date())
+        let day1 = cal.date(byAdding: .day, value: 1, to: day0)!
+        let day2 = cal.date(byAdding: .day, value: 2, to: day0)!
+        let day5 = cal.date(byAdding: .day, value: 5, to: day0)!
+
+        store.recordSwitch(toSlug: "a", at: day0)
+        store.recordSwitch(toSlug: "a", at: day1)
+        store.recordSwitch(toSlug: "a", at: day2)
+        #expect(store.currentStreakDays == 3)
+        #expect(store.longestStreakDays == 3)
+        #expect(store.activeDaysCount == 3)
+
+        // Gap of 2 days resets the streak; longest is preserved.
+        store.recordSwitch(toSlug: "a", at: day5)
+        #expect(store.currentStreakDays == 1)
+        #expect(store.longestStreakDays == 3)
+        #expect(store.activeDaysCount == 4)
+    }
+
+    @Test("recordDevicesSeen deduplicates and only writes when set grows")
+    func uniqueDevicesDedup() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+
+        let dock = USBDevice(vendorID: 0x2188, productID: 0x6533)
+        let cam = USBDevice(vendorID: 0x046d, productID: 0x085e)
+
+        store.recordDevicesSeen([dock])
+        #expect(store.uniqueDevicesSeenCount == 1)
+
+        // Re-seeing the same device shouldn't grow the set.
+        store.recordDevicesSeen([dock])
+        #expect(store.uniqueDevicesSeenCount == 1)
+
+        store.recordDevicesSeen([dock, cam])
+        #expect(store.uniqueDevicesSeenCount == 2)
+    }
+
+    @Test("resetStats wipes counters; tracking flag is preserved")
+    func resetStatsWipes() {
+        let defaults = makeSuite()
+        let store = SettingsStore(defaults: defaults)
+        store.statsTrackingEnabled = true
+        store.incrementSwitchCount()
+        store.recordSwitch(toSlug: "home-office")
+        store.incrementManualOverrideCount()
+        store.recordDevicesSeen([USBDevice(vendorID: 0x2188, productID: 0x6533)])
+
+        let stampBeforeReset = store.statsStartDate
+        store.resetStats()
+
+        #expect(store.profileSwitchCount == 0)
+        #expect(store.perProfileCounts.isEmpty)
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+        #expect(store.manualOverrideCount == 0)
+        #expect(store.currentStreakDays == 0)
+        #expect(store.longestStreakDays == 0)
+        #expect(store.activeDaysCount == 0)
+        #expect(store.uniqueDevicesSeenCount == 0)
+        // Tracking stays on; statsStartDate gets re-stamped to "now"
+        // (>= the stamp the original opt-in produced).
+        #expect(store.statsTrackingEnabled == true)
+        #expect((store.statsStartDate ?? .distantPast) >= (stampBeforeReset ?? .distantPast))
+    }
+
+    @Test("stats fields persist across reloads")
+    func statsFieldsRoundTrip() {
+        let defaults = makeSuite()
+        let date = Date()
+        do {
+            let store = SettingsStore(defaults: defaults)
+            store.statsTrackingEnabled = true
+            store.recordSwitch(toSlug: "home-office", at: date)
+            store.recordSwitch(toSlug: "conference-room", at: date)
+            store.incrementManualOverrideCount()
+            store.recordDevicesSeen([USBDevice(vendorID: 0x2188, productID: 0x6533)])
+        }
+        let reopened = SettingsStore(defaults: defaults)
+        #expect(reopened.statsTrackingEnabled == true)
+        #expect(reopened.statsStartDate != nil)
+        #expect(reopened.perProfileCounts["home-office"] == 1)
+        #expect(reopened.perProfileCounts["conference-room"] == 1)
+        #expect(reopened.lastSwitchSlug == "conference-room")
+        #expect(reopened.manualOverrideCount == 1)
+        #expect(reopened.uniqueDevicesSeenCount == 1)
     }
 }

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -274,6 +274,55 @@ struct SettingsStoreTests {
         #expect((store.statsStartDate ?? .distantPast) >= (stampBeforeReset ?? .distantPast))
     }
 
+    @Test("hasRecordedStats reflects user-meaningful data, not bookkeeping")
+    func hasRecordedStatsIgnoresStartDate() {
+        let store = SettingsStore(defaults: makeSuite())
+        // Fresh store: nothing.
+        #expect(store.hasRecordedStats == false)
+
+        // Pure opt-in stamps statsStartDate but doesn't count as
+        // recorded data. Off → on → off should NOT trigger the
+        // disable-reset prompt for a user who never actually used
+        // the feature.
+        store.statsTrackingEnabled = true
+        #expect(store.statsStartDate != nil)
+        #expect(store.hasRecordedStats == false)
+
+        // Toggling off doesn't change the picture.
+        store.statsTrackingEnabled = false
+        #expect(store.hasRecordedStats == false)
+    }
+
+    @Test("post-reset state is not considered recorded data")
+    func hasRecordedStatsAfterReset() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        #expect(store.hasRecordedStats == true)
+
+        store.resetStats()
+        // resetStats stamps statsStartDate to "now" while tracking
+        // is on, but every counter / collection is back to zero.
+        // The disable-reset prompt MUST not fire just because the
+        // start date is set.
+        #expect(store.hasRecordedStats == false)
+    }
+
+    @Test("recordSwitch and recordDevicesSeen both flip hasRecordedStats true")
+    func hasRecordedStatsTrueOnRealActivity() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+
+        store.recordSwitch(toSlug: "home-office")
+        #expect(store.hasRecordedStats == true)
+
+        store.resetStats()
+        #expect(store.hasRecordedStats == false)
+
+        store.recordDevicesSeen([USBDevice(vendorID: 0x2188, productID: 0x6533)])
+        #expect(store.hasRecordedStats == true)
+    }
+
     @Test("stats fields persist across reloads")
     func statsFieldsRoundTrip() {
         let defaults = makeSuite()

--- a/Tests/AVPainRelieverTests/EngineTests.swift
+++ b/Tests/AVPainRelieverTests/EngineTests.swift
@@ -360,6 +360,24 @@ struct EngineTests {
         #expect(observed == ["home-office", "home-office"])
     }
 
+    @Test("onDevicesEvaluated fires with the attached device set on every evaluate")
+    func onDevicesEvaluatedFiresWithAttachedSet() {
+        let h = makeHarness()
+        h.watcher.devices = [Self.caldigit, Self.lgCamera]
+        var observed: [Set<USBDevice>] = []
+        h.engine.onDevicesEvaluated = { observed.append($0) }
+
+        h.engine.start() // initial evaluate
+        h.watcher.devices = [Self.caldigit] // simulate unplug
+        h.watcher.triggerChange()
+        h.clock.advance(by: 1.5)
+
+        #expect(observed == [
+            [Self.caldigit, Self.lgCamera],
+            [Self.caldigit],
+        ])
+    }
+
     @Test("engine reflects current state when restarted after a state change")
     func restartAfterStop() {
         let h = makeHarness()


### PR DESCRIPTION
## Summary
- New \"Advanced\" tab in Settings, leading with an opt-in **Track usage stats locally** toggle. **Default: off.** No UserDefaults writes happen until the user opts in.
- Once enabled: total switches, per-profile counts (with most-used highlight + ranked rest), tracking-since date, last switched (relative time + profile), manual overrides, current/longest streak, active days, unique USB devices recognized.
- Reset Stats button (alert-confirmed) wipes counters but leaves the toggle alone.
- Engine gains an \`onDevicesEvaluated\` callback so the host can feed the unique-devices set without standing up a second USBWatcher.

## Privacy stance
Counts only — no meeting content, no durations, no per-day timestamps beyond the streak day-bucket math, no telemetry. Stays on the user's Mac. The gate lives in \`SettingsStore\`'s record/increment methods so even the existing easter-egg menu line freezes on opt-out without any view-level conditional.

## Test plan
- [x] All 200 unit tests pass (191 existing + 9 new).
- [ ] Fresh install: Settings → Advanced shows just the toggle + helper text. No metrics. No UserDefaults churn.
- [ ] Opt in. Metrics section appears. \"Tracking since today.\" Force a profile switch via the menu — manual overrides + auto-switches both bump.
- [ ] Plug/unplug a USB device. Unique devices count grows on first attach, stays put on re-attach.
- [ ] Wait until next day, trigger a switch. Current streak goes 1 → 2.
- [ ] Toggle off. Switch a profile — nothing changes (verify by docking/undocking). Toggle back on. \`statsStartDate\` does NOT re-stamp.
- [ ] Click Reset. Confirm alert. All numbers reset; \"Tracking since today\" reverts to today.
- [ ] Quit and relaunch — every value persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)