### PR TITLE
refactor: drop AppDelegate's republish + mirror vars

### DIFF
--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -17,7 +17,7 @@ struct AVPainRelieverApp: SwiftUI.App {
         // @Published property changes. View-level dependency tracking
         // is what makes the live update work.
         MenuBarExtra {
-            MenuContentView(delegate: appDelegate)
+            MenuContentView(delegate: appDelegate, settings: appDelegate.settings)
             // Hidden helpers — observe AppDelegate flags and open the
             // matching window. Live inside MenuBarExtra so SwiftUI's
             // openWindow environment is available; menu items render
@@ -25,7 +25,7 @@ struct AVPainRelieverApp: SwiftUI.App {
             WelcomeOpener(delegate: appDelegate)
             AddProfileOpener(delegate: appDelegate)
         } label: {
-            MenuLabelView(delegate: appDelegate)
+            MenuLabelView(delegate: appDelegate, settings: appDelegate.settings)
         }
         .menuBarExtraStyle(.menu)
 
@@ -127,6 +127,7 @@ private struct WelcomeWindowContent: View {
 
 private struct MenuLabelView: View {
     @ObservedObject var delegate: AppDelegate
+    @ObservedObject var settings: SettingsStore
 
     var body: some View {
         if delegate.atUnknownLocation {
@@ -141,7 +142,7 @@ private struct MenuLabelView: View {
             Text("New location")
         } else {
             Image(systemName: menuBarIcon)
-            if delegate.showProfileNameInMenuBar {
+            if settings.showProfileNameInMenuBar {
                 Text(delegate.currentProfileTitle)
             }
         }
@@ -156,11 +157,11 @@ private struct MenuLabelView: View {
     /// submenu and Profiles list render.
     private var menuBarIcon: String {
         guard
-            delegate.showProfileIconInMenuBar,
+            settings.showProfileIconInMenuBar,
             let slug = delegate.activeProfileSlug,
             let profile = delegate.availableProfiles.first(where: { $0.name == slug })
         else {
-            return delegate.menuBarIconSymbol
+            return settings.menuBarIconSymbol
         }
         return ProfileIcon.effectiveSymbol(for: slug, override: profile.icon)
     }
@@ -168,6 +169,7 @@ private struct MenuLabelView: View {
 
 private struct MenuContentView: View {
     @ObservedObject var delegate: AppDelegate
+    @ObservedObject var settings: SettingsStore
     @Environment(\.openWindow) private var openWindow
     /// macOS 14+ way to programmatically open the SwiftUI Settings
     /// scene. The AppKit-selector approach (showSettingsWindow:)
@@ -191,7 +193,7 @@ private struct MenuContentView: View {
         // disabled-NSMenuItem dim treatment that comes with non-
         // interactive items in NSMenu.
         if showStats || NSEvent.modifierFlags.contains(.option) {
-            Text(StatsCopy.line(for: delegate.profileSwitchCount))
+            Text(StatsCopy.line(for: settings.profileSwitchCount))
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Divider()

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -137,19 +137,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     override init() {
         super.init()
-        // Republish SettingsStore changes through our own
-        // ObservableObject so views that observe the AppDelegate (the
-        // menu, the About scene) re-render when a setting flips —
-        // without each view having to observe the store directly.
-        settings.objectWillChange
-            .sink { [weak self] in self?.objectWillChange.send() }
-            .store(in: &cancellables)
-        // Same propagation for the activator — Settings views show a
-        // live state badge that needs to repaint on every state
-        // transition.
-        virtualCameraActivator.objectWillChange
-            .sink { [weak self] in self?.objectWillChange.send() }
-            .store(in: &cancellables)
         // Drive the activator from the persisted toggle. Skips the
         // initial value (delivered synchronously when the sink
         // attaches) — `applicationDidFinishLaunching` handles the
@@ -608,21 +595,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             engine?.reapply()
         }
     }
-
-    // MARK: - Convenience surfaces for the menu
-
-    /// Mirror of `settings.profileSwitchCount` exposed on the
-    /// AppDelegate so the menu's `@ObservedObject` re-renders without
-    /// a separate observer plumbed through the view.
-    var profileSwitchCount: Int { settings.profileSwitchCount }
-
-    /// Mirror of `settings.showProfileNameInMenuBar` for the same reason.
-    var showProfileNameInMenuBar: Bool { settings.showProfileNameInMenuBar }
-
-    /// Mirror of `settings.showProfileIconInMenuBar` for the same reason.
-    var showProfileIconInMenuBar: Bool { settings.showProfileIconInMenuBar }
-
-    /// Mirror of `settings.menuBarIconSymbol` for the same reason.
-    var menuBarIconSymbol: String { settings.menuBarIconSymbol }
 
 }


### PR DESCRIPTION
## Summary

Slop-review follow-up #12 — drops the \`SettingsStore\` + \`VirtualCameraActivator\` \`objectWillChange\` re-broadcast in \`AppDelegate\` and the four \"convenience\" mirror computed properties that existed only because of it. Views that need those settings now observe \`SettingsStore\` directly via \`@ObservedObject\`.

## What was wrong

\`AppDelegate.init\` wired:

\`\`\`swift
settings.objectWillChange
    .sink { [weak self] in self?.objectWillChange.send() }
    .store(in: &cancellables)
virtualCameraActivator.objectWillChange
    .sink { [weak self] in self?.objectWillChange.send() }
    .store(in: &cancellables)
\`\`\`

…so every \`SettingsStore\` or activator change re-broadcast through \`AppDelegate.objectWillChange\`, repainting every view that observed the delegate — including ones that didn't care about that store. The pattern existed so \`MenuLabelView\` / \`MenuContentView\` could read four settings via \`delegate.showProfileNameInMenuBar\` / etc. without taking on a second \`@ObservedObject\`. Net effect: every settings flip caused an over-broad render fanout, and the AppDelegate carried four mirror vars whose only job was to make those reads compile.

The activator republish was already redundant — every view that needed activator state observed it directly (\`CameraSettingsTab\` via \`@ObservedObject var activator\`; an \`onReceive\` on \`\$state\` in \`App.swift\`).

## Changes

- **\`MenuLabelView\`, \`MenuContentView\`** (App.swift): add \`@ObservedObject var settings: SettingsStore\`. Replace four reads — \`delegate.{showProfileNameInMenuBar, showProfileIconInMenuBar, menuBarIconSymbol, profileSwitchCount}\` — with \`settings.<prop>\`. Same pattern \`SettingsView\` already uses.
- **App.swift**: pass \`settings: appDelegate.settings\` when constructing both views. Two-line change at the \`MenuBarExtra\` site.
- **AppDelegate.swift**: drop the two \`objectWillChange.sink\` calls in \`init\`, plus the four \"Convenience surfaces for the menu\" mirror computed vars at the bottom of the file.

## Net diff

2 files, **+8 / -35 LOC**.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — **186 tests pass** (same baseline)
- [ ] Hands-on: launch via \`./dev/build --full\`, open Settings → General, toggle "Show profile name in menu bar" and "Show profile icon in menu bar" and confirm the menu bar updates live; change the menu-bar icon symbol via the picker and confirm the menu bar updates; trigger a profile switch (replug a dock) and confirm the menu bar reflects the new active profile. Hold Option while opening the menu to see the easter-egg stats line — it should show the current switch count and update as you trigger more switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)