### PR TITLE
refactor: extract profile-config bootstrap into engine library

### DIFF
--- a/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
+++ b/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Discovers an existing profiles config or bootstraps a new one for
+/// fresh installs. Wraps the read / import / seed dance the host's
+/// first launch performs:
+///
+///   1. `~/Library/Application Support/AVPainReliever/profiles.toml` —
+///      the canonical Swift-app config; load it directly.
+///   2. `~/.hammerspoon/profiles.lua` — auto-migrate users coming from
+///      the Phase 1 Hammerspoon prototype. Imported profiles get
+///      written to the canonical TOML so future edits and the
+///      Add-Profile wizard operate on the same file.
+///   3. Neither file exists — write a starter `profiles.toml` so the
+///      engine has a working "laptop" fallback to apply on first
+///      launch instead of running idle.
+///
+/// Lives in the engine library so the host AppDelegate can stay a
+/// thin caller and the bootstrap behavior is testable without the
+/// app target.
+public struct ProfileBootstrapper {
+    public init() {}
+
+    /// Canonical location of the Swift-app's `profiles.toml`. Single
+    /// source of truth used by the first-launch bootstrap, the
+    /// Add-Profile wizard's writer, and the menu-bar's delete path.
+    public static let canonicalTOMLURL: URL =
+        URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(
+                "Library/Application Support/AVPainReliever/profiles.toml"
+            )
+
+    /// Load profiles from the canonical TOML, falling through to
+    /// Hammerspoon migration, falling through to a starter config
+    /// write. Logs each branch via `ApplierLogger` so the host's
+    /// console pipeline gets a uniform audit trail. Returns an empty
+    /// array only when every fallback failed; the engine then runs
+    /// idle until the user creates a config.
+    public func loadOrBootstrap(logger: ApplierLogger) -> [Profile] {
+        let tomlURL = Self.canonicalTOMLURL
+        let luaURL = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".hammerspoon/profiles.lua")
+
+        if FileManager.default.fileExists(atPath: tomlURL.path) {
+            do {
+                let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
+                logger.info("loaded \(profiles.count) profiles from \(tomlURL.path)")
+                return profiles
+            } catch {
+                logger.warn("failed to load \(tomlURL.path): \(error)")
+            }
+        }
+
+        if FileManager.default.fileExists(atPath: luaURL.path) {
+            do {
+                let lua = try String(contentsOf: luaURL, encoding: .utf8)
+                let importer = ConfigImporter()
+                let profiles = try importer.parse(lua)
+                // One-shot migration: write the imported profiles to
+                // the canonical TOML location so future launches AND
+                // the Add-Profile wizard work against the same file.
+                // Without this, the first wizard save creates a TOML
+                // containing only the new profile, silently shadowing
+                // everything in profiles.lua.
+                do {
+                    let toml = try importer.convertToTOML(lua)
+                    try FileManager.default.createDirectory(
+                        at: tomlURL.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    try toml.write(to: tomlURL, atomically: true, encoding: .utf8)
+                    logger.info("migrated \(profiles.count) profiles from \(luaURL.path) (Hammerspoon) → \(tomlURL.path); future edits should go to the TOML file")
+                } catch {
+                    logger.warn("loaded \(profiles.count) profiles from \(luaURL.path) but migration to \(tomlURL.path) failed: \(error). Wizard saves won't include these until migration succeeds.")
+                }
+                return profiles
+            } catch {
+                logger.warn("failed to import \(luaURL.path): \(error)")
+            }
+        }
+
+        // Fresh user with no Hammerspoon and no Swift-app config:
+        // bootstrap a starter `profiles.toml` so the app does
+        // something useful on first launch (apply MacBook audio
+        // defaults when undocked) instead of staring blankly until
+        // the user creates a config.
+        do {
+            try writeStarterConfig(at: tomlURL)
+            let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
+            logger.info("first launch — wrote a starter config to \(tomlURL.path) (\(profiles.count) profile)")
+            return profiles
+        } catch {
+            logger.warn("failed to write starter config to \(tomlURL.path): \(error) — engine will run idle until a config is created")
+            return []
+        }
+    }
+
+    /// Default `profiles.toml` content, written on first launch when
+    /// neither an existing TOML nor a Hammerspoon `profiles.lua`
+    /// exists. Includes one always-matches "laptop" profile with
+    /// modern-Mac defaults plus inline comments showing the user how
+    /// to add docked locations.
+    static let starterConfig = """
+    # AV Pain Reliever — profile config.
+    # Each [profiles.<name>] section defines a location.
+    #
+    # A profile matches when every USB device in its `fingerprint` is
+    # currently attached. Most-specific match wins; alphabetical
+    # tiebreak. An empty fingerprint matches always (specificity 0),
+    # making such a profile the implicit fallback when nothing more
+    # specific matches.
+
+    [profiles.laptop]
+    # Implicit fallback — no fingerprint means this matches whenever
+    # no docked profile does (typical state: undocked MacBook).
+    audioInput  = "MacBook Pro Microphone"
+    audioOutput = "MacBook Pro Speakers"
+
+    # Add a docked profile here, e.g.:
+    #
+    # [profiles.home-office]
+    # audioInput  = "Yeti Stereo Microphone"
+    # audioOutput = "External DAC"
+    # fingerprint = [
+    #   { vendorID = 0x2188, productID = 0x6533, name = "Dock" },
+    #   { vendorID = 0x043e, productID = 0x9a68, name = "External camera" },
+    # ]
+    #
+    # Easier: click the menu bar → Add Profile… and the wizard
+    # captures your currently-attached devices automatically.
+
+    """
+
+    private func writeStarterConfig(at url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: parent, withIntermediateDirectories: true
+        )
+        try Self.starterConfig.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -187,12 +187,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             .store(in: &cancellables)
     }
 
-    private static let profilesTOMLURL: URL =
-        URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(
-                "Library/Application Support/AVPainReliever/profiles.toml"
-            )
-
     /// The most recent profile name we surfaced through
     /// `onProfileApplied`. Used to suppress a notification for the
     /// initial evaluation on launch (the menu-bar title is already
@@ -342,7 +336,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         engine?.stop()
 
         let logger = ConsoleLogger()
-        let profiles = loadProfiles(logger: logger)
+        let profiles = ProfileBootstrapper().loadOrBootstrap(logger: logger)
         availableProfiles = profiles
         let engine = buildEngine(profiles: profiles, logger: logger)
         engine.onProfileApplied = { [weak self] profile in
@@ -500,7 +494,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             watcher: IOKitUSBWatcher(),
             audioController: CoreAudioController(),
             cameraController: AVFoundationCameraController(),
-            configURL: Self.profilesTOMLURL,
+            configURL: ProfileBootstrapper.canonicalTOMLURL,
             editing: editing,
             existingProfileSlugs: existing,
             virtualCameraEnabled: virtualCameraActivator.state == .on,
@@ -550,7 +544,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     func deleteProfile(_ profile: Profile) {
         let pretty = PrettyName.format(profile.name)
         do {
-            try ProfileWriter().delete(named: profile.name, in: Self.profilesTOMLURL)
+            try ProfileWriter().delete(named: profile.name, in: ProfileBootstrapper.canonicalTOMLURL)
             reloadConfig()
         } catch {
             let failure = NSAlert()
@@ -631,118 +625,4 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// Mirror of `settings.menuBarIconSymbol` for the same reason.
     var menuBarIconSymbol: String { settings.menuBarIconSymbol }
 
-    /// Profile-config discovery in priority order. Mirrors what the
-    /// eventual first-run wizard will codify, but for now lets a
-    /// developer or migrating Phase 1 user run the app immediately:
-    ///
-    ///   1. `~/Library/Application Support/AVPainReliever/profiles.toml`
-    ///      — the canonical Swift-app config location.
-    ///   2. `~/.hammerspoon/profiles.lua` — auto-import for users
-    ///      migrating from the Hammerspoon Phase 1 engine.
-    ///   3. **Bootstrap a default profiles.toml** — a fresh user
-    ///      with neither file gets a working "laptop" fallback
-    ///      profile written to (1) so the app actually does
-    ///      something on first launch.
-    private func loadProfiles(logger: ApplierLogger) -> [Profile] {
-        let tomlURL = Self.profilesTOMLURL
-        let luaURL = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".hammerspoon/profiles.lua")
-
-        if FileManager.default.fileExists(atPath: tomlURL.path) {
-            do {
-                let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
-                logger.info("loaded \(profiles.count) profiles from \(tomlURL.path)")
-                return profiles
-            } catch {
-                logger.warn("failed to load \(tomlURL.path): \(error)")
-            }
-        }
-
-        if FileManager.default.fileExists(atPath: luaURL.path) {
-            do {
-                let lua = try String(contentsOf: luaURL, encoding: .utf8)
-                let importer = ConfigImporter()
-                let profiles = try importer.parse(lua)
-                // One-shot migration: write the imported profiles to
-                // the canonical TOML location so future launches AND
-                // the Add-Profile wizard work against the same file.
-                // Without this, the first wizard save creates a TOML
-                // containing only the new profile, silently shadowing
-                // everything in profiles.lua.
-                do {
-                    let toml = try importer.convertToTOML(lua)
-                    try FileManager.default.createDirectory(
-                        at: tomlURL.deletingLastPathComponent(),
-                        withIntermediateDirectories: true
-                    )
-                    try toml.write(to: tomlURL, atomically: true, encoding: .utf8)
-                    logger.info("migrated \(profiles.count) profiles from \(luaURL.path) (Hammerspoon) → \(tomlURL.path); future edits should go to the TOML file")
-                } catch {
-                    logger.warn("loaded \(profiles.count) profiles from \(luaURL.path) but migration to \(tomlURL.path) failed: \(error). Wizard saves won't include these until migration succeeds.")
-                }
-                return profiles
-            } catch {
-                logger.warn("failed to import \(luaURL.path): \(error)")
-            }
-        }
-
-        // Fresh user with no Hammerspoon and no Swift-app config:
-        // bootstrap a starter `profiles.toml` so the app does
-        // something useful on first launch (apply MacBook audio
-        // defaults when undocked) instead of staring blankly until
-        // the user creates a config.
-        do {
-            try writeStarterConfig(at: tomlURL)
-            let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
-            logger.info("first launch — wrote a starter config to \(tomlURL.path) (\(profiles.count) profile)")
-            return profiles
-        } catch {
-            logger.warn("failed to write starter config to \(tomlURL.path): \(error) — engine will run idle until a config is created")
-            return []
-        }
-    }
-
-    /// Default `profiles.toml` content, written on first launch when
-    /// neither an existing TOML nor a Hammerspoon `profiles.lua`
-    /// exists. Includes one always-matches "laptop" profile with
-    /// modern-Mac defaults plus inline comments showing the user how
-    /// to add docked locations and OBS scenes.
-    private static let starterConfig = """
-    # AV Pain Reliever — profile config.
-    # Each [profiles.<name>] section defines a location.
-    #
-    # A profile matches when every USB device in its `fingerprint` is
-    # currently attached. Most-specific match wins; alphabetical
-    # tiebreak. An empty fingerprint matches always (specificity 0),
-    # making such a profile the implicit fallback when nothing more
-    # specific matches.
-
-    [profiles.laptop]
-    # Implicit fallback — no fingerprint means this matches whenever
-    # no docked profile does (typical state: undocked MacBook).
-    audioInput  = "MacBook Pro Microphone"
-    audioOutput = "MacBook Pro Speakers"
-
-    # Add a docked profile here, e.g.:
-    #
-    # [profiles.home-office]
-    # audioInput  = "Yeti Stereo Microphone"
-    # audioOutput = "External DAC"
-    # fingerprint = [
-    #   { vendorID = 0x2188, productID = 0x6533, name = "Dock" },
-    #   { vendorID = 0x043e, productID = 0x9a68, name = "External camera" },
-    # ]
-    #
-    # Easier: click the menu bar → Add Profile… and the wizard
-    # captures your currently-attached devices automatically.
-
-    """
-
-    private func writeStarterConfig(at url: URL) throws {
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(
-            at: parent, withIntermediateDirectories: true
-        )
-        try Self.starterConfig.write(to: url, atomically: true, encoding: .utf8)
-    }
 }


### PR DESCRIPTION
## Summary

Slop-review follow-up #11 — moves the first-launch profile-config bootstrap (TOML discovery + Hammerspoon migration + starter-config seeding) out of \`AppDelegate\` and into the engine library where the rest of the Config layer (\`ConfigLoader\`, \`ConfigImporter\`, \`ProfileWriter\`) already lives.

**Before:** \`AppDelegate.loadProfiles(logger:)\` (~60 lines) + \`starterConfig\` constant (~30 lines) + \`writeStarterConfig(at:)\` (~7 lines) + \`profilesTOMLURL\` static. ~120 lines of TOML-loading and Hammerspoon-migration glue in the app shell.

**After:**

\`\`\`swift
public struct ProfileBootstrapper {
    public static let canonicalTOMLURL: URL
    public func loadOrBootstrap(logger: ApplierLogger) -> [Profile]
}
\`\`\`

The discovery + migration + seed logic is byte-identical to the prior implementation — same priority order (canonical TOML → Hammerspoon migration → starter config), same logging shape, same fallback semantics. Starter TOML string is unchanged.

## Changes

### New file

- **\`Sources/AVPainReliever/Config/ProfileBootstrapper.swift\`** (140 LOC) — public struct with \`canonicalTOMLURL\` and \`loadOrBootstrap(logger:)\`. Sits alongside the other Config types.

### AppDelegate edits

- \`bootEngine()\` now calls \`ProfileBootstrapper().loadOrBootstrap(logger:)\` instead of the local \`loadProfiles\`.
- The two remaining \`Self.profilesTOMLURL\` references (Engine init + delete-profile \`ProfileWriter\` call) point at \`ProfileBootstrapper.canonicalTOMLURL\` instead. Single source of truth for the path.
- Drops \`loadProfiles\`, \`starterConfig\`, \`writeStarterConfig\`, and the \`profilesTOMLURL\` static (~123 lines removed).

### AppDelegate footprint

| | LOC |
|---|---:|
| Before | 748 |
| After  | 628 |
| Δ      | -120 |

The slop-review's #11 framing was "AppDelegate trim — extract config bootstrap to engine." That's exactly what this PR does. Doesn't address the broader god-object framing (#11's higher-numbered cousin) — that would touch profile-delete, dependency-bundle factory, six \`settings.foo\` mirrors, etc. Those stay AppDelegate-shaped here because they're app-shell concerns (NSAlert, SwiftUI environment, etc.).

## What this enables

- Bootstrap behavior is now testable without the app target. A future test could feed it a temporary directory and assert the TOML / Lua / starter-config branches behave correctly.
- \`#12\` (AppDelegate republish + 6 mirror vars) is unchanged in scope.
- The Config layer in the engine is self-contained again — nothing in \`AppDelegate\` reaches into it through file-IO.

## Stacked-PR notes

This PR targets \`main\` directly. PR #43 (CMIO/CaptureSession move into engine) merged earlier; this picks up that base. No rebase needed.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — 203 tests pass (same count and outcome as the pre-extraction baseline)
- [ ] Hands-on first-launch behavior: rename your existing \`~/Library/Application Support/AVPainReliever/profiles.toml\` aside, also rename \`~/.hammerspoon/profiles.lua\` aside if you have one, then launch via \`./dev/build --full\`. The starter config should write at the canonical path with the unchanged content. Restore your real config afterward.
- [ ] Hands-on Hammerspoon-migration path: same as above but only rename the TOML aside, leave the \`profiles.lua\`. The migration should fire and write a TOML version. Restore afterward.
- [ ] Hands-on normal-launch behavior (most useful): just launch with your real config in place. Should be indistinguishable from before. The OSLog line "loaded N profiles from /path/to/profiles.toml" comes from the bootstrapper now but says the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)