### PR TITLE
ci: skip actions/cache on self-hosted runner (fix XCFramework path mismatch)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,19 @@ jobs:
       # Mac (currently 26.4.1). When local Xcode bumps, CI follows.
 
       - name: Cache SPM artifacts
+        # Skipped on self-hosted because (a) the runner has natural
+        # disk persistence — `.build` and `~/Library/Caches/org.swift.swiftpm`
+        # survive between jobs without remote-cache help, and (b) the
+        # cache key only includes `runner.os`, which is "macOS" for
+        # both github-hosted and self-hosted macOS runners. Restoring
+        # a cache built by an earlier github-hosted run onto the
+        # self-hosted Mac poisons `.build` with paths embedded under
+        # `/Users/runner/work/...` (the github-hosted workspace),
+        # causing SPM's binary-target downloader to fail looking for
+        # Sparkle's XCFramework Info.plist at a path that doesn't
+        # exist on the self-hosted Mac. Burned us once on 2026-05-06;
+        # the conditional gate prevents a second incident.
+        if: runner.environment == 'github-hosted'
         uses: actions/cache@v5
         with:
           path: |


### PR DESCRIPTION
## Summary

Fixes the Test workflow failure on main right after [PR #36](https://github.com/superic/av-pain-reliever/pull/36) merged:

\`\`\`
error: XCFramework Info.plist not found at
'/Users/runner/work/av-pain-reliever/av-pain-reliever/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework'
\`\`\`

## Root cause

The path \`/Users/runner/work/...\` is a github-hosted runner workspace location, but the failing run executed on the self-hosted runner (\`avpain-mac\`, confirmed via job metadata). The mismatch is the smoking gun for **cross-environment cache poisoning**.

\`actions/cache@v5\`'s key only includes \`runner.os\` (== \`"macOS"\` for both github-hosted and self-hosted macOS runners), so a cache built by an earlier github-hosted run got restored onto the self-hosted Mac. The cached \`.build\` contained paths embedded under \`/Users/runner/work/...\` (the github-hosted workspace that doesn't exist on the self-hosted Mac), breaking SPM's binary-target lookup for Sparkle's XCFramework.

Confirmed on disk: the \`~/actions-runner/_work/av-pain-reliever/av-pain-reliever/.build/\` directory had files dated **May 3** (when we were on github-hosted runners), even though the self-hosted runner was set up May 5.

## Fix

Gate the Cache SPM artifacts step on \`runner.environment == 'github-hosted'\`. Self-hosted runners get natural disk persistence — \`.build\` and \`~/Library/Caches/org.swift.swiftpm\` survive between jobs without remote-cache help — so the step provides no value there and only opens the door to this kind of contamination.

Mirrors the same gating we already apply to \`release.yml\`'s Reset SPM artifact cache step ([PR #31](https://github.com/superic/av-pain-reliever/pull/31), same theory: skip cache gymnastics on self-hosted; trust the local disk).

## Cleanup that already happened (manual, not in this commit)

Wiped the poisoned \`~/actions-runner/_work/av-pain-reliever/av-pain-reliever/.build\` directory on the self-hosted Mac so the next workflow run starts from a clean slate.

## Test plan

- This PR's own Test workflow run will validate the fix end-to-end on the cleaned self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)