### PR TITLE
About: drop redundant app name from version, add fortune-slip horoscope, footer

### DIFF
--- a/Sources/AVPainRelieverApp/AboutView.swift
+++ b/Sources/AVPainRelieverApp/AboutView.swift
@@ -3,20 +3,34 @@ import SwiftUI
 let aboutWindowID = "about-window"
 
 /// About scene shown via the menu item and the standard ⌘? path.
-/// Replaces `NSApp.orderFrontStandardAboutPanel`. Layout is deliberately
-/// minimal: app icon, name, version, an update button, and the existing
-/// "Show welcome again" link. The only piece of personality is a one-shot
-/// confetti burst on appear — fits the plain-native aesthetic without
-/// pulling in a particle library.
+/// Replaces `NSApp.orderFrontStandardAboutPanel`. Layout: app icon
+/// (with a slow scale-pulse), the name, the version, a small
+/// fortune-paper slip with a randomly-selected oracular pronouncement
+/// from `HoroscopeOracle`, the update button, the "Show welcome
+/// again" link, and a copyright/source footer. A one-shot confetti
+/// burst fires on appear.
+///
+/// The fortune slip is intentionally off-spec for native macOS chrome
+/// — physical-paper skeuomorphism doesn't normally appear in Apple's
+/// design language. About dialogs are the most personality-tolerant
+/// surface in any Mac app though (Apple's own About panels carry the
+/// scrolling Mac-team credits Easter egg), so a small playful element
+/// here doesn't undermine the otherwise plain-native chrome of the
+/// rest of the app.
 struct AboutView: View {
     @ObservedObject var delegate: AppDelegate
     @Environment(\.dismissWindow) private var dismissWindow
     @State private var pulse = false
     @State private var showConfetti = true
+    /// Selected once when the view's @State is initialized so the
+    /// slip stays stable while the user is reading it. Closing and
+    /// re-opening the About window mints a fresh AboutView (new
+    /// @State), which picks a new horoscope.
+    @State private var horoscope: String = HoroscopeOracle.random()
 
     var body: some View {
         ZStack {
-            VStack(spacing: 20) {
+            VStack(spacing: 18) {
                 // Generated app icon — same artwork the OS uses.
                 // SwiftUI's Image(nsImage:) downscales cleanly from the
                 // 1024-square master.
@@ -41,6 +55,8 @@ struct AboutView: View {
                         .foregroundStyle(.secondary)
                 }
 
+                fortuneSlip
+
                 Button("Check for Updates") {
                     delegate.checkForUpdates()
                 }
@@ -52,10 +68,14 @@ struct AboutView: View {
                 }
                 .buttonStyle(.link)
                 .font(.caption)
+
+                Spacer(minLength: 0)
+
+                copyrightFooter
             }
             .padding(.vertical, 28)
             .padding(.horizontal, 28)
-            .frame(width: 360, height: 340)
+            .frame(width: 360, height: 460)
 
             if showConfetti {
                 ConfettiBurst()
@@ -75,5 +95,47 @@ struct AboutView: View {
         .dialogWindowChrome()
         .centeredOnScreen()
     }
-}
 
+    /// A small "paper fortune" slip rendering today's horoscope.
+    /// Italic serif text is the visual cue that turns "rounded box
+    /// with a sentence" into "printed fortune from a cookie." Stays
+    /// light-cream in both light and dark mode — real paper doesn't
+    /// invert when you turn off the lights, and the slip is small
+    /// enough that it doesn't visually overwhelm a dark dialog.
+    private var fortuneSlip: some View {
+        Text(horoscope)
+            .font(.system(.body, design: .serif).italic())
+            // Hardcoded dark "ink" color (not `.primary`) so the
+            // text on the cream slip stays readable in dark mode
+            // — `.primary` would flip to white and disappear.
+            .foregroundStyle(Color(red: 30 / 255, green: 25 / 255, blue: 20 / 255))
+            .multilineTextAlignment(.center)
+            .lineLimit(3)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(width: 280)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    // Warm off-white ≈ #FDFCF5 — barely-cream, reads
+                    // as "real paper" without being aggressive.
+                    .fill(Color(red: 253 / 255, green: 252 / 255, blue: 245 / 255))
+                    .shadow(color: .black.opacity(0.15), radius: 2, y: 1)
+            )
+            // Subtle tilt — casually-placed, not deliberately-displayed.
+            // Bigger angles read as cartoonish.
+            .rotationEffect(.degrees(-1.5))
+    }
+
+    /// Copyright + source link at the very bottom. Smallest text in
+    /// the dialog so it lives quietly without competing with the
+    /// horoscope or the update button.
+    private var copyrightFooter: some View {
+        HStack(spacing: 4) {
+            Text("© 2026 Eric Willis ·")
+            Link("Source on GitHub", destination: URL(string: "https://github.com/superic/av-pain-reliever")!)
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/AVPainRelieverApp/HoroscopeOracle.swift
+++ b/Sources/AVPainRelieverApp/HoroscopeOracle.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// A curated catalog of brief oracular pronouncements rendered on
+/// the small fortune-paper slip in the About window. Voice: mystical,
+/// declarative, mostly universal — never about audio, cameras,
+/// devices, docks, or anything in the app itself. The app reading
+/// the user's mind about their hardware would feel surveillance-y;
+/// the oracle should be as universal as a paper fortune from a
+/// restaurant.
+///
+/// Selected once per About-window appearance via `random()`; held in
+/// `@State` for the lifetime of that window so the slip doesn't
+/// change while the user is reading it.
+///
+/// Adding entries: keep them short (1-2 lines at the slip's ~280pt
+/// width with italic body-serif), declarative (not advice-giving),
+/// and mostly universal. Avoid: politics, fortune-cookie clichés
+/// you've seen on a billion paper slips, anything that names a
+/// piece of hardware or software, anything that could read as
+/// telling the user what they're feeling right now.
+enum HoroscopeOracle {
+    static let catalog: [String] = [
+        "The longest journey begins with a step you didn't notice.",
+        "Three small choices today will look like one large one in retrospect.",
+        "What you have configured will configure you back.",
+        "A path that fits perfectly is itself a kind of warning.",
+        "The door you avoided yesterday is the one that opens easily tomorrow.",
+        "A small kindness compounds at a rate the calendar cannot show.",
+        "The conversation you did not have today will find another shape tomorrow.",
+        "What you carry travels with you. What you put down travels too.",
+        "The quiet between two thoughts is older than either of them.",
+        "You will be patient about the wrong thing. Begin anyway.",
+        "Three things will happen this week. You will mistake the second for the first.",
+        "Forgiveness is a door that swings both ways.",
+        "Some questions ripen. Some questions rot. Tell the difference by the smell.",
+        "The next room is closer than you think and farther than you fear.",
+        "A truth said quickly is rarely the whole truth.",
+        "What looks like luck has been practicing for years.",
+        "The hand that holds the pen does not write the letter.",
+        "The future is not a place. It is a habit.",
+        "Today, an old idea will return wearing new clothes.",
+        "Rest is not the opposite of work. It is the secret part of it.",
+        "The map cannot tell you which way to lean.",
+        "You will surprise yourself by Tuesday. The good kind.",
+        "A small lie kept warm becomes a large one.",
+        "The thing you keep meaning to do will mean to do you back.",
+        "Listen for the silence that follows the question.",
+        "The bridge you are building is also building you.",
+        "Some endings arrive as a whisper. Honor the whisper.",
+        "The friend you have not called is calling you in a way you cannot hear.",
+        "Light bends around what you refuse to look at.",
+        "A simple meal eaten slowly is a kind of prayer.",
+        "The river does not negotiate with the rock. It outlasts it.",
+        "What you praise grows. What you ignore quietly grows too.",
+        "The story you keep telling about yourself is the one you keep becoming.",
+        "Curiosity is older than fear and tends to win on the long count.",
+        "Today, choose the harder kindness over the easier comfort.",
+        "What you can name, you can carry. What you cannot name, carries you.",
+        "The wind has no opinion about which way you wanted to sail.",
+        "Trust the second answer when the first one came too fast.",
+        "You will need a new word for something old. It will arrive.",
+        "The empty cup is a question. The full cup is one too.",
+        "Some debts are paid by someone you will never meet.",
+        "A small joy noticed is a large joy made.",
+        "The thing you fear losing is teaching you what to keep.",
+        "Begin where you are. The other beginnings are imaginary.",
+        "The truth often arrives in clothing you would not have chosen for it.",
+        "Kindness is not a soft thing. It has bones.",
+        "What you measure changes. What you cannot measure changes too.",
+        "The letter you wrote in your head does not count, but it counted.",
+        "The future is asking you a question it has not yet phrased.",
+        "You will be remembered for one thing you did not plan.",
+    ]
+
+    /// Returns one horoscope at random. Falls back to a stable
+    /// string if the catalog is somehow empty so the slip never
+    /// renders blank.
+    static func random() -> String {
+        catalog.randomElement() ?? "The future is asking you a question it has not yet phrased."
+    }
+}

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -310,17 +310,21 @@ private struct GeneralSettingsTab: View {
 
 /// Small helper to render the version string consistently across
 /// About, Settings, and any future window that needs it. Falls back
-/// to "dev build" when the binary isn't bundled (the SPM build
+/// to "Dev build" when the binary isn't bundled (the SPM build
 /// path).
+///
+/// Format: matches Apple's standard About-panel phrasing
+/// ("Version X.Y.Z"). Drops the app name (the title above the
+/// version line already shows it) and drops the parenthesized
+/// build number (we set CFBundleVersion == CFBundleShortVersionString,
+/// so showing both was redundant).
 enum VersionInfo {
     static var short: String {
         let info = Bundle.main.infoDictionary
         let shortVersion = info?["CFBundleShortVersionString"] as? String
-        let build = info?["CFBundleVersion"] as? String
-        switch (shortVersion, build) {
-        case let (s?, b?): return "AV Pain Reliever \(s) (\(b))"
-        case let (s?, nil): return "AV Pain Reliever \(s)"
-        default: return "AV Pain Reliever — dev build"
+        switch shortVersion {
+        case let v?: return "Version \(v)"
+        default:     return "Dev build"
         }
     }
 }


### PR DESCRIPTION
## Summary

Three changes to the About dialog that go together as a coherent polish pass.

### Drop the app name from the version line
\`VersionInfo.short\` previously emitted *"AV Pain Reliever 0.2.0.13 (0.2.0.13)"* — the app name is already in the big bold title above, and the build number was repeated in parens because we set CFBundleVersion == CFBundleShortVersionString. Now emits *"Version 0.2.0.13"* — Apple's standard About-panel phrasing exactly. Falls back to *"Dev build"* when running unbundled.

### New horoscope fortune slip
A small cream-colored "fortune cookie paper" rendering one of 50 oracular pronouncements from a new \`HoroscopeOracle\` catalog. Picked once per About-window appearance and held in \`@State\` so the slip doesn't change while being read. Italic serif text on warm off-white (\`#FDFCF5\`), subtle drop shadow, -1.5° tilt.

Intentionally off-spec for the otherwise plain-native chrome. About dialogs are the most personality-tolerant surface in any Mac app (Apple's own About panel hides the scrolling Mac-team credits Easter egg); the slip continues the personality thread the dialog already started with the scale-pulse icon and the on-appear confetti burst.

Voice rules for the catalog (documented in \`HoroscopeOracle.swift\`): universal mystical wisdom only, never about audio / cameras / devices / docks / anything in the app — the app reading the user's mind about their hardware would feel surveillance-y. The oracle should be as universal as a paper fortune from a restaurant.

The slip stays light-cream in both light and dark mode (real paper doesn't invert when you turn off the lights). Text color is hardcoded dark-warm-gray so it stays readable in dark mode.

### New copyright + source footer
*"© 2026 Eric Willis · Source on GitHub"* at the very bottom in caption2-secondary. The "Source on GitHub" portion is a clickable \`Link\` that opens the repo in the browser.

### Other
Window height bumped from 340pt → 460pt to accommodate without crowding.

## Files

- \`Sources/AVPainRelieverApp/HoroscopeOracle.swift\` — new
- \`Sources/AVPainRelieverApp/AboutView.swift\` — fortune slip + footer + restructured layout
- \`Sources/AVPainRelieverApp/SettingsView.swift\` — \`VersionInfo.short\` simplified

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` 203/203 passing
- [x] Manual UI verification: opens with random horoscope, fresh window mints fresh horoscope, slip stays cream in both light and dark mode, GitHub link opens in browser, version line reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)