### PR TITLE
docs/copy: drop v0.2.x example from experimental help, sync README toggle label

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The virtual camera fixes that. Once turned on, **AV Pain Reliever** appears as a
 To enable:
 
 1. Open **Settings… → Camera**.
-2. Toggle **Enable AV Pain Reliever as a virtual camera**.
+2. Toggle **Enable virtual camera**.
 3. Approve in **System Settings → General → Login Items & Extensions** when prompted (one-time setup).
 4. In Zoom / Slack / Teams, pick **AV Pain Reliever** as your camera.
 

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -296,7 +296,7 @@ private struct GeneralSettingsTab: View {
 
             Section {
                 Toggle("Receive experimental updates", isOn: $settings.experimentalUpdates)
-                Text("Opt in to early-access builds. Experimental releases include unfinished features (the virtual camera in v0.2.x) and may be less stable than the regular release line. Off by default.")
+                Text("Opt in to early-access builds. Experimental releases may include unfinished features and be less stable than the regular release line. Off by default.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary

Two small text-only edits, part of the experimental-channel posture cleanup ahead of graduating v0.2.x to stable.

- **\`Sources/AVPainRelieverApp/SettingsView.swift\`** — drop the "(the virtual camera in v0.2.x)" parenthetical from the help text under the "Receive experimental updates" toggle. The example will rot as v0.2.x graduates and the experimental track empties out / refills with future risky features. New copy is generic.
- **\`README.md\`** — sync the Virtual camera section's step 2 to the new in-app toggle label ("Enable virtual camera"), which [PR #33](https://github.com/superic/av-pain-reliever/pull/33) changed.

No logic changes, no release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)