### PR TITLE
.gitignore: exclude dev/ for local-only tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ prototypes/hammerspoon/logs/
 # Distribution output — produced by scripts/make-app.sh; never commit.
 dist/
 
+# Local-only dev tooling (private build helpers, cert config, etc).
+# Each developer maintains their own dev/ as the working tree of a
+# separate private repo. See dev/README.md for setup.
+dev/
+
 # Provisioning profiles. Team-specific, regenerable from
 # developer.apple.com, and contain the team ID + cert hashes —
 # never commit. Each developer drops their own at this path.


### PR DESCRIPTION
## Summary

One-line addition to `.gitignore`: excludes `dev/` from version control. Each developer maintains their own `dev/` as the working tree of a separate private repo (build helpers, cert config, etc.).

## Why

Without this entry, an accidental `git add .` from the project root would track `dev/` as a gitlink and leak private-repo SHAs into public history. The entry is also a soft signal that a per-developer local folder is expected there.

Pattern matches the existing per-developer ignores in `.gitignore` — `.claude/settings.local.json`, `Resources/*.provisionprofile`, signing certs.

## Test plan

- [ ] CI passes
- [ ] `git status` no longer shows `dev/` as untracked when the folder exists locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)