### PR TITLE
refactor: share Camera Extension notification names via a new SPM target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,16 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle.git", .upToNextMinor(from: "2.9.0")),
     ],
     targets: [
+        // Pure-Swift constants shared between the host app and the
+        // Camera Extension binary. No platform APIs, no third-party
+        // deps — keeps the linkage inert so the extension can pull
+        // it in without dragging anything else into its sandbox /
+        // signing scope. Lives in its own target rather than inside
+        // `AVPainReliever` because the extension target deliberately
+        // doesn't depend on the engine library.
+        .target(
+            name: "AVPainRelieverSharedConstants"
+        ),
         .target(
             name: "AVPainReliever",
             dependencies: ["TOMLKit"]
@@ -58,6 +68,7 @@ let package = Package(
             name: "AVPainRelieverApp",
             dependencies: [
                 "AVPainReliever",
+                "AVPainRelieverSharedConstants",
                 .product(name: "Sparkle", package: "Sparkle"),
             ]
         ),
@@ -76,10 +87,14 @@ let package = Package(
         // Camera Extension binary. Imports CoreMediaIO directly; no
         // dependency on AVPainReliever or AVPainRelieverApp — the
         // extension runs in its own process with a clean boundary.
+        // Pulls in `AVPainRelieverSharedConstants` so the host and
+        // extension can share the Darwin-notification name strings
+        // they exchange without hand-mirroring.
         // The compiled binary is wrapped in a .systemextension bundle
         // by scripts/make-app-with-virtual-camera.sh.
         .executableTarget(
-            name: "AVPainRelieverCameraExtension"
+            name: "AVPainRelieverCameraExtension",
+            dependencies: ["AVPainRelieverSharedConstants"]
         ),
     ]
 )

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -3,6 +3,7 @@ import AppKit
 import AVFoundation
 import SystemExtensions
 import AVPainReliever
+import AVPainRelieverSharedConstants
 import os.log
 
 private let logger = Logger(
@@ -65,17 +66,18 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     static let virtualCameraUID = VirtualCameraIdentity.deviceUID
     static let virtualCameraDisplayName = VirtualCameraIdentity.displayName
 
-    /// Mirror of the extension's notification names. Kept in sync by
-    /// hand — both targets are sandboxed-vs-not separate executables
-    /// without a shared Swift module, and three constants is cheaper
-    /// than building one. Any change here MUST mirror in
-    /// `CameraExtensionStream.swift`.
+    /// Re-exports of the shared notification names so the rest of
+    /// this file can keep its `Self.consumerActiveNotification`
+    /// spellings while the canonical strings live in
+    /// `AVPainRelieverSharedConstants` (a tiny target both this
+    /// host code and the Camera Extension link statically — no
+    /// more hand-mirroring across the two binaries).
     private static let consumerActiveNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-active"
+        CameraExtensionNotifications.consumerActive
     private static let consumerInactiveNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-inactive"
+        CameraExtensionNotifications.consumerInactive
     private static let queryConsumerStateNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.query-consumer-state"
+        CameraExtensionNotifications.queryConsumerState
 
     /// Time we keep the host capture pipeline warm after the last
     /// AVCapture client disconnects. Bridges back-to-back Zoom calls

--- a/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
+++ b/Sources/AVPainRelieverCameraExtension/CameraExtensionStream.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreMediaIO
 import CoreMedia
+import AVPainRelieverSharedConstants
 import os.log
 
 private let logger = Logger(
@@ -15,22 +16,18 @@ private let logger = Logger(
 /// to the sink; the device source forwards each consumed frame
 /// here via `stream.send(...)`.
 final class CameraExtensionStreamSource: NSObject, CMIOExtensionStreamSource {
-    /// Darwin notification names used to tell the host whether any
-    /// AVCapture client is currently reading the source. The host
-    /// uses this to gate its real-camera capture pipeline (and
-    /// therefore the macOS green camera light): pipeline runs only
-    /// while a consumer is connected, plus a grace window after the
-    /// last one disconnects. Names are Team-ID-prefixed so the
-    /// sandbox lets this extension post them.
+    /// Re-exports of the shared notification names so existing
+    /// `Self.consumerActiveNotification` call sites in this file
+    /// keep their current spellings. The canonical strings live in
+    /// `AVPainRelieverSharedConstants`, which both this extension
+    /// and the host's `VirtualCameraActivator` link statically —
+    /// no hand-mirroring across the two binaries.
     static let consumerActiveNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-active"
+        CameraExtensionNotifications.consumerActive
     static let consumerInactiveNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-inactive"
-    /// Sent by the host when it (re)starts observing — extension
-    /// responds by re-posting the current state so a host that
-    /// missed the most recent transition can seed its initial value.
+        CameraExtensionNotifications.consumerInactive
     static let queryConsumerStateNotification =
-        "HLH4LEWS9S.com.ericwillis.avpainreliever.query-consumer-state"
+        CameraExtensionNotifications.queryConsumerState
 
     private(set) var stream: CMIOExtensionStream!
     private let streamFormat: CMIOExtensionStreamFormat

--- a/Sources/AVPainRelieverSharedConstants/CameraExtensionNotifications.swift
+++ b/Sources/AVPainRelieverSharedConstants/CameraExtensionNotifications.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Darwin-notification name strings exchanged between the host app
+/// (`VirtualCameraActivator`) and the embedded Camera Extension
+/// (`CameraExtensionStreamSource`). The extension is a separate
+/// sandboxed executable that doesn't link against the engine
+/// library, so this small target sits underneath both and gets
+/// statically linked into each.
+///
+/// Names are Team-ID-prefixed so the extension's sandbox lets it
+/// post / observe them. Changing the prefix means rebuilding both
+/// binaries — there is no schema-evolution path here, just a
+/// hand-shake contract.
+public enum CameraExtensionNotifications {
+    /// Posted by the extension when an AVCapture client connects to
+    /// the source stream. The host gates its real-camera capture
+    /// pipeline on this signal so the macOS green camera light only
+    /// turns on when something is actually reading frames.
+    public static let consumerActive =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-active"
+
+    /// Posted by the extension after the last AVCapture client
+    /// disconnects. The host treats this as "tear-down candidate"
+    /// and runs a grace-window timer before actually stopping its
+    /// pipeline (cheap re-arm for back-to-back calls).
+    public static let consumerInactive =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.consumer-inactive"
+
+    /// Posted by the host when it (re)starts observing — the
+    /// extension responds by re-broadcasting the current
+    /// consumer-active value so a host that missed the most recent
+    /// transition can seed its initial state.
+    public static let queryConsumerState =
+        "HLH4LEWS9S.com.ericwillis.avpainreliever.query-consumer-state"
+}


### PR DESCRIPTION
## Summary

Slop-review follow-up #13 — eliminates the cross-binary hand-mirror of three Darwin notification name strings that the host app and the embedded Camera Extension exchange.

**Before:** \`VirtualCameraActivator\` (host) and \`CameraExtensionStreamSource\` (extension) each hardcoded the same three Team-ID-prefixed strings (\`consumer-active\`, \`consumer-inactive\`, \`query-consumer-state\`), with a "keep in sync by hand" comment in each file. A single typo on either side would silently break the consumer-watch handshake — the host's capture pipeline gates on these signals, so a mismatch means the macOS green camera light gets stuck on, or never lights up at all.

**After:** the three constants live in a new pure-Swift SPM target both binaries depend on.

## New target: \`AVPainRelieverSharedConstants\`

\`\`\`swift
public enum CameraExtensionNotifications {
    public static let consumerActive: String
    public static let consumerInactive: String
    public static let queryConsumerState: String
}
\`\`\`

- No platform APIs, no third-party deps. Pure Swift constants module.
- Lives in its own SPM target rather than inside \`AVPainReliever\` because the Camera Extension target deliberately doesn't depend on the engine library (separate sandbox, separate signing, separate executable).
- Both \`AVPainRelieverApp\` and \`AVPainRelieverCameraExtension\` list it as a dependency. SPM links it statically into each binary — no extra runtime artifact, no notarization-bundle changes.

## Consumer updates

- **\`VirtualCameraActivator\`** (host): import the new module; the three private static constants now forward to \`CameraExtensionNotifications\`, so every \`Self.consumerActiveNotification\` call site keeps its current spelling.
- **\`CameraExtensionStreamSource\`** (extension): same — import + forward. The static-on-the-type spelling \`Self.consumerActiveNotification\` is preserved because other code in the extension target already references it that way.

## Test plan

- [x] \`swift build\` — both \`AVPainRelieverApp\` and \`AVPainRelieverCameraExtension\` link cleanly with the new shared target
- [x] \`swift test\` — **183 tests pass** (same baseline)
- [ ] Hands-on: launch via \`./dev/build --full\`, enable the virtual camera, point Zoom (or FaceTime / Photo Booth) at "AV Pain Reliever," and confirm the consumer-watch handshake still works:
  - Opening the consumer should make the macOS green camera light come on (host kicks off capture in response to \`consumerActive\`)
  - Closing the consumer should turn the light off after the 30s grace window (\`consumerInactive\` + grace timer)
  - The \`queryConsumerState\` round-trip happens at host start; you should see one extension log line in response on each app launch

This is a build-system + linkage change, so the only realistic regression mode is "the extension can't link the new module" or "the constants don't match what the running OS posts." First is caught by \`swift build\`; second by the live handshake test above.

## Out of scope

- The Team-ID prefix \`HLH4LEWS9S\` is still inline in the constant strings. Darwin notifications under sandboxing require that exact name shape — the prefix is load-bearing at runtime. CLAUDE.md's "no team ID in public-repo content" rule is in tension with that technical requirement; the posture is unchanged from before this PR (the constants are just consolidated rather than duplicated). Resolving that tension is a separate decision.

## Net diff

4 files, **+71 / -22 LOC** (the new shared-target file is most of the additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)