### PR TITLE
chore: silence pre-existing var-should-be-let warning in CMIOSinkWriter

### DIFF
--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -455,7 +455,7 @@ final class CMIOSinkWriter {
             mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
         )
         var direction: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
+        let size = UInt32(MemoryLayout<UInt32>.size)
         var used: UInt32 = 0
         let status = CMIOObjectGetPropertyData(
             streamID, &address, 0, nil, size, &used, &direction


### PR DESCRIPTION
## Summary
- One-character fix: \`var size\` → \`let size\` in \`CMIOSinkWriter.streamDirection\`. Pre-existing M2 warning that's been showing on every build; the value is passed to \`CMIOObjectGetPropertyData\` by value, never with \`&\`.
- No behavior change. Build output is now warning-free.

## Test plan
- [x] \`swift build\` — no warnings emitted from CMIOSinkWriter.
- [x] \`swift test\` — 191/191 still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)