### PR TITLE
UI: button styling pass for macOS HIG alignment

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -93,8 +93,11 @@ struct AddProfileView: View {
                     HStack {
                         sectionHeader("USB fingerprint", symbol: Theme.Symbol.usbSection)
                         Spacer()
-                        Button("Refresh", action: viewModel.refresh)
-                            .controlSize(.small)
+                        Button(action: viewModel.refresh) {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Rescan attached USB devices")
                     }
                 }
 
@@ -151,10 +154,8 @@ struct AddProfileView: View {
 
             HStack {
                 Spacer()
-                Button(action: dismiss) {
-                    Label("Cancel", systemImage: "xmark")
-                }
-                .keyboardShortcut(.cancelAction)
+                Button("Cancel", action: dismiss)
+                    .keyboardShortcut(.cancelAction)
                 Button(action: { viewModel.save() }) {
                     HStack(spacing: 6) {
                         if viewModel.didSave {
@@ -170,13 +171,6 @@ struct AddProfileView: View {
                                 .tint(.white)
                             Text("Saving…")
                         } else {
-                            // Idle state: pencil for edit (matches the
-                            // Settings → Profiles row's Edit button),
-                            // plus for add (matches the menu's
-                            // "Add Profile…" item icon). Keeps the
-                            // wizard's commit action visually paired
-                            // with whichever entry point launched it.
-                            Image(systemName: viewModel.editingExisting ? "pencil" : "plus")
                             Text(viewModel.editingExisting ? "Update Profile" : "Save Profile")
                         }
                     }

--- a/Sources/AVPainRelieverApp/IconButton.swift
+++ b/Sources/AVPainRelieverApp/IconButton.swift
@@ -1,19 +1,19 @@
 import SwiftUI
 
-/// Bordered icon-only button with a fixed icon-frame so multiple
+/// Borderless icon-only button with a fixed icon-frame so multiple
 /// IconButtons rendered side-by-side end up at identical heights
 /// regardless of which SF Symbol each one carries.
 ///
 /// Why this exists as a standalone view: SF Symbols of different
 /// designs (e.g. `pencil` vs `trash`) have intrinsically different
-/// glyph bounds at the same `.font(...)` size. A `.bordered` button
-/// auto-sizes to its content + chrome padding, so a row of plain
-/// `Button { Label(...) }` instances ends up with mismatched
+/// glyph bounds at the same `.font(...)` size. Even with `.borderless`
+/// chrome, the hit-target auto-sizes to content padding, so a row of
+/// plain `Button { Label(...) }` instances ends up with mismatched
 /// dimensions when the icons differ in metric. Pinning the inner
 /// `Image` to a fixed 18×20 frame — larger than either glyph's
 /// intrinsic content — neutralises the difference: each icon
 /// renders centred inside the same-size box, so each button's
-/// auto-sized chrome lands at the same dimensions too.
+/// hit-target lands at the same dimensions too.
 ///
 /// Accessibility: VoiceOver reads `accessibilityLabel`. A `.help(...)`
 /// tooltip surfaces the same string to sighted users hovering over
@@ -51,7 +51,7 @@ struct IconButton: View {
                     .frame(width: 18, height: 20)
             }
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(.borderless)
         .labelStyle(.iconOnly)
         .help(accessibilityLabel)
     }

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -88,12 +88,11 @@ private struct CameraSettingsTab: View {
                     Button("Restart AV Pain Reliever") {
                         activator.relaunch()
                     }
-                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
                 } else if showsApprovalAffordance {
-                    Button("Open Login Items & Extensions") {
+                    Button("Open Login Items & Extensions…") {
                         openExtensionsSettings()
                     }
-                    .controlSize(.small)
                 }
 
                 // Form footer hint rendered as the last row in the
@@ -318,14 +317,11 @@ private struct ProfilesSettingsTab: View {
             Divider()
 
             HStack {
-                Button {
+                Button("Add Profile…") {
                     delegate.beginAddingProfile()
                     openWindow(id: addProfileWindowID)
                     NSApp.activate(ignoringOtherApps: true)
-                } label: {
-                    Label("Add Profile", systemImage: "plus")
                 }
-                .buttonStyle(.borderedProminent)
                 Spacer()
                 Text("\(delegate.availableProfiles.count) profile\(delegate.availableProfiles.count == 1 ? "" : "s")")
                     .font(.caption)
@@ -362,7 +358,7 @@ private struct ProfilesSettingsTab: View {
                 openWindow(id: addProfileWindowID)
                 NSApp.activate(ignoringOtherApps: true)
             } label: {
-                Label("Add Profile", systemImage: "plus")
+                Text("Add Profile…")
                     .padding(.horizontal, 12)
                     .padding(.vertical, 2)
             }
@@ -505,7 +501,11 @@ private struct StatsSettingsTab: View {
                         resetConfirmationVisible = true
                     } label: {
                         Text("Reset stats…")
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                 } header: {
                     Label("Reset", systemImage: "arrow.counterclockwise")
                 }


### PR DESCRIPTION
## Summary

Sweeps every standalone button across About, Welcome, Profiles, Camera, Stats, and the Add/Edit Profile sheet so the app reads as a native macOS settings utility instead of an indie SwiftUI app.

## Design rules applied

1. No SF Symbol prefix on text buttons (sheet/dialog/list footer Buttons). Exceptions: menu bar items, state indicators, toolbar buttons.
2. \`borderedProminent\` reserved for the default action of a sheet/dialog (the one bound to Return). Everywhere else, use bordered.
3. Cancel is plain text — no xmark, no role decoration needed.
4. Row-action buttons in lists are borderless icon-only.
5. Visual weight matches urgency — restart-required action now reads as the call-to-action it is.
6. Ellipsis (\`…\`) on buttons that open further UI (sheets, alerts, system panes).

## Per-button changes

- **Add Profile sheet footer** — drop xmark from Cancel and plus/pencil from Save Profile / Update Profile (idle state). Spinner + ✓ Saved state indicators preserved.
- **Profiles tab footer Add button** — drop borderedProminent + plus icon, use plain bordered \`Add Profile…\` (System Settings idiom).
- **Profiles empty-state Add button** — drop plus icon, add ellipsis, keep borderedProminent + large (earned in empty state).
- **Profile row Edit/Delete** — IconButton switched \`.bordered\` → \`.borderless\`. Doc comment updated.
- **Camera tab Restart button** — promote to borderedProminent at default size. Visual weight now matches the orange status dot.
- **Camera tab Open Login Items button** — drop \`.small\`, add ellipsis (deep-links to System Settings).
- **Stats tab Reset button** — full-width red row inside the grouped section. Matches Apple ID → Sign Out / Game Center → Reset Recommendations. Destructive intent visible at a glance; no more orphan-chip-in-grouped-section look.
- **Add Profile USB fingerprint header** — text \"Refresh\" → borderless \`arrow.clockwise\` icon with \"Rescan attached USB devices\" tooltip. Matches Mail / App Store / System Settings refresh idiom.

## Files touched

- \`Sources/AVPainRelieverApp/AddProfileView.swift\`
- \`Sources/AVPainRelieverApp/IconButton.swift\`
- \`Sources/AVPainRelieverApp/SettingsView.swift\`

Untouched on purpose: AboutView (already correct), WelcomeView (already correct), App.swift menu bar (menu items SHOULD have icons), Theme/GroupedFormChrome/WindowChrome.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — 203/203 passing
- [x] Manual UI verification (per project's \"test locally before shipping\" rule):
  - About + Welcome unchanged ✓
  - Profiles tab footer + row buttons read as native ✓
  - Add Profile sheet footer reads as native ✓
  - Camera tab Restart-required state shows prominent button ✓
  - Stats tab Reset is full-width red row ✓
  - USB fingerprint Refresh is borderless icon ✓

## Local rebuild + install

\`\`\`sh
git checkout ui/button-hig-cleanup
pkill -f AVPainRelieverApp
MAC_CERT_NAME=\"Developer ID Application: Eric Willis (HLH4LEWS9S)\" \\
NOTARIZE_KEYCHAIN_PROFILE=avpain-notary \\
scripts/make-app-with-virtual-camera.sh
rm -rf /Applications/AVPainReliever.app
ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
open /Applications/AVPainReliever.app
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)