### PR TITLE
UI: native alerts, vertical device list, USB icon, copy cleanup

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -388,7 +388,7 @@ struct AddProfileView: View {
     @ViewBuilder
     private var cameraSectionHelperText: some View {
         if viewModel.virtualCameraEnabled {
-            Text("AV Pain Reliever's virtual camera will use this as its source. Set Zoom, Slack, and Teams to “AV Pain Reliever” once — they'll follow your profile automatically.")
+            Text("Virtual camera will use this as its source. Set Zoom, Slack, and Teams to “AV Pain Reliever” once — they'll follow your profile automatically.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -538,30 +538,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         aboutOpenToken = UUID()
     }
 
-    /// Confirm + delete a profile. Shown as a modal alert so the user
-    /// can't accidentally lose a configuration. After deletion the
-    /// engine reloads against the trimmed config.
-    func requestDelete(_ profile: Profile) {
-        let alert = NSAlert()
+    /// Delete a profile from the on-disk config and reload the engine.
+    /// Caller (the SwiftUI Profiles tab) owns the confirmation alert
+    /// — keeping the confirmation in SwiftUI lets it render with
+    /// native `.alert()` chrome (no app-icon badge) matching the
+    /// other destructive prompts in Settings (Reset stats, etc.).
+    /// On failure, surfaces an NSAlert because the error path is
+    /// rare and doesn't have a sensible SwiftUI escape hatch from
+    /// here.
+    func deleteProfile(_ profile: Profile) {
         let pretty = PrettyName.format(profile.name)
-        alert.messageText = "Delete “\(pretty)”?"
-        alert.informativeText = "This profile won't switch your audio + camera defaults when its USB devices are attached. You can always recapture it later."
-        alert.alertStyle = .warning
-        // Override the generic-app fallback icon NSAlert picks up when
-        // running unbundled (`swift run`, no Info.plist). Setting
-        // `alert.icon` makes the pill render in both bundled and
-        // unbundled contexts; `.warning` style still overlays its
-        // caution badge on top.
-        alert.icon = AppIcon.image
-        // Cancel first → default (Return) → safe accidental press.
-        // Delete second, destructive-styled (red on macOS 11+) so the
-        // dangerous action both looks dangerous and requires a
-        // deliberate click rather than a stray Return.
-        alert.addButton(withTitle: "Cancel")
-        let deleteButton = alert.addButton(withTitle: "Delete")
-        deleteButton.hasDestructiveAction = true
-        let response = alert.runModal()
-        guard response == .alertSecondButtonReturn else { return }
         do {
             try ProfileWriter().delete(named: profile.name, in: Self.profilesTOMLURL)
             reloadConfig()

--- a/Sources/AVPainRelieverApp/MenuBarIcon.swift
+++ b/Sources/AVPainRelieverApp/MenuBarIcon.swift
@@ -42,7 +42,7 @@ enum MenuBarIcon {
         "arrow.left.arrow.right",
         "wand.and.stars",
         // Connectivity
-        "cable.connector",
+        "externaldrive.connected.to.line.below",
         // The eighteenth slot — fills the orphan cell in the 6×3
         // grid and ties back to the About / Welcome confetti.
         "party.popper.fill",

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -72,13 +72,21 @@ struct SettingsView: View {
 private struct CameraSettingsTab: View {
     @ObservedObject var settings: SettingsStore
     @ObservedObject var activator: VirtualCameraActivator
+    // Intercept-before-apply: when the user toggles OFF, hold the
+    // confirmation up before flipping the underlying setting.
+    // Rolling back a deactivation after the fact would push the
+    // activator into .requiresRelaunch (macOS doesn't actually stop
+    // the extension on `deactivationRequest`, so a re-enable in the
+    // same session can't recover cleanly). Confirm-first avoids
+    // ever entering that bad state on a misclick.
+    @State private var pendingVirtualCameraDisable = false
 
     var body: some View {
         Form {
             Section {
                 Toggle(
-                    "Enable AV Pain Reliever as a virtual camera",
-                    isOn: $settings.virtualCameraEnabled
+                    "Enable virtual camera",
+                    isOn: virtualCameraToggleBinding
                 )
                 .disabled(activator.isEnvOverride)
 
@@ -107,6 +115,35 @@ private struct CameraSettingsTab: View {
             }
         }
         .groupedFormChrome()
+        .alert(
+            "Turn off the virtual camera?",
+            isPresented: $pendingVirtualCameraDisable
+        ) {
+            Button("Cancel", role: .cancel) {}
+            Button("Turn Off") {
+                settings.virtualCameraEnabled = false
+            }
+        } message: {
+            Text("Zoom, Slack, Teams, and other apps with their own camera picker will stop following your profile changes. They'll stay on whichever camera you last selected inside each app. You can turn this back on later.")
+        }
+    }
+
+    /// Custom binding for the toggle that intercepts the off
+    /// transition. Reads pass through to `settings.virtualCameraEnabled`.
+    /// Writes that flip ON apply directly. Writes that flip OFF
+    /// raise the confirm-disable alert without touching the setting
+    /// — the alert's "Turn Off" action does the actual write.
+    private var virtualCameraToggleBinding: Binding<Bool> {
+        Binding(
+            get: { settings.virtualCameraEnabled },
+            set: { newValue in
+                if !newValue && settings.virtualCameraEnabled {
+                    pendingVirtualCameraDisable = true
+                } else {
+                    settings.virtualCameraEnabled = newValue
+                }
+            }
+        )
     }
 
     /// Live status row — colored dot + human-readable label that
@@ -174,7 +211,7 @@ private struct CameraSettingsTab: View {
         case .failed:
             return "Activation didn't complete. Open System Settings → General → Login Items & Extensions to check the extension's state, then toggle this off and on to retry."
         case .requiresRelaunch:
-            return "macOS holds the virtual camera in a stale state after toggling off and back on inside one session. Restart AV Pain Reliever to re-enable it cleanly."
+            return "macOS holds the virtual camera in a stale state after toggling off and back on inside one session. Restart the app to re-enable it cleanly."
         }
     }
 
@@ -254,7 +291,7 @@ private struct GeneralSettingsTab: View {
                 }
                 .padding(.vertical, 4)
             } header: {
-                Label("Detection", systemImage: "cable.connector")
+                Label("Detection", systemImage: Theme.Symbol.usbSection)
             }
 
             Section {
@@ -291,6 +328,10 @@ enum VersionInfo {
 private struct ProfilesSettingsTab: View {
     @ObservedObject var delegate: AppDelegate
     @Environment(\.openWindow) private var openWindow
+    // Native SwiftUI .alert() for delete confirmation — matches the
+    // Stats tab's "Reset stats?" pattern. Was an NSAlert on
+    // AppDelegate that always rendered with the app icon badge.
+    @State private var profilePendingDeletion: Profile?
 
     var body: some View {
         Group {
@@ -307,12 +348,30 @@ private struct ProfilesSettingsTab: View {
                                 openWindow(id: addProfileWindowID)
                                 NSApp.activate(ignoringOtherApps: true)
                             },
-                            onDelete: { delegate.requestDelete(profile) }
+                            onDelete: { profilePendingDeletion = profile }
                         )
                     }
                 }
                 .listStyle(.inset)
             }
+        }
+        .alert(
+            "Delete “\(PrettyName.format(profilePendingDeletion?.name ?? ""))”?",
+            isPresented: Binding(
+                get: { profilePendingDeletion != nil },
+                set: { if !$0 { profilePendingDeletion = nil } }
+            ),
+            presenting: profilePendingDeletion
+        ) { profile in
+            // Cancel first → bound to .cancelAction (Return key) → safe
+            // accidental press. Delete second, .destructive → red text
+            // and requires a deliberate click.
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                delegate.deleteProfile(profile)
+            }
+        } message: { _ in
+            Text("This profile won't switch your audio + camera defaults when its USB devices are attached. You can always recapture it later.")
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             // Native macOS bottom-bar pattern (Mail sidebar, Reminders,
@@ -362,7 +421,7 @@ private struct ProfilesSettingsTab: View {
             VStack(spacing: 4) {
                 Text("Set up your first location")
                     .font(.title3.weight(.semibold))
-                Text("Plug in your dock or peripherals, then capture them as a profile. AV Pain Reliever will switch your audio + camera defaults whenever you dock there again.")
+                Text("Plug in your dock or peripherals, then capture them as a profile. Your audio + camera defaults will switch automatically when you dock there again.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -393,7 +452,7 @@ private struct ProfileRow: View {
     let onDelete: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(alignment: .top, spacing: 10) {
             // Leading icon mirrors the Switch To submenu: profile's
             // user-picked icon when set, slug-driven auto-mapper
             // fallback when not.
@@ -404,7 +463,8 @@ private struct ProfileRow: View {
                 .font(.title3)
                 .foregroundStyle(isActive ? .primary : .secondary)
                 .frame(width: 28)
-            VStack(alignment: .leading, spacing: 2) {
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
                     Text(PrettyName.format(profile.name))
                         .font(.body.weight(.medium))
@@ -417,11 +477,23 @@ private struct ProfileRow: View {
                             .background(Color.green, in: Capsule())
                     }
                 }
-                if let summary = summaryText {
-                    summary
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
+                // Vertical device list — each device on its own row
+                // with an icon-aligned column. Apple's pattern in
+                // System Settings → Bluetooth / Network / Internet
+                // Accounts. Replaces the earlier inline
+                // "icon + name • icon + name • …" caption that wrapped
+                // unpredictably when device names were long, splitting
+                // an SF Symbol from its label across lines.
+                ForEach(deviceRows) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: row.icon)
+                            .frame(width: 14, alignment: .center)
+                        Text(row.label)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
             }
             Spacer()
@@ -443,38 +515,39 @@ private struct ProfileRow: View {
                 action: onDelete
             )
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 6)
     }
 
-    /// Caption-line under each profile name. Renders inline SF Symbols
-    /// (mic / speaker / camera) instead of the emoji prefixes the
-    /// earlier draft used — emoji at caption size read as cheap and
-    /// clash with the otherwise-monochrome SF Symbol vocabulary used
-    /// throughout the menu and wizard. `Text + Text(Image:)`
-    /// concatenation keeps it a single flowing line that wraps and
-    /// respects `.lineLimit(2)` cleanly.
-    private var summaryText: Text? {
-        var parts: [Text] = []
+    /// One row in the per-profile device summary list.
+    private struct DeviceRow: Identifiable {
+        let icon: String
+        let label: String
+        var id: String { "\(icon)|\(label)" }
+    }
+
+    /// Devices to surface under the profile name, in display order:
+    /// microphone, speaker, camera, then USB fingerprint summary.
+    /// USB row uses `Theme.Symbol.usbSection` for both the count case
+    /// and the "always matches when undocked" case — the differentiator
+    /// is the label, not the glyph.
+    private var deviceRows: [DeviceRow] {
+        var rows: [DeviceRow] = []
         if let mic = profile.audioInput {
-            parts.append(Text(Image(systemName: "mic")) + Text(" \(mic)"))
+            rows.append(DeviceRow(icon: "mic", label: mic))
         }
         if let out = profile.audioOutput {
-            parts.append(Text(Image(systemName: "speaker.wave.2")) + Text(" \(out)"))
+            rows.append(DeviceRow(icon: "speaker.wave.2", label: out))
         }
         if let cam = profile.camera {
-            parts.append(Text(Image(systemName: "camera")) + Text(" \(cam)"))
+            rows.append(DeviceRow(icon: "camera", label: cam))
         }
         if profile.fingerprint.isEmpty {
-            parts.append(Text("Always matches when undocked"))
+            rows.append(DeviceRow(icon: Theme.Symbol.usbSection, label: "Always matches when undocked"))
         } else {
             let count = profile.fingerprint.count
-            parts.append(Text("\(count) USB device\(count == 1 ? "" : "s")"))
+            rows.append(DeviceRow(icon: Theme.Symbol.usbSection, label: "\(count) USB device\(count == 1 ? "" : "s")"))
         }
-        guard !parts.isEmpty else { return nil }
-        let separator = Text("  •  ")
-        return parts.dropFirst().reduce(parts[0]) { acc, next in
-            acc + separator + next
-        }
+        return rows
     }
 }
 

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -43,7 +43,12 @@ enum Theme {
         /// Wizard section icons — keep in lockstep with the section
         /// titles in `AddProfileView`.
         static let nameSection = "tag.fill"
-        static let usbSection = "cable.connector"
+        // Was `cable.connector` — that glyph reads as a stick figure
+        // at small sizes (the USB-A connector silhouette is genuinely
+        // person-shaped). `externaldrive.connected.to.line.below` is
+        // unambiguously "peripheral connected to host" and reads cleanly
+        // at caption size.
+        static let usbSection = "externaldrive.connected.to.line.below"
         static let audioSection = "speaker.wave.2.fill"
         static let cameraSection = "camera.fill"
     }
@@ -52,6 +57,24 @@ enum Theme {
         /// Tagline shown under the welcome greeting. Keep voice warm,
         /// not corporate; the user-facing personality lives here.
         static let tagline = "Your audio and camera, dialed in automatically."
+        /// The app's display name. Use sparingly in user-facing copy
+        /// — see the rule below before adding a new reference.
+        ///
+        /// **Self-naming rule for user-facing strings:**
+        /// - **Inside a Settings tab, sheet, alert, or any in-app
+        ///   surface** → don't name the app; the frame already
+        ///   implies it. *"Enable virtual camera"* not *"Enable
+        ///   AV Pain Reliever as a virtual camera."*
+        /// - **In a button label that performs an action ON the app
+        ///   itself** (Restart, Quit) → name it; "Restart" alone
+        ///   could read as "restart macOS" — explicit target wins.
+        /// - **When telling the user to do something in ANOTHER
+        ///   app** ("Pick X in Zoom") → name it (in quotes); the
+        ///   user needs to recognize the exact string in the other
+        ///   app's picker.
+        /// - **About / Welcome / menu bar / login items /
+        ///   notifications** → name it; these are external or
+        ///   system-level surfaces where the brand is the point.
         static let appName = "AV Pain Reliever"
     }
 }


### PR DESCRIPTION
## Summary

Settings polish pass — accumulated several small wins on one branch:

### SwiftUI native confirmation alerts (replaces NSAlerts with app-icon badges)
- **Delete profile** (Profiles → trash) was an NSAlert with the pill icon stamped in the corner; now a SwiftUI \`.alert()\` with no badge, matching the Stats tab's "Reset stats?" pattern. \`AppDelegate.requestDelete(_:)\` split into a UI-free \`deleteProfile(_:)\`; confirmation lives in \`ProfilesSettingsTab\` via item-bound \`.alert(presenting:)\`.
- **Disable virtual camera** (Camera tab → toggle off) is a new intercept-and-confirm alert. The toggle uses a custom Binding that, on the off transition, raises the alert WITHOUT touching \`settings.virtualCameraEnabled\`. Cancel keeps the toggle on with no actual deactivation; only "Turn Off" applies. Avoids ever entering \`.requiresRelaunch\` on a misclick.

### Profiles tab vertical device list (Option A from the design pass)
The inline "icon + name • icon + name • …" caption was wrapping unpredictably and orphaning SF Symbols from their labels. Restructured to a vertical list of \`HStack\` rows, one per device, with a fixed-width icon column. Matches Apple's pattern in System Settings → Bluetooth / Network / Internet Accounts.

### USB icon swap
\`cable.connector\` reads as a stick figure at caption size (the USB-A connector silhouette is genuinely person-shaped). Swept three sites: \`Theme.Symbol.usbSection\` (wizard + Profiles row), General tab "Detection" section header, and the menu bar icon picker catalog Connectivity slot. New icon: \`externaldrive.connected.to.line.below\`.

### Self-naming copy cleanup + a one-place rule
Four strings dropped redundant "AV Pain Reliever" self-references when the in-app context already implies the app:
- Camera toggle: *"Enable AV Pain Reliever as a virtual camera"* → *"Enable virtual camera"*
- Camera restart help: *"...Restart AV Pain Reliever to re-enable it cleanly."* → *"...Restart the app to re-enable it cleanly."*
- Profiles empty state: agentless rewrite drops the self-name
- Camera section help (Add/Edit Profile): drops the redundant first self-name; keeps the QUOTED one because that's the literal string users have to find in Zoom/Slack/Teams pickers

About / Welcome / menu bar / restart-button-target / virtual-camera-display-name keep the name — they're brand surfaces or external contracts. \`Theme.Copy.appName\` now has a doc comment with the full self-naming rule so future copy edits don't need to re-derive it.

## Files touched

- \`Sources/AVPainRelieverApp/AddProfileView.swift\` — camera section help copy
- \`Sources/AVPainRelieverApp/AppDelegate.swift\` — \`requestDelete\` → \`deleteProfile\`, drop confirmation NSAlert
- \`Sources/AVPainRelieverApp/MenuBarIcon.swift\` — Connectivity slot in catalog
- \`Sources/AVPainRelieverApp/SettingsView.swift\` — toggle binding + alert, ProfileRow vertical layout, Detection section icon, three copy edits
- \`Sources/AVPainRelieverApp/Theme.swift\` — \`usbSection\` icon swap with rationale, \`appName\` doc comment with self-naming rule

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — 203/203 passing
- [x] Manual UI verification across Profiles tab, Camera tab, Add/Edit Profile sheet, General tab, About + Welcome (unchanged)

## Local rebuild + install

\`\`\`sh
git checkout ui/delete-profile-swiftui-alert
pkill -f AVPainRelieverApp
MAC_CERT_NAME=\"Developer ID Application: Eric Willis (HLH4LEWS9S)\" \\
NOTARIZE_KEYCHAIN_PROFILE=avpain-notary \\
scripts/make-app-with-virtual-camera.sh
rm -rf /Applications/AVPainReliever.app
ditto dist/AVPainReliever.app /Applications/AVPainReliever.app
open /Applications/AVPainReliever.app
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)