### PR TITLE
cleanup: drop dead code and stale comments flagged by slop review

### DIFF
--- a/Sources/AVPainRelieverApp/AboutView.swift
+++ b/Sources/AVPainRelieverApp/AboutView.swift
@@ -29,84 +29,69 @@ struct AboutView: View {
     @State private var horoscope: String = HoroscopeOracle.random()
 
     var body: some View {
-        ZStack {
-            // Three vertical zones with flexible space between them:
-            // top group (icon + name + version) anchored at the top,
-            // fortune slip floating in the middle, action group +
-            // footer anchored at the bottom. The two flexible Spacers
-            // around the fortune keep it visually centered between
-            // the top and bottom groups regardless of frame height.
-            VStack(spacing: 0) {
-                VStack(spacing: 18) {
-                    // Generated app icon — same artwork the OS uses.
-                    // SwiftUI's Image(nsImage:) downscales cleanly
-                    // from the 1024-square master.
-                    Image(nsImage: AppIcon.image)
-                        .resizable()
-                        .interpolation(.high)
-                        .frame(width: 96, height: 96)
-                        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
-                        .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
-                        .scaleEffect(pulse ? 1.03 : 1.0)
-                        .animation(
-                            .easeInOut(duration: 1.8).repeatForever(autoreverses: true),
-                            value: pulse
-                        )
-                        .onAppear { pulse = true }
+        // Three vertical zones with flexible space between them:
+        // top group (icon + name + version) anchored at the top,
+        // fortune slip floating in the middle, action group +
+        // footer anchored at the bottom. The two flexible Spacers
+        // around the fortune keep it visually centered between
+        // the top and bottom groups regardless of frame height.
+        VStack(spacing: 0) {
+            VStack(spacing: 18) {
+                // Generated app icon — same artwork the OS uses.
+                // SwiftUI's Image(nsImage:) downscales cleanly
+                // from the 1024-square master.
+                Image(nsImage: AppIcon.image)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: 96, height: 96)
+                    .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                    .shadow(color: .black.opacity(0.18), radius: 12, y: 6)
+                    .scaleEffect(pulse ? 1.03 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 1.8).repeatForever(autoreverses: true),
+                        value: pulse
+                    )
+                    .onAppear { pulse = true }
 
-                    VStack(spacing: 4) {
-                        Text(Theme.Copy.appName)
-                            .font(.system(size: 26, weight: .bold, design: .rounded))
-                        Text(VersionInfo.short)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                VStack(spacing: 4) {
+                    Text(Theme.Copy.appName)
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                    Text(VersionInfo.short)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
+            }
 
-                Spacer(minLength: 0)
-                fortuneSlip
-                Spacer(minLength: 0)
+            Spacer(minLength: 0)
+            fortuneSlip
+            Spacer(minLength: 0)
 
-                // Action group anchors 14pt above the footer — the
-                // earlier draft pushed the buttons down from the
-                // fortune, but the user prefers them anchored to
-                // the bottom of the dialog with the fortune drifting
-                // toward the middle.
-                VStack(spacing: 18) {
-                    Button("Check for Updates") {
-                        delegate.checkForUpdates()
-                    }
-                    .controlSize(.large)
-
-                    Button("Show welcome again") {
-                        delegate.showWelcomeAgain()
-                        dismissWindow(id: aboutWindowID)
-                    }
-                    .buttonStyle(.link)
-                    .font(.caption)
+            // Action group anchors 14pt above the footer — the
+            // earlier draft pushed the buttons down from the
+            // fortune, but the user prefers them anchored to
+            // the bottom of the dialog with the fortune drifting
+            // toward the middle.
+            VStack(spacing: 18) {
+                Button("Check for Updates") {
+                    delegate.checkForUpdates()
                 }
-                .padding(.bottom, 14)
+                .controlSize(.large)
 
-                copyrightFooter
+                Button("Show welcome again") {
+                    delegate.showWelcomeAgain()
+                    dismissWindow(id: aboutWindowID)
+                }
+                .buttonStyle(.link)
+                .font(.caption)
             }
-            .padding(.vertical, 28)
-            .padding(.horizontal, 28)
-            .frame(width: 360, height: 460)
+            .padding(.bottom, 14)
 
-            if showConfetti {
-                ConfettiBurst()
-                    .allowsHitTesting(false)
-                    .task {
-                        // Outlast the longest particle trajectory
-                        // (max riseDuration + fallDuration ≈ 2.4s)
-                        // so every piece arcs back down before the
-                        // layer unmounts. After this, the ZStack
-                        // collapses and no animations keep ticking.
-                        try? await Task.sleep(for: .seconds(3.2))
-                        showConfetti = false
-                    }
-            }
+            copyrightFooter
         }
+        .padding(.vertical, 28)
+        .padding(.horizontal, 28)
+        .frame(width: 360, height: 460)
+        .oneShotConfetti(isPresented: $showConfetti)
         .background(.background)
         .dialogWindowChrome()
         .centeredOnScreen()

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -140,13 +140,6 @@ final class AddProfileViewModel: ObservableObject {
     /// has actually opted into.
     let virtualCameraEnabled: Bool
 
-    /// Localized name AVFoundation reports for the embedded virtual
-    /// camera. Mirrors `VirtualCameraActivator.virtualCameraDisplayName`.
-    /// Hardcoded here rather than imported because the engine
-    /// module (which owns this view model's `CameraSummary` type)
-    /// has no view of the host activator's constants.
-    private static let virtualCameraDisplayName = "AV Pain Reliever"
-
     /// Saved fingerprint from the profile being edited — preserved
     /// verbatim across `refresh()` so saved-but-disconnected devices
     /// keep showing up even after the live watcher snapshot updates.
@@ -228,13 +221,10 @@ final class AddProfileViewModel: ObservableObject {
             }
         let disconnectedIDs = Set(disconnected.map(\.device))
 
-        // Two-tier sort for live devices: location-defining hardware
-        // (mics, speakers, cameras, capture cards, displays, docks,
-        // hubs — anything not flagged by `DevicePortability`) at the
-        // top, portable peripherals (keyboards, mice, phones,
-        // headphones, watches) at the bottom. Disconnected entries
-        // pushed to the very bottom by name so the active hardware
-        // stays grouped at the top.
+        // Sort live devices by tier (Important → other named →
+        // portable named → unnamed) per `sortedByTier` below, then
+        // append disconnected entries at the very bottom so active
+        // hardware stays grouped at the top.
         attachedDevices = Self.sortedByTier(liveSnapshot)
             + Self.sortedByTier(disconnected)
         disconnectedDeviceIDs = disconnectedIDs
@@ -274,8 +264,8 @@ final class AddProfileViewModel: ObservableObject {
         // brief window where the virtual camera was selectable: the
         // saved-but-now-invalid value is sanitized below.
         cameras = cameraController.availableCameras()
-            .filter { $0.name != Self.virtualCameraDisplayName }
-        if camera == Self.virtualCameraDisplayName {
+            .filter { $0.name != VirtualCameraActivator.virtualCameraDisplayName }
+        if camera == VirtualCameraActivator.virtualCameraDisplayName {
             camera = nil
         }
 
@@ -292,7 +282,7 @@ final class AddProfileViewModel: ObservableObject {
             // preferred — that's by design (#2). Skip it here so
             // the pre-fill always lands on a *real* camera.
             let preferred = cameraController.currentPreferredName()
-            camera = preferred == Self.virtualCameraDisplayName ? nil : preferred
+            camera = preferred == VirtualCameraActivator.virtualCameraDisplayName ? nil : preferred
         }
 
         // First-launch convenience: if the user hasn't typed a name and
@@ -328,16 +318,8 @@ final class AddProfileViewModel: ObservableObject {
         audioDevices.filter(\.supportsOutput)
     }
 
-    /// Two-tier sort for the wizard's live device list. Top tier
-    /// holds devices that aren't flagged by `DevicePortability` —
-    /// docks, hubs, mics, speakers, cameras, capture cards,
-    /// displays, etc. — i.e. the location-bound hardware. Bottom
-    /// tier holds the portable peripherals the wizard already
-    /// suggests unticking (keyboards, mice, phones, headphones,
-    /// watches). Within each tier, items sort alphabetically by
-    /// `displayName` so the order is stable across re-renders.
-    ///
-    /// Four-tier sort, alphabetical within each tier:
+    /// Four-tier sort for the wizard's device list, alphabetical
+    /// within each tier:
     /// 1. Important (mic / video / speaker / audio per
     ///    `DevicePortability.importantCategory`) — top, easiest to
     ///    scan when picking fingerprint candidates.

--- a/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
+++ b/Sources/AVPainRelieverApp/CMIOSinkWriter.swift
@@ -69,13 +69,8 @@ final class CMIOSinkWriter {
     private static let outputHeight: Int = 720
     private static let outputFormat: OSType = kCVPixelFormatType_32BGRA
 
-    init(deviceUID: String, width: Int32, height: Int32) {
+    init(deviceUID: String) {
         self.deviceUID = deviceUID
-        // width/height retained as ignored params for backward-
-        // compat with the call site; the output target is fixed
-        // at 1280×720 BGRA (matches the extension's source format).
-        _ = width
-        _ = height
     }
 
     /// Discovers the device, opens its sink stream, primes the

--- a/Sources/AVPainRelieverApp/CameraCaptureSession.swift
+++ b/Sources/AVPainRelieverApp/CameraCaptureSession.swift
@@ -267,12 +267,29 @@ final class CameraCaptureSession: NSObject {
         logger.info("switchSource: '\(self.currentDeviceUniqueID ?? "<none>", privacy: .public)' → '\(device.uniqueID, privacy: .public)' (\(name, privacy: .public))")
 
         session.beginConfiguration()
-        if let currentInput {
-            session.removeInput(currentInput)
+        // Stash the previous input so we can put it back if the new
+        // device fails to install. Without this fallback a transient
+        // failure (device unplugged between findDevice and
+        // AVCaptureDeviceInput init, format incompatibility surfacing
+        // late) leaves the session with no input and frames silently
+        // stop — the previous-input restore keeps the pipeline flowing.
+        let previousInput = currentInput
+        let previousUID = currentDeviceUniqueID
+        if let previousInput {
+            session.removeInput(previousInput)
             self.currentInput = nil
             self.currentDeviceUniqueID = nil
         }
-        _ = installInput(device: device)
+        if !installInput(device: device) {
+            if let previousInput, session.canAddInput(previousInput) {
+                session.addInput(previousInput)
+                self.currentInput = previousInput
+                self.currentDeviceUniqueID = previousUID
+                logger.warning("switchSource: install failed; restored previous source '\(previousUID ?? "<none>", privacy: .public)'")
+            } else {
+                logger.error("switchSource: install failed and no previous source could be restored — session has no input")
+            }
+        }
         session.commitConfiguration()
 
         if !session.isRunning {

--- a/Sources/AVPainRelieverApp/ConfettiBurst.swift
+++ b/Sources/AVPainRelieverApp/ConfettiBurst.swift
@@ -160,3 +160,27 @@ private struct ConfettiParticle: View {
         }
     }
 }
+
+extension View {
+    /// Overlay a one-shot `ConfettiBurst` when `isPresented` is true.
+    /// After `duration` the binding flips back to false so the overlay
+    /// unmounts and no animations keep ticking. Default duration
+    /// outlasts the longest particle trajectory (≈ 2.4s rise + fall).
+    /// Used by the About + Welcome dialogs to keep the celebratory
+    /// burst self-contained — the caller just toggles the flag.
+    func oneShotConfetti(
+        isPresented: Binding<Bool>,
+        duration: Duration = .seconds(3.2)
+    ) -> some View {
+        overlay {
+            if isPresented.wrappedValue {
+                ConfettiBurst()
+                    .allowsHitTesting(false)
+                    .task {
+                        try? await Task.sleep(for: duration)
+                        isPresented.wrappedValue = false
+                    }
+            }
+        }
+    }
+}

--- a/Sources/AVPainRelieverApp/IconPickerView.swift
+++ b/Sources/AVPainRelieverApp/IconPickerView.swift
@@ -61,36 +61,15 @@ struct IconPickerView: View {
 
             Divider()
 
-            // Curated catalog grid. Each cell is a 36×36 button; the
-            // selected one (matching `selection`) gets a tinted
-            // background so it stands out against the others.
+            // Curated catalog grid. Each cell is an `IconTile`; the
+            // selected one (matching `selection`) renders with a
+            // tinted background so it stands out against the others.
             LazyVGrid(columns: columns, spacing: 6) {
                 ForEach(ProfileIcon.catalog, id: \.self) { symbol in
-                    Button {
+                    IconTile(symbol: symbol, isSelected: selection == symbol) {
                         selection = symbol
                         onPick()
-                    } label: {
-                        Image(systemName: symbol)
-                            .font(.body)
-                            .frame(width: 36, height: 36)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .fill(selection == symbol
-                                          ? Color.accentColor.opacity(0.18)
-                                          : Color.clear)
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .strokeBorder(
-                                        selection == symbol
-                                            ? Color.accentColor
-                                            : Color.clear,
-                                        lineWidth: 1
-                                    )
-                            )
                     }
-                    .buttonStyle(.plain)
-                    .help(symbol)
                 }
             }
         }

--- a/Sources/AVPainRelieverApp/IconTile.swift
+++ b/Sources/AVPainRelieverApp/IconTile.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// 36×36 tappable SF Symbol tile used by both `IconPickerView` (the
+/// wizard's per-profile icon picker) and `MenuBarSymbolPicker` (the
+/// global menu-bar icon picker). Selection treatment: tinted accent
+/// fill plus a 1-point accent stroke so the chosen tile stands out
+/// against the unselected ones. Caller owns the symbol catalog and
+/// the selection state — this view only renders one cell.
+struct IconTile: View {
+    let symbol: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button {
+            onTap()
+        } label: {
+            Image(systemName: symbol)
+                .font(.body)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(isSelected
+                              ? Color.accentColor.opacity(0.18)
+                              : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(
+                            isSelected
+                                ? Color.accentColor
+                                : Color.clear,
+                            lineWidth: 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(symbol)
+    }
+}

--- a/Sources/AVPainRelieverApp/LaunchAtLogin.swift
+++ b/Sources/AVPainRelieverApp/LaunchAtLogin.swift
@@ -47,17 +47,4 @@ enum LaunchAtLogin {
             logger.warning("login-item update failed (enabled=\(enabled)): \(error.localizedDescription, privacy: .public)")
         }
     }
-
-    /// Best-effort read of whether the system currently considers us
-    /// a login item. Useful for surfacing the truth in Settings if a
-    /// register call silently failed (e.g. unsigned dev binary).
-    /// Returns nil when SMAppService can't tell.
-    static func isRegistered() -> Bool? {
-        let status = SMAppService.mainApp.status
-        switch status {
-        case .enabled: return true
-        case .notRegistered, .notFound, .requiresApproval: return false
-        @unknown default: return nil
-        }
-    }
 }

--- a/Sources/AVPainRelieverApp/MenuBarSymbolPicker.swift
+++ b/Sources/AVPainRelieverApp/MenuBarSymbolPicker.swift
@@ -5,12 +5,12 @@ import SwiftUI
 /// updates the binding and dismisses the popover.
 ///
 /// Visual sibling of `IconPickerView` (the wizard's per-profile
-/// picker) — same tile size, same selection-highlight treatment, so
-/// the two pickers read as one component family. The reason this is
-/// a separate view instead of generalising `IconPickerView`: the
-/// wizard picker has an "Auto" affordance keyed to a profile slug,
-/// which makes no sense for a global menu-bar default. A standalone
-/// view keeps both call sites simple.
+/// picker) — same tile size, same selection-highlight treatment via
+/// the shared `IconTile`, so the two pickers read as one component
+/// family. The reason this is a separate view instead of generalising
+/// `IconPickerView`: the wizard picker has an "Auto" affordance keyed
+/// to a profile slug, which makes no sense for a global menu-bar
+/// default. A standalone view keeps both call sites simple.
 struct MenuBarSymbolPicker: View {
     /// User's current pick. Non-optional because the menu bar always
     /// has a fallback symbol — `nil` would have no useful meaning.
@@ -24,31 +24,10 @@ struct MenuBarSymbolPicker: View {
     var body: some View {
         LazyVGrid(columns: columns, spacing: 6) {
             ForEach(MenuBarIcon.catalog, id: \.self) { symbol in
-                Button {
+                IconTile(symbol: symbol, isSelected: selection == symbol) {
                     selection = symbol
                     onPick()
-                } label: {
-                    Image(systemName: symbol)
-                        .font(.body)
-                        .frame(width: 36, height: 36)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(selection == symbol
-                                      ? Color.accentColor.opacity(0.18)
-                                      : Color.clear)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(
-                                    selection == symbol
-                                        ? Color.accentColor
-                                        : Color.clear,
-                                    lineWidth: 1
-                                )
-                        )
                 }
-                .buttonStyle(.plain)
-                .help(symbol)
             }
         }
         .padding(12)

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -173,7 +173,7 @@ private struct CameraSettingsTab: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
-                    .background(Color.orange, in: Capsule())
+                    .background(Theme.Color.warn, in: Capsule())
             }
         }
         .padding(.vertical, 2)
@@ -181,9 +181,9 @@ private struct CameraSettingsTab: View {
 
     private var statusColor: Color {
         switch activator.state {
-        case .on: return .green
-        case .activating, .needsApproval: return .orange
-        case .failed, .requiresRelaunch: return .red
+        case .on: return Theme.Color.success
+        case .activating, .needsApproval: return Theme.Color.warn
+        case .failed, .requiresRelaunch: return Theme.Color.error
         case .off: return .secondary
         }
     }
@@ -489,7 +489,7 @@ private struct ProfileRow: View {
                             .foregroundStyle(.white)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
-                            .background(Color.green, in: Capsule())
+                            .background(Theme.Color.success, in: Capsule())
                     }
                 }
                 // Vertical device list — each device on its own row
@@ -605,7 +605,7 @@ private struct StatsSettingsTab: View {
                         resetConfirmationVisible = true
                     } label: {
                         Text("Reset stats…")
-                            .foregroundStyle(.red)
+                            .foregroundStyle(Theme.Color.error)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                     }

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -7,11 +7,12 @@ import AppKit
 /// cyan highlight) borrowed from the Hammerspoon TUI. The user
 /// reverted that direction (2026-05-02): the app should look like a
 /// plain native macOS utility, no custom accent colors. So this
-/// namespace now exposes only the three semantic system colors the
-/// app actually needs (success / warn / error) for status pills and
-/// banner-style errors. Everything else (headers, captions, links,
-/// button tints) uses SwiftUI's defaults — `.primary` for body text,
-/// `.secondary` for hints, the system accent for prominent buttons.
+/// namespace exposes a small set of semantic system colors —
+/// success / warn / error for status pills and banner-style errors,
+/// plus muted for low-volume informational pills. Everything else
+/// (headers, captions, links, button tints) uses SwiftUI's defaults
+/// — `.primary` for body text, `.secondary` for hints, the system
+/// accent for prominent buttons.
 ///
 /// `Theme.Symbol` and `Theme.Copy` stay as before — those are
 /// product identifiers, not stylistic choices.

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -50,13 +50,6 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         /// in-session deactivation; resolved by relaunching the
         /// app from a fresh process.
         case requiresRelaunch
-
-        var isLive: Bool {
-            switch self {
-            case .activating, .needsApproval, .on: return true
-            case .off, .failed, .requiresRelaunch: return false
-            }
-        }
     }
 
     static let extensionBundleID = "com.ericwillis.avpainreliever.CameraExtension"

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -232,11 +232,7 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
 
     private func startCapturePipeline() {
         guard captureSession == nil else { return }
-        let writer = CMIOSinkWriter(
-            deviceUID: Self.virtualCameraUID,
-            width: 1280,
-            height: 720
-        )
+        let writer = CMIOSinkWriter(deviceUID: Self.virtualCameraUID)
         let session = CameraCaptureSession(
             sink: writer,
             initialSourceName: pendingSourceName

--- a/Sources/AVPainRelieverApp/WelcomeView.swift
+++ b/Sources/AVPainRelieverApp/WelcomeView.swift
@@ -13,59 +13,45 @@ struct WelcomeView: View {
     @State private var showConfetti = true
 
     var body: some View {
-        ZStack {
-            VStack(spacing: 24) {
-                Image(nsImage: AppIcon.image)
-                    .resizable()
-                    .interpolation(.high)
-                    .frame(width: 104, height: 104)
-                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-                    .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
+        VStack(spacing: 24) {
+            Image(nsImage: AppIcon.image)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: 104, height: 104)
+                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
 
-                VStack(spacing: 8) {
-                    Text(Self.greetingTitle)
-                        .font(.system(size: 24, weight: .bold, design: .rounded))
-                        .multilineTextAlignment(.center)
-                    Text(Theme.Copy.tagline)
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-
-                Spacer(minLength: 0)
-
-                VStack(spacing: 10) {
-                    Button(action: onAddProfile) {
-                        Text("Add Your First Location")
-                            .frame(minWidth: 220)
-                            .padding(.vertical, 4)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .keyboardShortcut(.defaultAction)
-
-                    Button("Skip — I'll set up later", action: onSkip)
-                        .buttonStyle(.borderless)
-                        .keyboardShortcut(.cancelAction)
-                }
+            VStack(spacing: 8) {
+                Text(Self.greetingTitle)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .multilineTextAlignment(.center)
+                Text(Theme.Copy.tagline)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
             }
-            .padding(.vertical, 32)
-            .padding(.horizontal, 28)
-            .frame(width: 480, height: 540)
 
-            if showConfetti {
-                ConfettiBurst()
-                    .allowsHitTesting(false)
-                    .task {
-                        // Outlast the longest particle trajectory so
-                        // every piece arcs back down before the layer
-                        // unmounts. After this, the ZStack collapses
-                        // and no animations keep ticking.
-                        try? await Task.sleep(for: .seconds(3.2))
-                        showConfetti = false
-                    }
+            Spacer(minLength: 0)
+
+            VStack(spacing: 10) {
+                Button(action: onAddProfile) {
+                    Text("Add Your First Location")
+                        .frame(minWidth: 220)
+                        .padding(.vertical, 4)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+
+                Button("Skip — I'll set up later", action: onSkip)
+                    .buttonStyle(.borderless)
+                    .keyboardShortcut(.cancelAction)
             }
         }
+        .padding(.vertical, 32)
+        .padding(.horizontal, 28)
+        .frame(width: 480, height: 540)
+        .oneShotConfetti(isPresented: $showConfetti)
         .background(.background)
         .dialogWindowChrome()
         .centeredOnScreen()

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -115,6 +115,9 @@ they come up so we can prioritize for v2:
 - Per-profile *focus mode* / *Do Not Disturb*
 - Hammerspoon → Swift *config import* (read existing `profiles.lua` and
   generate `profiles.toml`)
+- *Crash and error reporting* (opt-in telemetry for unhandled crashes,
+  plus an in-app viewer for recent OSLog failures so the user notices
+  silent breakage without running `log show`)
 
 ### Onboarding
 


### PR DESCRIPTION
## Summary

Slop-review cleanup over four commits. The first three are pure hygiene; the fourth is a real correctness fix in the camera swap path. swift test: 203/203 at every checkpoint.

### Commit 1 — `245e6b2` — first batch (5 fixes)

- **LaunchAtLogin:** delete unused `isRegistered()` helper. No call sites in `Sources/` or `Tests/`.
- **VirtualCameraActivator:** delete unused `State.isLive` computed property. Same story — declared, never referenced.
- **Theme:** docstring claimed "only the three semantic system colors" but `Theme.Color` has four — `.muted` was added later for the wizard's "Travels with you" pill and the doc never caught up.
- **AddProfileViewModel:** two "Two-tier sort" comments contradicted the four-tier implementation right below them. Stripped the stale prose.
- **AddProfileViewModel:** dropped the duplicated `virtualCameraDisplayName` constant; reference `VirtualCameraActivator.virtualCameraDisplayName` directly (both files live in the same target).

### Commit 2 — `f5d442a` — future-work capture

- **docs/decisions.md:** added "Crash and error reporting" under *Scope creep candidates* — opt-in crash telemetry plus an in-app viewer for recent OSLog failures so silent breakage doesn't hide from the user.

### Commit 3 — `d712202` — second batch (4 fixes)

- **`IconTile.swift` (new):** the 36×36 SF Symbol tile button was byte-identical between `IconPickerView` and `MenuBarSymbolPicker`. Both now use the shared view; net negative LOC.
- **`View.oneShotConfetti(isPresented:duration:)` modifier** on `ConfettiBurst.swift`: `AboutView` and `WelcomeView` each had the same overlay + 3.2s task block. Both now call the modifier; the wrapping ZStack collapses out of each view.
- **`CMIOSinkWriter.init`:** dropped the unused `width`/`height` parameters. Output target is fixed at 1280×720 BGRA via static constants; the params were silently discarded with `_ = width; _ = height`. One call site updated.
- **`SettingsView`:** route raw `Color.green/.orange/.red` through `Theme.Color.success/.warn/.error` at the five status-pill / destructive-action sites. `Theme.Color` is the project's single source of truth for status colors per CLAUDE.md.

### Commit 4 — `447b120` — camera swap correctness fix

- **`CameraCaptureSession.swapInputLocked`:** stop silently discarding `installInput`'s Bool return value. If the new device's `AVCaptureDeviceInput` init fails (device unplugged between `findDevice` and the swap, or a format incompatibility surfaces late), the session was left with no input and frames silently stopped. Now stash the previous input before removing it, attempt the new device, and on failure put the previous input back so the pipeline keeps flowing. Logs both branches — `warning` when fallback succeeded, `error` when nothing could be restored.
- This is the only commit with a real behavior change. No tests for this path (depends on real hardware), so the safety net is the build pass + careful diff review + hands-on verification.

## Test plan

- [x] `swift build` — clean across all four commits
- [x] `swift test` — 203 tests pass (same count and outcome as the pre-change baseline) at every checkpoint
- [x] Local hands-on (post-reboot): virtual camera reaches `[activated enabled]` and is selectable. The "Restart required" state seen earlier was a pre-existing macOS quirk from accumulated stale extension versions, unrelated to this PR.
- [ ] Visual hands-on for commit 3: open About + Welcome (confetti still plays, dialogs still center), open the wizard's icon picker + Settings → General menu-bar icon picker (confirm tile selection still highlights — selected tile gets blue-tinted fill + 1pt accent stroke; unselected tiles plain), confirm Settings → Camera status pill colors look correct.
- [ ] Hands-on for commit 4: with the virtual camera running and a profile that switches between two source cameras, trigger the swap (replug the dock) and confirm frames keep flowing. The fallback only fires on install failure (rare); the success path through the new code should be indistinguishable from the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)