### PR TITLE
Wizard: tighter pill labels + tier-sort important to top, unnamed to bottom

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -236,7 +236,7 @@ final class AddProfileViewModel: ObservableObject {
         // pushed to the very bottom by name so the active hardware
         // stays grouped at the top.
         attachedDevices = Self.sortedByTier(liveSnapshot)
-            + disconnected.sorted { $0.displayName < $1.displayName }
+            + Self.sortedByTier(disconnected)
         disconnectedDeviceIDs = disconnectedIDs
 
         // Default selection: only the headline hardware classified
@@ -337,29 +337,49 @@ final class AddProfileViewModel: ObservableObject {
     /// watches). Within each tier, items sort alphabetically by
     /// `displayName` so the order is stable across re-renders.
     ///
-    /// Important devices (mics, cameras, capture cards, dedicated
-    /// audio interfaces) get a green **Important** pill in the
-    /// row UI rather than being lifted to a separate tier — earlier
-    /// experimentation showed that for sophisticated docks almost
-    /// every device qualifies as "important," which collapsed the
-    /// tier and gave no visible benefit over alphabetical. The pill
-    /// gives the same signal without disturbing the row order.
-    /// Single source of truth for both pills:
+    /// Four-tier sort, alphabetical within each tier:
+    /// 1. Important (mic / video / speaker / audio per
+    ///    `DevicePortability.importantCategory`) — top, easiest to
+    ///    scan when picking fingerprint candidates.
+    /// 2. Other named, non-portable.
+    /// 3. Portable named (keyboards, mice, phones — likely to
+    ///    travel with the user, not great fingerprint candidates).
+    /// 4. Unnamed (vendor + product both nil — usually internal
+    ///    hub legs of multi-function devices, low signal value)
+    ///    — bottom.
+    ///
+    /// Important wins over portable when the rare overlap appears
+    /// (e.g. a "Mic Mouse"), so the pill's strongest signal is
+    /// always at the top of the list.
+    ///
+    /// Single source of truth for both classifications:
     /// `DevicePortability.importantCategory` /
     /// `DevicePortability.portabilityCategory`.
     private static func sortedByTier(_ devices: [NamedUSBDevice])
         -> [NamedUSBDevice]
     {
         devices.sorted { lhs, rhs in
-            let lhsPortable = DevicePortability
-                .portabilityCategory(deviceName: lhs.name) != nil
-            let rhsPortable = DevicePortability
-                .portabilityCategory(deviceName: rhs.name) != nil
-            if lhsPortable != rhsPortable {
-                return !lhsPortable
+            let lhsTier = tier(for: lhs)
+            let rhsTier = tier(for: rhs)
+            if lhsTier != rhsTier {
+                return lhsTier < rhsTier
             }
             return lhs.displayName < rhs.displayName
         }
+    }
+
+    /// Lower number = higher in the list.
+    private static func tier(for device: NamedUSBDevice) -> Int {
+        if DevicePortability.importantCategory(deviceName: device.name) != nil {
+            return 0
+        }
+        if device.name == nil && device.vendorName == nil {
+            return 3
+        }
+        if DevicePortability.portabilityCategory(deviceName: device.name) != nil {
+            return 2
+        }
+        return 1
     }
 
     // MARK: - Name handling

--- a/Sources/AVPainRelieverApp/DevicePortability.swift
+++ b/Sources/AVPainRelieverApp/DevicePortability.swift
@@ -110,24 +110,25 @@ enum DevicePortability {
         if name.contains("display") || name.contains("ultrafine") {
             return nil
         }
-        if name.contains("microphone") || name.contains("podcast") {
-            return "microphone"
+        if name.contains("microphone") || name.contains("mic") || name.contains("podcast") {
+            return "mic"
         }
-        if name.contains("camera") || name.contains("webcam") {
-            return "camera"
-        }
-        if name.contains("capture") {
-            return "capture card"
+        // "video" intentionally covers cameras, webcams, AND HDMI
+        // capture cards. Capture cards aren't really cameras but
+        // they ARE video sources from the user's perspective; one
+        // unified label keeps the pill vocabulary tight.
+        if name.contains("camera") || name.contains("webcam") || name.contains("capture") {
+            return "video"
         }
         if name.contains("speaker") {
             return "speaker"
         }
-        // "audio" without a display/ultrafine prefix is reliable
-        // shorthand for a dedicated audio interface (CalDigit
-        // Thunderbolt 3 Audio, RME, Apollo, etc.). The earlier
-        // exclusion drops display-audio sub-components.
+        // Catch-all for dedicated audio gear that isn't obviously a
+        // mic or speaker — audio interfaces (CalDigit Thunderbolt
+        // 3 Audio, RME, Apollo), DACs, etc. The display/ultrafine
+        // exclusion above keeps display-audio sub-components out.
         if name.contains("audio") || name.contains("dac") {
-            return "audio interface"
+            return "audio"
         }
         return nil
     }

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -329,26 +329,45 @@ struct AddProfileViewModelTests {
         #expect(Set(loaded.map(\.name)) == ["home-studio"])
     }
 
-    @Test("device list sorts non-portable items above portable ones")
-    func deviceListTwoTierSort() {
+    @Test("device list sorts important → named → portable → unnamed, alphabetical within each tier")
+    func deviceListTierSort() {
         let watcher = FakeWatcher()
         watcher.named = [
-            NamedUSBDevice(
-                device: USBDevice(vendorID: 0x05ac, productID: 0x0265),
-                name: "Magic Trackpad"
-            ), // portable
+            // Important
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x2188, productID: 0x6533),
                 name: "CalDigit Thunderbolt 3 Audio"
-            ), // non-portable
-            NamedUSBDevice(
-                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
-                name: "Magic Keyboard"
-            ), // portable
+            ),
             NamedUSBDevice(
                 device: USBDevice(vendorID: 0x1e4e, productID: 0x701f),
                 name: "HDMI to U3 capture"
-            ), // non-portable
+            ),
+            // Other named, non-portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x2188, productID: 0x0747),
+                name: "CalDigit — Card Reader",
+                vendorName: nil
+            ),
+            // Portable
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x05ac, productID: 0x024f),
+                name: "Magic Keyboard"
+            ),
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x05ac, productID: 0x0265),
+                name: "Magic Trackpad"
+            ),
+            // Unnamed
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x043e, productID: 0x9a71),
+                name: nil,
+                vendorName: nil
+            ),
+            NamedUSBDevice(
+                device: USBDevice(vendorID: 0x043e, productID: 0x9a73),
+                name: nil,
+                vendorName: nil
+            ),
         ]
         let vm = AddProfileViewModel(
             watcher: watcher,
@@ -358,16 +377,19 @@ struct AddProfileViewModelTests {
             editing: nil,
             onSaved: {}
         )
-        let names = vm.attachedDevices.map(\.name)
-        // Non-portable items above portable, alphabetical within
-        // each tier. Important devices are signaled via the green
-        // "Important" pill in the row UI (see DevicePortability
-        // tests), not by floating to a separate tier.
-        #expect(names == [
-            "CalDigit Thunderbolt 3 Audio",  // non-portable, alphabetical
-            "HDMI to U3 capture",            // non-portable, alphabetical
-            "Magic Keyboard",                // portable, alphabetical
-            "Magic Trackpad",                // portable, alphabetical
+        let displayNames = vm.attachedDevices.map(\.displayName)
+        #expect(displayNames == [
+            // Tier 0: Important, alphabetical
+            "CalDigit Thunderbolt 3 Audio",
+            "HDMI to U3 capture",
+            // Tier 1: Other named, non-portable
+            "CalDigit — Card Reader",
+            // Tier 2: Portable
+            "Magic Keyboard",
+            "Magic Trackpad",
+            // Tier 3: Unnamed
+            "(unnamed device)",
+            "(unnamed device)",
         ])
     }
 

--- a/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
+++ b/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
@@ -52,15 +52,23 @@ struct DevicePortabilityTests {
     // explicitly excluded so the pill stays visually distinct on
     // sophisticated docks.
 
-    @Test("standalone mics, cameras, capture cards, and audio interfaces are flagged")
+    @Test("standalone mics, video sources, speakers, and audio gear are flagged with the right pill label")
     func importantHeadlineHardware() {
-        #expect(DevicePortability.importantCategory(deviceName: "Yeti Stereo Microphone") == "microphone")
-        #expect(DevicePortability.importantCategory(deviceName: "Shure MV7 podcast mic") == "microphone")
-        #expect(DevicePortability.importantCategory(deviceName: "FaceTime HD Camera") == "camera")
-        #expect(DevicePortability.importantCategory(deviceName: "Logitech webcam") == "camera")
-        #expect(DevicePortability.importantCategory(deviceName: "HDMI to U3 capture") == "capture card")
-        #expect(DevicePortability.importantCategory(deviceName: "CalDigit Thunderbolt 3 Audio") == "audio interface")
-        #expect(DevicePortability.importantCategory(deviceName: "External DAC") == "audio interface")
+        // Mics
+        #expect(DevicePortability.importantCategory(deviceName: "Yeti Stereo Microphone") == "mic")
+        #expect(DevicePortability.importantCategory(deviceName: "Shure MV7 podcast mic") == "mic")
+        // Video — cameras AND capture cards both show "video" so the
+        // pill vocabulary stays tight (capture cards aren't really
+        // cameras but they're video sources from the user's POV).
+        #expect(DevicePortability.importantCategory(deviceName: "FaceTime HD Camera") == "video")
+        #expect(DevicePortability.importantCategory(deviceName: "Logitech webcam") == "video")
+        #expect(DevicePortability.importantCategory(deviceName: "HDMI to U3 capture") == "video")
+        // Speakers
+        #expect(DevicePortability.importantCategory(deviceName: "Audioengine A2+ Speakers") == "speaker")
+        // Catch-all "audio" — dedicated audio gear that isn't
+        // obviously a mic/speaker.
+        #expect(DevicePortability.importantCategory(deviceName: "CalDigit Thunderbolt 3 Audio") == "audio")
+        #expect(DevicePortability.importantCategory(deviceName: "External DAC") == "audio")
     }
 
     @Test("display sub-components are NOT flagged as Important")


### PR DESCRIPTION
## Summary
- **Pills** are shorter and more consistent: \`mic\` (was \"microphone\"), \`video\` (was \"camera\" / \"capture card\" — one label covers both since capture cards are video sources from the user's POV), \`audio\` (was \"audio interface\" — now the catch-all for dedicated audio gear that isn't obviously a mic or speaker), \`speaker\` unchanged.
- **Device list** picks up two new sort tiers around the existing non-portable / portable split: Important on top, Unnamed (no vendor + no product name) at the bottom. Alphabetical within each tier. Same tier sort now applies to the disconnected list so saved-but-not-attached devices from an editing profile order consistently.

## Test plan
- [x] All 203 unit tests pass — DevicePortability label tests + new four-tier AddProfileViewModel sort test updated.
- [ ] Open Add Profile. Devices appear in the new order: important → other named → portable → unnamed.
- [ ] Pills read \"Important: mic\", \"Important: video\", \"Important: audio\", \"Important: speaker\" as appropriate.
- [ ] Open Edit Profile on a profile with disconnected devices saved. Disconnected list also follows the tier order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)