### PR TITLE
release: graduate v0.2.x to stable Sparkle channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,15 +260,21 @@ jobs:
               echo "APPCAST_ITEM_FILE=" >> "$GITHUB_ENV"
               exit 0
           fi
-          # v0.2.x+ ships through the experimental Sparkle channel —
-          # only installs that have allowlisted "experimental" (via
-          # the Settings → General → Updates → Receive experimental
-          # updates toggle) see these items as available upgrades.
-          # v0.1.x stays on the empty/stable channel so every install
-          # picks them up automatically.
+          # Stable by default. To opt a release into the experimental
+          # Sparkle channel, append `-experimental` (or
+          # `-experimental.N`) to the tag — e.g. `v0.2.1.0-experimental.1`.
+          # Only installs that have allowlisted "experimental" via
+          # Settings → General → Updates → "Receive experimental
+          # updates" see those items.
+          #
+          # Earlier rule was the inverse (v0.2.x defaulted to
+          # experimental during the virtual-camera development track).
+          # That track graduated to stable in 2026-05; the new default
+          # matches how most apps work and is future-proof for major
+          # version bumps without workflow edits.
           case "$VERSION_TAG" in
-              v0.0.0-*|v0.1.*) export CHANNEL= ;;
-              *) export CHANNEL=experimental ;;
+              *-experimental*) export CHANNEL=experimental ;;
+              *)               export CHANNEL= ;;
           esac
           echo "Appcast channel: ${CHANNEL:-<stable>}"
           ITEM_FILE="$RUNNER_TEMP/appcast-item.xml"

--- a/SWIFT_PORT.md
+++ b/SWIFT_PORT.md
@@ -3741,6 +3741,84 @@ PR: [#31](https://github.com/superic/av-pain-reliever/pull/31)
 (workflow changes), shipped in v0.2.0.12. Doc updates in a follow-
 up PR.
 
+### v0.2.x graduates from experimental to stable (2026-05-05)
+
+The virtual-camera development track has been on the experimental
+Sparkle channel since v0.2.0 (2026-05-04). Decision today: graduate
+it. The work was driven by three things converging:
+
+1. **Apple-side gates are clear.** A round of research (Apple
+   Developer Forums + Halle Winkler's CMIO blog series, see the
+   memory `project_virtual_camera_v2.md`) confirmed that
+   distributing a CMIO Camera Extension via Developer ID outside
+   the Mac App Store needs only the entitlements we already declare
+   (`system-extension.install`, `application-groups`,
+   `device.camera`). No additional Apple email request needed. The
+   12 successful notarizations of v0.2.0 → v0.2.0.12 are empirical
+   proof.
+2. **The feature has been exercised end-to-end.** Capture from
+   FaceTime HD + HDMI capture cards, hold-last-frame during
+   profile switches, format negotiation, self-source feedback loop
+   guard, and the macOS-extension-deactivation `.requiresRelaunch`
+   workaround all shipped and survived real use.
+3. **Keeping v0.2.x experimental indefinitely is wrong** — the
+   experimental channel exists for risky feature development, not
+   as a permanent home for shipped features. Sitting on it
+   permanently contradicts the channel's purpose and confuses
+   future graduations.
+
+What the graduation actually changes:
+
+- **`release.yml` channel rule inverted.** Was: "v0.1.x stable,
+  everything else experimental." Now: stable by default; explicit
+  `-experimental` (or `-experimental.N`) tag suffix opts in. Future
+  `v0.2.0.13`, `v0.3.0`, `v1.0.0` etc. ship stable automatically.
+  Future risky-feature builds use a tag like
+  `v0.2.1.0-experimental.1`. Convention is more future-proof
+  (no workflow edit needed when major version bumps) and matches
+  how most apps work (stable is the default; experimental is the
+  intentional opt-in).
+- **`appcast.xml` v0.2.0.12 retagged stable.** Single XML edit
+  drops the `<sparkle:channel>experimental</sparkle:channel>` line
+  from v0.2.0.12 only. Previous experimental items (v0.2.0.2 →
+  v0.2.0.11) keep their tags — historical accuracy preserved; they
+  WERE experimental at the time. Stable-channel users (currently
+  nobody beyond the dev) will see v0.2.0.12 on their next Sparkle
+  check; no need to wait for a new release.
+- **Settings → General → "Receive experimental updates" toggle
+  stays.** Per the dev's intent, the experimental capability is
+  preserved for future risky-feature work — the toggle, the
+  `ChannelGatingDelegate`, the `experimentalUpdates` setting, and
+  the "you're running an experimental version" nudge alert all
+  remain in place. Help text under the toggle was genericized
+  ahead of this PR (PR #34) so it doesn't name v0.2.x specifically
+  and stays accurate as the experimental queue empties / refills.
+- **`docs/RELEASING.md` documents the new tag convention** in a
+  new "Stable vs experimental tags" section, including the
+  `vX.Y.Z` vs `vX.Y.Z-experimental.N` rule and graduation
+  procedure ("ship next release without the suffix; optionally
+  retag specific appcast items").
+
+What graduation explicitly does NOT do:
+
+- No new release tag was cut. The dev is currently the only user;
+  no need for a ceremonial graduation release. The next normal
+  release (whenever something ships next) will be the first
+  workflow-default-stable release.
+- No code-level change to extension activation, the host's CMIO
+  pipeline, or the virtual camera surfaces in Settings. The
+  feature itself is unchanged — only its Sparkle channel
+  classification changed.
+
+Lesson: experimental release channels are scaffolding, not a
+permanent home. When the feature they were built around graduates,
+the channel needs to be reset back to "empty waiting room" for the
+next risky thing — keep the mechanism, retire the specific
+classification.
+
+PR: TBD (this commit), shipped without a tag. Next release inherits
+the new behavior automatically.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/appcast.xml
+++ b/appcast.xml
@@ -471,7 +471,6 @@
 <p>Money.</p>
 ]]></description>
             <pubDate>Wed, 06 May 2026 04:20:42 +0000</pubDate>
-            <sparkle:channel>experimental</sparkle:channel>
             <sparkle:version>0.2.0.12</sparkle:version>
             <sparkle:shortVersionString>0.2.0.12</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -237,6 +237,31 @@ git push origin :refs/tags/v0.0.0-dryrun
 gh release delete v0.0.0-dryrun --yes --cleanup-tag
 ```
 
+### Stable vs experimental tags
+
+The release workflow picks the Sparkle channel from the tag name:
+
+- `vX.Y.Z` (e.g. `v0.2.0.13`, `v0.3.0`) → **stable channel.** Every
+  install on the regular update line picks it up.
+- `vX.Y.Z-experimental.N` (e.g. `v0.2.1.0-experimental.1`) →
+  **experimental channel.** Only installs that have flipped
+  Settings → General → Updates → "Receive experimental updates"
+  on will see it as available.
+
+Stable is the default. Use experimental for builds that introduce
+risky or unfinished features and need real-world testing on a
+self-selected subset of users before promotion. To "graduate" an
+experimental track to stable, ship the next release without the
+suffix and (if desired) edit `appcast.xml` to drop the
+`<sparkle:channel>experimental</sparkle:channel>` line from the
+already-shipped item you want to retroactively expose to the stable
+channel.
+
+This rule was inverted in 2026-05 — earlier, v0.2.x defaulted to
+experimental during the virtual-camera development track. After the
+camera shipped, defaults flipped to "stable unless explicitly
+opted out." See SWIFT_PORT.md for the graduation event.
+
 ---
 
 ## Regenerating the app icon


### PR DESCRIPTION
## Summary

Virtual-camera dev track graduates from the experimental Sparkle channel to stable. Three small changes, no source-level code edits.

## Three decisions, three changes

### 1. Workflow channel rule inverted (\`.github/workflows/release.yml\`)

Was: \`v0.0.0-*|v0.1.*) CHANNEL= ;; *) CHANNEL=experimental ;;\` — implicitly tagged every v0.2.x as experimental, would do the same for future v0.3.x / v1.0.0 without workflow edits.

Now: \`*-experimental*) CHANNEL=experimental ;; *) CHANNEL= ;;\` — stable by default; explicit \`-experimental\` (or \`-experimental.N\`) tag suffix opts in. Future-proof for major version bumps.

### 2. v0.2.0.12 retagged as stable in \`appcast.xml\`

Single XML edit drops the \`<sparkle:channel>experimental</sparkle:channel>\` line from v0.2.0.12 only. Earlier items (v0.2.0.2 → v0.2.0.11) keep their tags — historical accuracy preserved; they WERE experimental at the time. Stable-channel users see v0.2.0.12 on their next Sparkle check.

### 3. \`docs/RELEASING.md\` documents the new tag convention

New "Stable vs experimental tags" section spells out the \`vX.Y.Z\` vs \`vX.Y.Z-experimental.N\` rule and the graduation procedure.

## Preserved (per intent — keep experimental capability for future risky features)

- Settings → General → "Receive experimental updates" toggle
- \`ChannelGatingDelegate\`, \`experimentalUpdates\` setting
- "You're running an experimental version" nudge alert
- All v0.2.0.2 → v0.2.0.11 appcast items keep their experimental tag (historical accuracy)

## Not changing

- No source-level code edits — extension activation, CMIO pipeline, virtual camera surfaces in Settings all unchanged
- No new release tag — the dev is currently the only user; next normal release inherits the new workflow-default-stable behavior automatically

## Files touched

- \`.github/workflows/release.yml\` — channel rule + new comment
- \`appcast.xml\` — drop one line from the v0.2.0.12 item
- \`docs/RELEASING.md\` — new "Stable vs experimental tags" section
- \`SWIFT_PORT.md\` — graduation journal entry

## Test plan

- [x] \`swift build\` — clean (no source change, just sanity check)
- [x] No source code changed → no test impact
- [ ] CI test workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)