### PR TITLE
Updater: refresh on experimental-updates toggle to bypass stale Sparkle cache

### DIFF
--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -99,7 +99,7 @@ final class Updater {
             .removeDuplicates()
             .dropFirst()
             .sink { [weak self] _ in
-                self?.controller.checkForUpdatesInBackground()
+                self?.controller.updater.checkForUpdatesInBackground()
             }
             .store(in: &cancellables)
     }

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import Combine
 import Sparkle
 import OSLog
 
@@ -64,6 +65,8 @@ final class Updater {
     /// strong one here so the channel-allowlist callback survives.
     private let channelDelegate: ChannelGatingDelegate
 
+    private var cancellables: Set<AnyCancellable> = []
+
     init(settings: SettingsStore) {
         // `startingUpdater: true` kicks off the scheduled-check loop
         // immediately. The delegate's `allowedChannels(for:)` hook is
@@ -82,6 +85,23 @@ final class Updater {
         let feedDescription = controller.updater.feedURL?.absoluteString ?? "nil"
         Self.logger.info("Sparkle updater started; feed=\(feedDescription, privacy: .public)")
         installWindowTitleObserver()
+        // The delegate's `allowedChannels` is re-queried on every
+        // check, but Sparkle caches its parsed/filtered appcast result
+        // for a window between checks. A user who flips the
+        // experimental-updates toggle and immediately clicks "Check
+        // for Updates…" can hit the stale cache and see "you're up
+        // to date" until they toggle off-then-on (which evidently
+        // forces Sparkle to invalidate). Force a fresh background
+        // check on every toggle change so the new allowlist takes
+        // effect right away — silent if no update found, standard
+        // prompt if one is.
+        settings.$experimentalUpdates
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.controller.checkForUpdatesInBackground()
+            }
+            .store(in: &cancellables)
     }
 
     /// Sparkle's update alert XIB doesn't set a window title, so its


### PR DESCRIPTION
## Summary
- The \`ChannelGatingDelegate.allowedChannels\` callback already reads \`settings.experimentalUpdates\` live, but Sparkle caches its parsed/filtered appcast for a window between checks. A user who flips the toggle and immediately hits "Check for Updates…" can hit the stale cache and see "you're up to date" — only toggling off-then-on (which evidently invalidates) makes Sparkle re-evaluate.
- Observe \`settings.\$experimentalUpdates\` via Combine in \`Updater.init\`. On any change, fire \`controller.updater.checkForUpdatesInBackground()\` so Sparkle re-fetches the appcast and re-runs the channel filter with the current allowlist. Silent if no update is found, standard prompt if one is.

## Test plan
- [x] All 203 unit tests pass.
- [ ] On a v0.2.x build with experimental updates currently OFF: flip the toggle on. Within a few seconds Sparkle picks up the latest experimental release and shows the standard update prompt — no off-then-on dance required.
- [ ] On a v0.2.x build with experimental updates ON and at the latest release: flip off, flip back on. No update prompt (silent — already at latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)