### PR TITLE
Wizard: apply groupedFormChrome so cards match Settings padding

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -142,6 +142,11 @@ struct AddProfileView: View {
                         .strokeBorder(Theme.Color.error.opacity(0.35), lineWidth: 1)
                 )
                 .transition(.opacity.combined(with: .move(edge: .top)))
+                // Error banner sits OUTSIDE the Form, so give it the
+                // same horizontal margin from the window edge that
+                // the buttons row gets — keeps it visually parallel
+                // to the action buttons rather than touching edges.
+                .padding(.horizontal, 20)
             }
 
             HStack {
@@ -181,17 +186,19 @@ struct AddProfileView: View {
                 .keyboardShortcut(.defaultAction)
                 .animation(.easeInOut(duration: 0.18), value: viewModel.didSave)
             }
+            // Buttons row sits OUTSIDE the Form, so give it explicit
+            // horizontal margin so Cancel / Save don't touch the
+            // window edges.
+            .padding(.horizontal, 20)
+            .padding(.bottom, 16)
         }
-        // The wizard is a regular Window scene; it doesn't get the
-        // extra container padding SwiftUI's `Settings { ... }` scene
-        // wraps tab content in. Equal window width alone (480pt)
-        // wasn't enough — the wizard's gray Form cards still landed
-        // visibly tighter to the window edges than the matching
-        // Settings cards. Bump horizontal explicitly to compensate;
-        // vertical stays at 20pt so Cancel / Save buttons keep
-        // their existing distance from the bottom edge.
-        .padding(.horizontal, 36)
-        .padding(.vertical, 20)
+        // No outer horizontal padding on the VStack — the Form fills
+        // the window edge-to-edge (with .groupedFormChrome's 8pt
+        // breathing room baked in), exactly matching how a Settings
+        // tab renders. The error banner and buttons row carry their
+        // own per-element horizontal padding above so they don't
+        // touch the window edges.
+        .padding(.top, 8)
         // Fixed dialog size — pairs with the dialog chrome (no
         // resize/minimize/zoom) configured at the window scene. The
         // Form itself scrolls internally if the device list overflows

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -182,22 +182,18 @@ struct AddProfileView: View {
                 .animation(.easeInOut(duration: 0.18), value: viewModel.didSave)
             }
         }
-        // Wider horizontal padding than vertical so the Form's gray
-        // section cards land with breathing room that reads as
-        // consistent with the Settings tabs. The wizard's window is
-        // 40pt wider than the Settings window AND lacks the system
-        // chrome that the Settings scene wraps tab content in, so we
-        // can't rely on `.groupedFormChrome()`'s 8pt alone — the Form
-        // cards would visually creep up against the window edges.
-        // Vertical stays at 20pt so the Cancel / Save buttons keep
-        // their existing comfortable distance from the bottom.
-        .padding(.horizontal, 32)
-        .padding(.vertical, 20)
+        .padding(20)
         // Fixed dialog size — pairs with the dialog chrome (no
         // resize/minimize/zoom) configured at the window scene. The
         // Form itself scrolls internally if the device list overflows
         // on a fingerprint-heavy location.
-        .frame(width: 520, height: 600)
+        //
+        // Width matches the Settings window (480pt) so the gray Form
+        // section cards inside the wizard land at the same visual
+        // proportions as Settings' equivalents — same window width
+        // → same effective card inset → cards read as the same
+        // family without per-surface padding tweaks.
+        .frame(width: 480, height: 600)
         // Window scene's static title is "Add Profile"; override it
         // dynamically so the title bar tracks Add vs Edit mode.
         .navigationTitle(viewModel.editingExisting ? "Edit Profile" : "Add Profile")

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -123,7 +123,7 @@ struct AddProfileView: View {
                     sectionHeader("Camera", symbol: Theme.Symbol.cameraSection)
                 }
             }
-            .formStyle(.grouped)
+            .groupedFormChrome()
 
             if let error = viewModel.lastError {
                 HStack(alignment: .top, spacing: 8) {

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -182,7 +182,17 @@ struct AddProfileView: View {
                 .animation(.easeInOut(duration: 0.18), value: viewModel.didSave)
             }
         }
-        .padding(20)
+        // Wider horizontal padding than vertical so the Form's gray
+        // section cards land with breathing room that reads as
+        // consistent with the Settings tabs. The wizard's window is
+        // 40pt wider than the Settings window AND lacks the system
+        // chrome that the Settings scene wraps tab content in, so we
+        // can't rely on `.groupedFormChrome()`'s 8pt alone — the Form
+        // cards would visually creep up against the window edges.
+        // Vertical stays at 20pt so the Cancel / Save buttons keep
+        // their existing comfortable distance from the bottom.
+        .padding(.horizontal, 32)
+        .padding(.vertical, 20)
         // Fixed dialog size — pairs with the dialog chrome (no
         // resize/minimize/zoom) configured at the window scene. The
         // Form itself scrolls internally if the device list overflows

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -182,17 +182,21 @@ struct AddProfileView: View {
                 .animation(.easeInOut(duration: 0.18), value: viewModel.didSave)
             }
         }
-        .padding(20)
+        // The wizard is a regular Window scene; it doesn't get the
+        // extra container padding SwiftUI's `Settings { ... }` scene
+        // wraps tab content in. Equal window width alone (480pt)
+        // wasn't enough — the wizard's gray Form cards still landed
+        // visibly tighter to the window edges than the matching
+        // Settings cards. Bump horizontal explicitly to compensate;
+        // vertical stays at 20pt so Cancel / Save buttons keep
+        // their existing distance from the bottom edge.
+        .padding(.horizontal, 36)
+        .padding(.vertical, 20)
         // Fixed dialog size — pairs with the dialog chrome (no
         // resize/minimize/zoom) configured at the window scene. The
         // Form itself scrolls internally if the device list overflows
-        // on a fingerprint-heavy location.
-        //
-        // Width matches the Settings window (480pt) so the gray Form
-        // section cards inside the wizard land at the same visual
-        // proportions as Settings' equivalents — same window width
-        // → same effective card inset → cards read as the same
-        // family without per-surface padding tweaks.
+        // on a fingerprint-heavy location. Width matches the Settings
+        // window so the wizard reads as the same family.
         .frame(width: 480, height: 600)
         // Window scene's static title is "Add Profile"; override it
         // dynamically so the title bar tracks Add vs Edit mode.

--- a/Sources/AVPainRelieverApp/GroupedFormChrome.swift
+++ b/Sources/AVPainRelieverApp/GroupedFormChrome.swift
@@ -13,6 +13,23 @@ extension View {
     /// chrome (background, frame, etc.), edit it here and every
     /// caller follows. The Profiles Settings tab is intentionally
     /// bespoke (no Form, different layout) and doesn't use this.
+    ///
+    /// **Don't wrap the Form in a container that adds horizontal
+    /// padding.** e.g. avoid:
+    ///
+    ///     VStack {
+    ///         Form { ... }.groupedFormChrome()
+    ///     }.padding(.horizontal, 20)  // ← wrong
+    ///
+    /// The point of this modifier is to let the Form fill its
+    /// container edge-to-edge so it lines up with how a Settings
+    /// tab renders inside SwiftUI's `Settings { ... }` scene.
+    /// Outer horizontal padding on the container narrows the
+    /// gray cards beyond Settings' visual; this exact bug was
+    /// fixed in the wizard layout. If sibling elements (buttons
+    /// row, error banner, etc.) need their own margin from the
+    /// window edge, pad each one individually with
+    /// `.padding(.horizontal, …)` — see `AddProfileView.body`.
     func groupedFormChrome() -> some View {
         self
             .formStyle(.grouped)

--- a/Sources/AVPainRelieverApp/GroupedFormChrome.swift
+++ b/Sources/AVPainRelieverApp/GroupedFormChrome.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+extension View {
+    /// Shared chrome for every grouped-`Form` surface in the app
+    /// (Settings tabs, the Add/Edit Profile wizard, anywhere we
+    /// render a `Form { ... }.formStyle(.grouped)`). Bundles the
+    /// formStyle + the 8pt outer padding that gives the gray
+    /// rounded section cards consistent breathing room against
+    /// the window edges.
+    ///
+    /// One place to change the convention. If we ever bump the
+    /// padding, swap to a different formStyle, or add other shared
+    /// chrome (background, frame, etc.), edit it here and every
+    /// caller follows. The Profiles Settings tab is intentionally
+    /// bespoke (no Form, different layout) and doesn't use this.
+    func groupedFormChrome() -> some View {
+        self
+            .formStyle(.grouped)
+            .padding(8)
+    }
+}

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -13,24 +13,6 @@ enum SettingsTab: Hashable {
     case stats
 }
 
-private extension View {
-    /// Shared chrome for every Settings tab body — `.formStyle(.grouped)`
-    /// + 8 pt padding around the Form's rounded card. Apply to the
-    /// `Form` at the root of each tab's body so the gray section
-    /// cards line up consistently against the window edges. Camera,
-    /// General, and Stats use this; Profiles has its own layout
-    /// (no Form) and stays bespoke for now.
-    ///
-    /// One place to change the convention. If we ever want to bump
-    /// the padding to 12 or swap to a different formStyle, edit
-    /// here and every tab follows.
-    func settingsTabContent() -> some View {
-        self
-            .formStyle(.grouped)
-            .padding(8)
-    }
-}
-
 /// The Settings scene has four tabs: General (toggles + slider),
 /// Profiles (list with edit/delete), Camera (virtual camera
 /// install/enable + status), and Stats (opt-in local usage
@@ -125,7 +107,7 @@ private struct CameraSettingsTab: View {
                 Label("Virtual camera", systemImage: "camera.metering.center.weighted")
             }
         }
-        .settingsTabContent()
+        .groupedFormChrome()
     }
 
     /// Live status row — colored dot + human-readable label that
@@ -286,7 +268,7 @@ private struct GeneralSettingsTab: View {
                 Label("Updates", systemImage: "arrow.down.circle")
             }
         }
-        .settingsTabContent()
+        .groupedFormChrome()
     }
 }
 
@@ -529,7 +511,7 @@ private struct StatsSettingsTab: View {
                 }
             }
         }
-        .settingsTabContent()
+        .groupedFormChrome()
         .alert(
             "Reset all usage stats?",
             isPresented: $resetConfirmationVisible


### PR DESCRIPTION
## Summary
- Add/Edit Profile wizard's gray section cards landed tighter to window edges than the matching Settings cards (same regression class as last week's Stats tab).
- Promoted the previously fileprivate \`settingsTabContent()\` modifier into a new shared file as \`.groupedFormChrome()\`. Renamed because the modifier is no longer Settings-specific.
- Camera / General / Stats Settings tabs and the wizard's Form all use it now. Profiles Settings tab is intentionally bespoke and stays untouched (planned for separate exploration).
- Memory note updated to reflect the new name and broader applicability.

## Test plan
- [x] All 203 unit tests pass.
- [ ] Open Settings → General/Camera/Stats. Section cards have the same breathing room as before — visually identical.
- [ ] Open Add Profile (or Edit on an existing profile). Section cards now have padding that feels consistent with Settings.
- [ ] Cancel / Save Profile buttons at the bottom of the wizard haven't moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)