### PR TITLE
refactor: move CMIO/CaptureSession adapters into engine library

### DIFF
--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
@@ -24,7 +24,7 @@ private let logger = Logger(
 ///
 /// Mirrors the pattern OBS uses in its mac-virtualcam plugin
 /// (referenced for architecture, not code).
-final class CMIOSinkWriter {
+public final class CMIOSinkWriter {
     private let deviceUID: String
     private var deviceID: CMIODeviceID = 0
     private var streamID: CMIOStreamID = 0
@@ -69,7 +69,7 @@ final class CMIOSinkWriter {
     private static let outputHeight: Int = 720
     private static let outputFormat: OSType = kCVPixelFormatType_32BGRA
 
-    init(deviceUID: String) {
+    public init(deviceUID: String) {
         self.deviceUID = deviceUID
     }
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -1,7 +1,6 @@
 import Foundation
 import AVFoundation
 import CoreVideo
-import AVPainReliever
 import os.log
 
 private let logger = Logger(
@@ -30,7 +29,7 @@ private let logger = Logger(
 /// the session keeps running across the swap — the only gap is the
 /// ~500 ms it takes the new device to start delivering frames. The
 /// extension covers that gap by holding the last frame.
-final class CameraCaptureSession: NSObject {
+public final class CameraCaptureSession: NSObject {
     private let session = AVCaptureSession()
     private let captureQueue = DispatchQueue(
         label: "com.ericwillis.avpainreliever.host.capture",
@@ -54,7 +53,7 @@ final class CameraCaptureSession: NSObject {
     /// would create a self-source feedback loop.
     private let initialSourceName: String?
 
-    init(sink: CMIOSinkWriter, initialSourceName: String? = nil) {
+    public init(sink: CMIOSinkWriter, initialSourceName: String? = nil) {
         self.sink = sink
         self.initialSourceName = initialSourceName
         super.init()
@@ -83,13 +82,13 @@ final class CameraCaptureSession: NSObject {
 
     /// Boots up capture asynchronously. Returns immediately.
     /// Failures are logged; the menu bar doesn't surface them today.
-    func start() {
+    public func start() {
         captureQueue.async { [weak self] in
             self?.bootIfAuthorized()
         }
     }
 
-    func stop() {
+    public func stop() {
         captureQueue.async { [weak self] in
             guard let self else { return }
             self.session.stopRunning()
@@ -220,7 +219,7 @@ final class CameraCaptureSession: NSObject {
     /// camera. Used to keep the host from ever opening its own
     /// output as a capture source.
     private static func isVirtualCamera(_ device: AVCaptureDevice) -> Bool {
-        device.uniqueID == VirtualCameraActivator.virtualCameraUID
+        device.uniqueID == VirtualCameraIdentity.deviceUID
     }
 
     /// Add an `AVCaptureDeviceInput` for `device` to the session.
@@ -328,7 +327,7 @@ final class CameraCaptureSession: NSObject {
 }
 
 extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
-    func captureOutput(
+    public func captureOutput(
         _ output: AVCaptureOutput,
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
@@ -370,7 +369,7 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
 }
 
 extension CameraCaptureSession: VirtualCameraSourceController {
-    func setSource(named: String) -> CameraApplyResult {
+    public func setSource(named: String) -> CameraApplyResult {
         guard Self.findDevice(named: named) != nil else {
             return .notFound
         }

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/VirtualCameraIdentity.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/VirtualCameraIdentity.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Identity constants for the embedded AV Pain Reliever virtual
+/// camera. The same values are hardcoded inside the Camera Extension
+/// binary (`Sources/AVPainRelieverCameraExtension/`) — they have to
+/// match by hand because the extension target is sandboxed and shares
+/// no Swift module with the engine.
+///
+/// Lives in the engine library so the host-side capture adapters
+/// (`CameraCaptureSession`, `CMIOSinkWriter`) can reference them
+/// without depending on the app target. The app target's
+/// `VirtualCameraActivator` re-exports them under its existing
+/// `virtualCameraUID` / `virtualCameraDisplayName` names so callers
+/// don't need to learn a new spelling.
+public enum VirtualCameraIdentity {
+    /// Stable UUID matching the extension's
+    /// `CameraExtensionDeviceSource.deviceUUID`. The host uses this
+    /// to find the virtual camera in the CMIO device list and to
+    /// recognize its own output device when sorting cameras for the
+    /// wizard.
+    public static let deviceUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
+
+    /// Localized name the extension registers — also what
+    /// AVFoundation reports for the virtual camera's
+    /// `localizedName`. Used as the value of
+    /// `preferredCameraOverride` so `ProfileApplier` can set the
+    /// system-wide preferred camera to "AV Pain Reliever" when the
+    /// virtual camera is live, mirroring what users set in Zoom.
+    public static let displayName = "AV Pain Reliever"
+}

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -55,18 +55,15 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     static let extensionBundleID = "com.ericwillis.avpainreliever.CameraExtension"
     static let envVar = "AVPR_ACTIVATE_VIRTUAL_CAMERA"
 
-    /// Stable UUID matching the extension's
-    /// `CameraExtensionDeviceSource.deviceUUID`. The host uses this
-    /// to find the virtual camera in the CMIO device list.
-    static let virtualCameraUID = "B45B7E4D-3F4E-4F4D-9C2A-1B2C3D4E5F60"
-
-    /// Localized name the extension registers — also what
-    /// AVFoundation reports for the virtual camera's
-    /// `localizedName`. Used as the value of
-    /// `preferredCameraOverride` so `ProfileApplier` can set the
-    /// system-wide preferred camera to "AV Pain Reliever" when the
-    /// virtual camera is live, mirroring what users set in Zoom.
-    static let virtualCameraDisplayName = "AV Pain Reliever"
+    /// Re-exports of `VirtualCameraIdentity` so existing call sites
+    /// (`AddProfileViewModel`, internal references below) keep their
+    /// `VirtualCameraActivator.virtualCameraUID` /
+    /// `VirtualCameraActivator.virtualCameraDisplayName` spellings.
+    /// The single source of truth lives in the engine library
+    /// alongside the host-side capture adapters that need to compare
+    /// against it without depending on the app target.
+    static let virtualCameraUID = VirtualCameraIdentity.deviceUID
+    static let virtualCameraDisplayName = VirtualCameraIdentity.displayName
 
     /// Mirror of the extension's notification names. Kept in sync by
     /// hand — both targets are sandboxed-vs-not separate executables


### PR DESCRIPTION
## Summary

Slop-review follow-up #7 — moves the virtual camera's host-side adapter code out of the app shell and into the engine library, where the other adapter implementations (and the protocol this code conforms to) already live.

**Before:** ~828 LOC of pure CoreMediaIO + AVFoundation adapter code lived in \`Sources/AVPainRelieverApp/\` (\`CMIOSinkWriter\`, \`CameraCaptureSession\`). The engine's other adapters (\`CoreAudioController\`, \`AVFoundationCameraController\`) lived in \`Sources/AVPainReliever/Adapters/\`. \`CameraCaptureSession\` even conformed to the engine-defined \`VirtualCameraSourceController\` protocol — implementation across the boundary from its contract.

**After:** the moved code lives next to the protocol it implements. \`VirtualCameraActivator\` stays in the app shell because it owns \`SystemExtensions\` activation lifecycle + AppKit relaunch, which the engine library can't import.

## Changes

- **\`Sources/AVPainReliever/Adapters/VirtualCamera/\` (new subdirectory)** groups the three related files. The other engine adapters stay flat at \`Adapters/\` since they're singletons; the virtual camera is a small subsystem so a subdir reads cleaner.
- **\`VirtualCameraIdentity.swift\` (new):** public \`deviceUID\` + \`displayName\` constants. Single source of truth — the values still have to match what's hardcoded in the Camera Extension target (cross-target hand-mirror is a separate slop-review finding, #13, not addressed here).
- **\`git mv\`** \`CMIOSinkWriter.swift\` and \`CameraCaptureSession.swift\` into the new subdirectory. Renames tracked properly (99% / 97% similarity).
- Public modifiers added to the types + APIs the app target instantiates: \`CMIOSinkWriter.init\`; \`CameraCaptureSession.init\`, \`start\`, \`stop\`, \`setSource\`, \`captureOutput\`. Internal-only members (queue plumbing, format conversion, discovery helpers) stay private.
- \`CameraCaptureSession\` drops \`import AVPainReliever\` (it IS now part of \`AVPainReliever\`) and references \`VirtualCameraIdentity.deviceUID\` directly instead of \`VirtualCameraActivator.virtualCameraUID\`.
- \`VirtualCameraActivator\`'s static \`virtualCameraUID\` / \`virtualCameraDisplayName\` now forward to \`VirtualCameraIdentity\`, preserving the existing API surface so \`AddProfileViewModel\` and internal callers keep their current spellings.

Net: 4 files changed, +48 / -22 LOC (mostly the new identity constants file).

## What this enables

- Engine-target tests can now exercise the host-capture path without depending on the app target.
- \`#13\` (Darwin notification name dedup across host + extension) is now narrower since the related identity constants are already in a public engine spot. Whoever picks that up next can extend \`VirtualCameraIdentity\` (or sit a sibling alongside it) and the host + extension can both reference the same place — separate PR.
- \`#11\` (AppDelegate config-bootstrap extraction into engine) is unaffected by this PR.

## Stacked-PR notes

This PR is stacked on the slop-review cleanup that's already on \`main\` (PR #42, merged as 09d228e). Targets \`main\` directly — no rebase needed.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — 203 tests pass (same count and outcome as the pre-move baseline)
- [ ] Hands-on: launch via \`./dev/build --full\`, confirm the virtual camera still reaches \`[activated enabled]\`, the wizard's camera picker still hides the AV Pain Reliever output, and Zoom / FaceTime / Photo Booth still see frames from the active source. The internal wiring is identical — only the file location changed — so a regression here would be a build-system surprise rather than a logic bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)