### PR TITLE
docs: lowercase-hyphenated naming under docs/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@
 #   5. Append a new <item> to appcast.xml on main and push, so existing
 #      installs see the update.
 #
-# Required GitHub Secrets — see docs/RELEASING.md for setup instructions:
+# Required GitHub Secrets — see docs/releasing.md for setup instructions:
 #   MACOS_CERTIFICATE             base64 of the Developer ID Application .p12
 #   MACOS_CERTIFICATE_PASSWORD    .p12 password
 #   MACOS_KEYCHAIN_PASSWORD       random — for the temp keychain Actions creates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -640,7 +640,7 @@ is at `/Applications/Xcode.app` (currently 26.4.1), so toolchain
 parity is automatic — when local Xcode bumps, CI follows. Queue
 time drops from "30+ minute spike risk" to "starts in seconds."
 Setup details + security model in
-[docs/SELF_HOSTED_RUNNER.md](docs/SELF_HOSTED_RUNNER.md).
+[docs/self-hosted-runner.md](docs/self-hosted-runner.md).
 
 Security mitigation for self-hosted on a public repo: configured
 the Actions setting `fork-pr-contributor-approval =
@@ -658,7 +658,7 @@ and `cmp`'d the two Mach-Os. Result: 3,520 byte delta (down from
 ~209 KB on v0.2.0.11), all attributable to notarization-ticket
 embedding. Same SDK, same renderings paths, byte-equivalent code.
 Only then published. This step is now standard for every release —
-see [docs/RELEASING.md](docs/RELEASING.md) "Pre-publish binary
+see [docs/releasing.md](docs/releasing.md) "Pre-publish binary
 verification."
 
 Lessons:
@@ -691,8 +691,8 @@ Files touched:
 - `.github/workflows/release.yml` — runs-on swap, removed Select
   Xcode step, made SPM cache reset GitHub-hosted-only
 - `.github/workflows/test.yml` — same
-- `docs/SELF_HOSTED_RUNNER.md` — new setup + security guide
-- `docs/RELEASING.md` — added pre-publish verification convention,
+- `docs/self-hosted-runner.md` — new setup + security guide
+- `docs/releasing.md` — added pre-publish verification convention,
   post-mortem entry for v0.2.0.12
 
 PR: [#31](https://github.com/superic/av-pain-reliever/pull/31)
@@ -751,7 +751,7 @@ What the graduation actually changes:
   remain in place. Help text under the toggle was genericized
   ahead of this PR (PR #34) so it doesn't name v0.2.x specifically
   and stays accurate as the experimental queue empties / refills.
-- **`docs/RELEASING.md` documents the new tag convention** in a
+- **`docs/releasing.md` documents the new tag convention** in a
   new "Stable vs experimental tags" section, including the
   `vX.Y.Z` vs `vX.Y.Z-experimental.N` rule and graduation
   procedure ("ship next release without the suffix; optionally
@@ -1315,7 +1315,7 @@ generation) gating the first real release.
   ready-to-paste `<item>` block. Reads the private key from
   `$SPARKLE_PRIVATE_KEY` (CI) or the `avpainreliever` keychain
   account (local).
-- `docs/RELEASING.md` — runbook for Apple Developer Program
+- `docs/releasing.md` — runbook for Apple Developer Program
   enrollment, Sparkle key generation, the seven `gh secret set`
   commands, the first-tag checklist, and a troubleshooting section.
 
@@ -1368,12 +1368,12 @@ generation) gating the first real release.
 
 - Apple Developer Program enrollment ($99/yr, 24–48h approval).
 - Sparkle EdDSA keypair generation + Info.plist substitution.
-- Setting the seven GitHub Secrets per `docs/RELEASING.md`.
+- Setting the seven GitHub Secrets per `docs/releasing.md`.
 - First `git tag v0.1.0` push to exercise the workflow end-to-end.
 - Smoke-test auto-update by tagging `v0.1.1` immediately after
   with a one-line README change.
 
-`docs/RELEASING.md` is the canonical handoff for these.
+`docs/releasing.md` is the canonical handoff for these.
 
 ### Verification done in this session
 
@@ -1433,7 +1433,7 @@ auto-update exercise immediately after.
   out cleanly: "The binary is not signed with a valid Developer ID
   certificate" + "The signature does not include a secure
   timestamp" for both arm64 and x86_64 slices. Fix: add the path
-  to the array. Documented in `docs/RELEASING.md` post-mortem
+  to the array. Documented in `docs/releasing.md` post-mortem
   section so a future Sparkle version bump prompts a re-walk of
   `Versions/B/`.
 - **`xcrun notarytool log <id>` is the must-have diagnostic.** A
@@ -1477,7 +1477,7 @@ To make a recurrence less likely:
   (allows up to <3.0) to `.upToNextMinor(from: "2.9.0")` (allows
   2.9.x patches only). New minor needs a deliberate bump and a
   fresh walk of `Versions/B/` to confirm no new nested helpers.
-- `docs/RELEASING.md` post-mortem section captures the four
+- `docs/releasing.md` post-mortem section captures the four
   lessons above + the diagnostic incantations.
 
 ### Pending after v0.1.0 (small)
@@ -1498,7 +1498,7 @@ To make a recurrence less likely:
   AppDelegate as the SwiftUI scene wiring + lifecycle. Not
   blocking anything; the file is dense but understandable.
 - Homebrew-cask distribution path (still on the v2 list per
-  `docs/RELEASING.md`).
+  `docs/releasing.md`).
 
 ---
 
@@ -1596,7 +1596,7 @@ from the same drawing via a new `scripts/regen-icon.sh` pipeline:
 2. `sips` downscales to every size `iconutil` expects.
 3. `iconutil -c icns` packs the iconset.
 
-`docs/RELEASING.md` documents the regen step.
+`docs/releasing.md` documents the regen step.
 
 **Menu bar symbol picker.** New Settings → General → Behavior row
 "Menu bar icon" with a popover-bound 6-column grid of ~12 curated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,19 @@ Never put the cert name, team ID, or anything personal-credential-shaped into pu
 | Virtual camera (V2 CMIO extension) — design + impl journal | `docs/virtual-camera.md` |
 | Phase-1 Hammerspoon→Swift port history | `docs/port-history.md` |
 | Project journal (newest-first) | `CHANGELOG.md` |
-| Release process (cutting a release, secrets setup) | `docs/RELEASING.md` |
-| Self-hosted CI runner setup + lockstep rule | `docs/SELF_HOSTED_RUNNER.md` |
-| Virtual camera developer setup (build/install loop) | `docs/VIRTUAL_CAMERA_DEV.md` |
+| Release process (cutting a release, secrets setup) | `docs/releasing.md` |
+| Self-hosted CI runner setup + lockstep rule | `docs/self-hosted-runner.md` |
+| Virtual camera developer setup (build/install loop) | `docs/virtual-camera-dev.md` |
 | User-facing intro | `README.md` |
 
 If a fact you need isn't in any of these, it likely belongs in code comments or memory, not new prose.
+
+### Markdown filename convention
+
+- **Repo-root meta files** (`README.md`, `LICENSE`, `CHANGELOG.md`, `CLAUDE.md`) → UPPERCASE. These speak *about* the project; GitHub renders them prominently.
+- **Content under `docs/`** → lowercase-hyphenated. Modern docs convention; URL-friendly. Example: `docs/architecture.md`, `docs/self-hosted-runner.md`.
+
+Don't mix the two conventions inside `docs/`. If a new doc belongs there, it's lowercase-hyphenated.
 
 ## Project-wide conventions
 

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -15,7 +15,7 @@ import OSLog
 ///     raw.githubusercontent.com.
 ///   - `SUPublicEDKey` is the EdDSA public key Sparkle uses to verify
 ///     downloaded zips. Filled in once by the maintainer running
-///     Sparkle's `generate_keys` (see docs/RELEASING.md).
+///     Sparkle's `generate_keys` (see docs/releasing.md).
 ///
 /// We don't override automatic-check defaults — Sparkle's standard
 /// behaviour (prompt the user on first launch, then check daily once
@@ -37,7 +37,7 @@ final class Updater {
     /// Build-time placeholder string in `Resources/Info.plist`. The
     /// release pipeline expects the maintainer to swap this for the
     /// real `SUPublicEDKey` printed by Sparkle's `generate_keys`
-    /// before tagging a signed release — see docs/RELEASING.md §2.
+    /// before tagging a signed release — see docs/releasing.md §2.
     static let publicKeyPlaceholder = "__SPARKLE_PUBLIC_KEY__"
 
     /// True iff Sparkle should be wired up for the running binary.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,7 +14,7 @@ Builds run on a **self-hosted runner** installed on the maintainer's
 Mac, not on a GitHub-hosted VM. This is what guarantees toolchain
 parity between the bytes shipped to users and the bytes the maintainer
 sees in dev builds. Setup, security model, and recovery procedure are
-in [SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md).
+in [self-hosted-runner.md](self-hosted-runner.md).
 
 Until the GitHub Secrets listed below are populated, every step that
 depends on Apple credentials or the Sparkle private key skips with a
@@ -133,7 +133,7 @@ post-mortem below for the failure mode this prevents.
 Setup, security configuration (fork-PR approval policy), status
 checks, lockstep rule for Xcode upgrades, uninstall, and recovery
 on a fresh Mac are all in
-[SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md). Do that one-time
+[self-hosted-runner.md](self-hosted-runner.md). Do that one-time
 install before tagging your first release; subsequent releases
 just need the runner to be online.
 
@@ -460,7 +460,7 @@ the CI version.
 
 Fix: switched CI to a self-hosted runner on the maintainer's Mac
 that uses the maintainer's own Xcode (see
-[SELF_HOSTED_RUNNER.md](SELF_HOSTED_RUNNER.md)). Toolchain parity
+[self-hosted-runner.md](self-hosted-runner.md)). Toolchain parity
 guaranteed. Bonus: queue time dropped from "30+ min spike risk on
 Apple Silicon free pool" to "starts in seconds."
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -5,8 +5,8 @@ maintainer's Mac. This document covers why, the security model, the
 install procedure, and how to recover the setup on a fresh machine.
 
 For the release pipeline that uses this runner, see
-[RELEASING.md](RELEASING.md). The v0.2.0.12 post-mortem that
-motivated this setup is captured in RELEASING.md's "Post-mortem:
+[releasing.md](releasing.md). The v0.2.0.12 post-mortem that
+motivated this setup is captured in releasing.md's "Post-mortem:
 lessons from v0.2.0.12" section.
 
 ## Why self-hosted
@@ -185,7 +185,7 @@ the maintainer's Mac (no `Select Xcode` step in the workflows). So:
   point.** Treat it like a toolchain-only release: tag a no-source-
   change version, ship it, byte-compare CI vs dev locally, confirm
   rendering parity. See the
-  [RELEASING.md](RELEASING.md) "Pre-publish binary verification"
+  [releasing.md](releasing.md) "Pre-publish binary verification"
   section.
 
 ## Status checks

--- a/docs/virtual-camera-dev.md
+++ b/docs/virtual-camera-dev.md
@@ -2,7 +2,7 @@
 
 Recipe for building, activating, and testing the v0.2.0 Camera
 Extension on a development Mac. Distribution flow lives in
-`docs/RELEASING.md` once we get there; for now this is the loop
+`docs/releasing.md` once we get there; for now this is the loop
 used while the feature is on `feature/virtual-camera`.
 
 The recommended path uses your normal Developer ID Application
@@ -89,7 +89,7 @@ System extensions can't be activated by macOS without a notarized
 bundle, even with valid Developer ID signing. The build script
 runs notarization via `xcrun notarytool` against a keychain
 profile you've already set up for v0.1.x — see
-`docs/RELEASING.md` for the one-time
+`docs/releasing.md` for the one-time
 `xcrun notarytool store-credentials avpain-notary` step.
 
 If you've ever notarized a v0.1.x release locally, you have it.

--- a/docs/virtual-camera.md
+++ b/docs/virtual-camera.md
@@ -2,7 +2,7 @@
 
 The native CMIO Camera Extension that lets Zoom / Slack / Teams pick up "AV Pain Reliever" as a camera and follow the active profile's source. This is the canonical V2 record — design decisions, system-extension lifecycle, lock-step rule with the host app, codesign quirks, and the implementation milestones (M1–M7) as they landed.
 
-For developer setup of this feature see [docs/VIRTUAL_CAMERA_DEV.md](VIRTUAL_CAMERA_DEV.md) (build/install loop, common failures, fallback paths).
+For developer setup of this feature see [docs/virtual-camera-dev.md](virtual-camera-dev.md) (build/install loop, common failures, fallback paths).
 
 ## V2 plan: native virtual camera (CMIO Camera Extension)
 
@@ -311,7 +311,7 @@ What landed:
   activation. No-op on v0.1.x builds (entitlement absent → request
   fails harmlessly). M4 will replace this with a real Settings
   toggle.
-- `docs/VIRTUAL_CAMERA_DEV.md` — local-test recipe:
+- `docs/virtual-camera-dev.md` — local-test recipe:
   `systemextensionsctl developer on`, build, ditto into
   `/Applications`, env-var-launch, verify in Zoom, iteration loop,
   uninstall, common failure modes.
@@ -384,7 +384,7 @@ milestones don't relearn the same things:
    the extension on. State then transitions to
    `[activated enabled]`.
 
-The dev workflow (`docs/VIRTUAL_CAMERA_DEV.md`) was rewritten in a
+The dev workflow (`docs/virtual-camera-dev.md`) was rewritten in a
 follow-up commit to reflect the actual recipe instead of the
 ad-hoc + developer-mode + SIP-off path I originally documented.
 
@@ -676,7 +676,7 @@ Three sub-tasks, all landed:
    base64-encoded provisioning profile; decoded into
    `Resources/AVPainReliever.provisionprofile` only for v0.2.x+
    runs (skipped silently on v0.1.x to keep that pipeline a
-   no-op). `docs/RELEASING.md` updated to reflect the new
+   no-op). `docs/releasing.md` updated to reflect the new
    secret + the script-selection logic.
 
 3. **Sparkle / extension upgrade-replace verification —
@@ -747,7 +747,7 @@ Failure modes worth watching for:
 ### v0.2.0 release notes (draft, ready to copy)
 
 Paste this into the GitHub Release body when pre-creating the v0.2.0
-draft release (per `docs/RELEASING.md`'s curated-notes flow). The CI
+draft release (per `docs/releasing.md`'s curated-notes flow). The CI
 workflow renders it through GitHub's `/markdown` API and pipes the
 HTML into the appcast `<description>`, so what you write here is
 exactly what shows up in Sparkle's "What's New" panel for upgrading

--- a/scripts/make-app-with-virtual-camera.sh
+++ b/scripts/make-app-with-virtual-camera.sh
@@ -21,7 +21,7 @@
 #
 # Dev workflow note: ad-hoc-signed builds will only activate on a
 # machine with `systemextensionsctl developer on`. See
-# docs/VIRTUAL_CAMERA_DEV.md for the full local-test recipe.
+# docs/virtual-camera-dev.md for the full local-test recipe.
 
 set -euo pipefail
 
@@ -154,7 +154,7 @@ cp -R "$SPARKLE_FRAMEWORK_SRC" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framewor
 # We require it for Developer-ID-signed builds and warn (but allow)
 # ad-hoc builds without it, since the ad-hoc path is for the
 # fallback developer-mode workflow that doesn't honour profiles
-# anyway. See docs/VIRTUAL_CAMERA_DEV.md.
+# anyway. See docs/virtual-camera-dev.md.
 if [[ -n "${MAC_CERT_NAME:-}" ]]; then
     if [[ ! -f "$APP_PROVISIONING_PROFILE" ]]; then
         cat <<EOF >&2
@@ -172,7 +172,7 @@ Generate one at developer.apple.com:
   - Profiles: New → Developer ID → select the App ID → download.
 
 Save the .provisionprofile at the path above (it's gitignored).
-See docs/VIRTUAL_CAMERA_DEV.md for the full walkthrough.
+See docs/virtual-camera-dev.md for the full walkthrough.
 EOF
         exit 1
     fi
@@ -192,7 +192,7 @@ if [[ -n "${MAC_CERT_NAME:-}" ]]; then
 else
     SIGN_IDENTITY="-"
     SIGN_OPTS=()
-    echo "==> ad-hoc sign (MAC_CERT_NAME unset; needs systemextensionsctl developer on + SIP off — see docs/VIRTUAL_CAMERA_DEV.md fallback)"
+    echo "==> ad-hoc sign (MAC_CERT_NAME unset; needs systemextensionsctl developer on + SIP off — see docs/virtual-camera-dev.md fallback)"
 fi
 
 sign_path() {
@@ -269,4 +269,4 @@ echo "  version:   $VERSION  (build $BUILD_VERSION)"
 echo "  extension: $EXT_DIR_NAME"
 echo "  zip:       $FINAL_ZIP ($(stat -f%z "$FINAL_ZIP") bytes)"
 echo
-echo "next: see docs/VIRTUAL_CAMERA_DEV.md for activation + Zoom test"
+echo "next: see docs/virtual-camera-dev.md for activation + Zoom test"

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -57,7 +57,7 @@ mkdir -p "$DIST_DIR"
 # ---------- 2. build universal binary ----------
 # `swift build` accepts repeated --arch flags to produce a universal
 # binary in one shot. Fallback (lipo two single-arch builds) is documented
-# in docs/RELEASING.md if Apple ever regresses this.
+# in docs/releasing.md if Apple ever regresses this.
 echo "==> swift build (release, universal arm64+x86_64)"
 swift build -c release \
     --arch arm64 --arch x86_64 \


### PR DESCRIPTION
## Summary

Renames the three legacy UPPERCASE files in `docs/` to match the lowercase-hyphenated convention used by the new docs added in the recent reorg:

- `docs/RELEASING.md` → `docs/releasing.md`
- `docs/SELF_HOSTED_RUNNER.md` → `docs/self-hosted-runner.md`
- `docs/VIRTUAL_CAMERA_DEV.md` → `docs/virtual-camera-dev.md`

## Why

The mixed casing was an accident of timing — those three files predated the docs/ split, so they got the "loud" repo-root treatment by default. Now that `docs/` is content territory with multiple files, two coexisting conventions look messy.

The rule going forward (codified in CLAUDE.md):

- **Repo-root meta files** (`README.md`, `LICENSE`, `CHANGELOG.md`, `CLAUDE.md`) → UPPERCASE. These speak *about* the project; GitHub renders them prominently.
- **Content under `docs/`** → lowercase-hyphenated. Modern docs convention, URL-friendly.

## Reference updates

Patched 10 files' references in the same commit so nothing dangles:

- `CLAUDE.md` (where-to-look table + new naming-convention subsection)
- `CHANGELOG.md` (history entries)
- The three docs/ files cross-referencing each other
- `scripts/make-app.sh`, `scripts/make-app-with-virtual-camera.sh`
- `.github/workflows/release.yml`
- `Sources/AVPainRelieverApp/Updater.swift`

`grep -rn` for the old names now returns zero hits.

## Test plan

- [x] `swift build` clean (verified locally)
- [x] `swift test` — 203/203 pass (verified locally)
- [ ] CI passes
- [ ] Spot-check that links in CLAUDE.md and docs/* still resolve on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)