### PR TITLE
docs: carve out a narrow team-ID exception in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ This workspace contains **two independent git repos**:
 - **Public repo** (`superic/av-pain-reliever`) — the project tree at the root. CI / Sparkle / public releases.
 - **Private dev repo** (`superic/av-pain-reliever-dev`) — cloned into `dev/`, gitignored from the public repo. Contains the local build helper (`dev/build`), credentials config, and recovery docs. See `dev/README.md` (private) for setup, recovery, and the cert / notary / Sparkle-key dance.
 
-Never put the cert name, team ID, or anything personal-credential-shaped into public-repo content. See `dev/README.md` for what lives in private.
+Never put the cert name or anything credential-shaped (signing identity passwords, notary keychain profile names, Sparkle EdDSA private keys) into public-repo content. See `dev/README.md` for what lives in private.
+
+The team ID gets a narrow carve-out: macOS sandboxing requires team-ID-prefixed names for some runtime APIs (Darwin notification names posted from a Camera Extension or other sandboxed extensions, App Group identifiers, mach service names, keychain access groups). Those uses are load-bearing — the OS rejects calls without the prefix — so the team ID stays inline at those specific call sites. It's not a credential (it can't be used to sign code on its own) and it's already embedded in every shipping signed binary plus the appcast XML signatures. The rule is "no new exposure where the OS doesn't require it" — utility scripts, CI configs, and prose still keep the team ID out.
 
 ## Where to look for what
 


### PR DESCRIPTION
## Summary

The "no team ID in public-repo content" rule in CLAUDE.md is in tension with macOS sandboxing requirements. Some runtime APIs require Team-ID-prefixed names — the OS rejects calls that don't carry the prefix:

- **Darwin notification names** posted from a sandboxed extension (e.g. our Camera Extension's \`consumerActive\` / \`consumerInactive\` / \`queryConsumerState\` notifications)
- **App Group identifiers**
- **mach service names**
- **keychain access groups**

The current code already inlines the prefix at those sites because the alternative is "the runtime handshake silently breaks." Adjacent PR #48 just consolidated the three Camera-Extension notification strings into a shared SPM target — surfacing this tension between the rule and the technical requirement.

## Resolution

Carve out a narrow exception: keep the rule for credential-shaped values (signing identity passwords, notary keychain profile names, Sparkle EdDSA private keys) and incidental exposure (utility scripts, CI configs, prose). Allow the team ID inline at runtime call sites where the platform requires it.

The team ID is also already embedded in every shipping signed binary and in the appcast XML signatures, so source-code references at sandbox-required sites add no new exposure beyond what's already public via the release artifacts.

## Net diff

1 file, +3 / -1 LOC. Pure docs.

## Test plan

- [x] Re-read the updated paragraph: keeps the prohibition for credential-shaped values; explicitly scopes the team-ID exception to runtime call sites where the OS requires the prefix; calls out that the team ID is already in shipping artifacts so the carve-out adds no new exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)