### PR TITLE
cleanup: engine doc sweep + named log-rate constants

### DIFF
--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -35,14 +35,14 @@ public struct CameraSummary: Hashable, Sendable, Identifiable {
 ///   "preferred default camera." AVFoundation-modern apps (FaceTime,
 ///   browser `getUserMedia`, native AVCapture clients) pick it up
 ///   automatically.
-/// - Apps with their own camera-selection UI (Zoom, Slack, Teams,
-///   OBS) maintain their OWN selection independently. The engine
+/// - Apps with their own camera-selection UI (Zoom, Slack, Teams)
+///   maintain their OWN selection independently. The engine
 ///   intentionally does NOT try to drive those — no plist hacks, no
-///   UI scripting. For users who need Zoom/Slack to follow the
-///   profile too, V2's OBS support will let them route through OBS
-///   Virtual Camera (configure OBS once with a per-scene camera,
-///   point Zoom/Slack at OBS Virtual Camera once, OBS scene switch
-///   handles the rest).
+///   UI scripting. For those, the V2 native virtual camera
+///   (`VirtualCameraSourceController` below) is the bridge: the user
+///   selects "AV Pain Reliever" once in each app's picker, and the
+///   active profile drives which real camera the virtual camera
+///   streams from.
 public protocol CameraController {
     /// Set the system's `userPreferredCamera` to the camera with the
     /// given `localizedName`. Returns `.notFound` if no such camera

--- a/Sources/AVPainReliever/Adapters/Notifier.swift
+++ b/Sources/AVPainReliever/Adapters/Notifier.swift
@@ -274,15 +274,19 @@ public final class UserNotificationsNotifier: NSObject, Notifier, UNUserNotifica
 }
 #endif
 
-/// Production notifier that shells out to `osascript` to display a
-/// notification. Works without a bundle identifier — `osascript`
-/// posts as itself, which the user has already approved (or will be
-/// prompted to approve once) for notifications.
+/// `swift run` dev fallback notifier that shells out to `osascript`
+/// to display a notification. Works without a bundle identifier —
+/// `osascript` posts as itself, which the user has already approved
+/// (or will be prompted to approve once) for notifications.
 ///
-/// We'll replace this with `UNUserNotificationCenter` when the menu-
-/// bar app ships as a signed `.app` with a `CFBundleIdentifier`.
-/// Until then, this gets us "Switched to X" toasts during dev
-/// without the bundle/auth dance.
+/// `UNUserNotificationCenter` (the production path in
+/// `UserNotificationsNotifier` above) requires a bundle id, so it
+/// rejects unbundled processes outright. AppDelegate picks this
+/// implementation when `Bundle.main.bundleIdentifier` is nil — i.e.
+/// the `swift run AVPainRelieverApp` dev-loop case. The signed
+/// `.app` always uses `UserNotificationsNotifier`. Action buttons,
+/// custom icons, and `onAction` callbacks aren't supported here —
+/// `osascript` only renders title + body.
 public struct AppleScriptNotifier: Notifier {
     public init() {}
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
@@ -69,6 +69,14 @@ public final class CMIOSinkWriter {
     private static let outputHeight: Int = 720
     private static let outputFormat: OSType = kCVPixelFormatType_32BGRA
 
+    /// Log-rate-limit cadences. Heartbeat fires every Nth successful
+    /// enqueue so the log shows the pipeline is alive without one
+    /// line per frame; reject cadence fires every Nth rejected
+    /// enqueue so a steady-state queue-full pattern is visible
+    /// without flooding.
+    private static let enqueueHeartbeatStride: UInt64 = 60
+    private static let enqueueRejectStride: UInt64 = 30
+
     public init(deviceUID: String) {
         self.deviceUID = deviceUID
     }
@@ -180,7 +188,7 @@ public final class CMIOSinkWriter {
             // we just gave it so the buffer doesn't leak.
             Unmanaged<CMSampleBuffer>.fromOpaque(retained).release()
             enqueueRejectCount += 1
-            if enqueueRejectCount % 30 == 1 {
+            if enqueueRejectCount % Self.enqueueRejectStride == 1 {
                 logger.error(
                     "CMSimpleQueueEnqueue rejected (rejects=\(self.enqueueRejectCount)/\(self.enqueueCount), status=\(enqueueStatus))"
                 )
@@ -189,7 +197,7 @@ public final class CMIOSinkWriter {
         }
 
         enqueueCount += 1
-        if enqueueCount == 1 || enqueueCount % 60 == 0 {
+        if enqueueCount == 1 || enqueueCount % Self.enqueueHeartbeatStride == 0 {
             logger.info(
                 "Enqueued frame #\(self.enqueueCount, privacy: .public) (rejects=\(self.enqueueRejectCount, privacy: .public))"
             )

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -42,6 +42,12 @@ public final class CameraCaptureSession: NSObject {
     private var currentInput: AVCaptureDeviceInput?
     private var currentDeviceUniqueID: String?
 
+    /// Log-rate-limit cadence for the "sink writer still not ready"
+    /// retry path. Capture is steady-state at 30 fps, so every Nth
+    /// frame is roughly one log line per N/30 seconds while the
+    /// extension is missing — informative without flooding.
+    private static let sinkRetryLogStride: UInt64 = 90
+
     /// Camera the active profile wanted as the source at session-
     /// boot time. The activator remembers the most recent
     /// `setSource(named:)` request and passes it here so that when
@@ -353,7 +359,7 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
             sinkStarted = sink.start()
             if sinkStarted {
                 logger.info("Sink writer connected on retry (after \(self.capturedFrameCount, privacy: .public) frames)")
-            } else if capturedFrameCount % 90 == 1 {
+            } else if capturedFrameCount % Self.sinkRetryLogStride == 1 {
                 logger.error("Sink writer still not ready after \(self.capturedFrameCount, privacy: .public) frames")
             }
             if !sinkStarted { return }

--- a/Sources/AVPainReliever/Config/ConfigLoader.swift
+++ b/Sources/AVPainReliever/Config/ConfigLoader.swift
@@ -43,10 +43,8 @@ public enum ConfigError: Error, Equatable {
 ///
 /// All body fields are optional. Inside a fingerprint entry, `vendorID`
 /// and `productID` are required; `name` is for human reading and is
-/// ignored at match time. Unknown fields (including legacy
-/// `obsScene` entries left behind by an earlier OBS-routing
-/// experiment) are silently ignored, so V1 reads V2-and-beyond TOML
-/// cleanly minus features it doesn't know.
+/// ignored at match time. Unknown fields are silently ignored, so V1
+/// reads V2-and-beyond TOML cleanly minus features it doesn't know.
 ///
 /// The top-level `[profiles.<name>]` namespace reserves the file's top
 /// level for future settings (debounce override, log path, etc.) without

--- a/Sources/AVPainReliever/Config/Profile.swift
+++ b/Sources/AVPainReliever/Config/Profile.swift
@@ -3,10 +3,7 @@ import Foundation
 /// A location profile — a named set of USB devices (the "fingerprint")
 /// that, when all simultaneously attached, identifies the location,
 /// plus the audio + camera settings the engine should apply when that
-/// profile wins.
-///
-/// All apply-time fields are optional. OBS scene-switching is
-/// intentionally omitted from V1; planned for V2.
+/// profile wins. All apply-time fields are optional.
 public struct Profile: Hashable, Sendable {
     /// The slug-cased profile name, e.g. `"home-office"`. Pretty-cased
     /// to "Home Office" at notification time, not here.
@@ -30,11 +27,11 @@ public struct Profile: Hashable, Sendable {
     /// or nil to leave camera selection untouched. AVFoundation-modern
     /// apps (FaceTime, browser getUserMedia, native AVCapture clients)
     /// pick this up automatically; apps with their own camera UI
-    /// (Zoom, Slack) maintain their own selection independently — the
-    /// engine intentionally does NOT try to drive those (no plist
-    /// hacks, no UI-scripting). For users who want Zoom/Slack to
-    /// follow the profile too, V2's planned OBS support will let them
-    /// route through OBS Virtual Camera.
+    /// (Zoom, Slack) maintain their own selection independently. For
+    /// those, the V2 native virtual camera (`VirtualCameraSourceController`)
+    /// covers them — they select "AV Pain Reliever" once and the
+    /// active profile drives which real camera the virtual one
+    /// streams from.
     public let camera: String?
 
     /// User-picked SF Symbol name to display next to this profile's

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -17,10 +17,6 @@ public protocol ApplierLogger {
 /// responsible for resolving the right profile (`ProfileResolver`),
 /// debouncing USB bursts (`Debouncer`), and choosing a fallback when
 /// no profile matches. The applier just executes the side effects.
-///
-/// OBS scene-switching is intentionally not part of V1; planned for
-/// V2. When it lands, it'll arrive as a separate optional injectable
-/// alongside `AudioController` and `CameraController`.
 public final class ProfileApplier {
     private let audio: AudioController
     private let camera: CameraController?
@@ -95,9 +91,9 @@ public final class ProfileApplier {
 
     private func applyCamera(_ name: String) {
         // No CameraController configured (e.g., older macOS, or
-        // construction-time decision). Same convention as the V1
-        // OBS removal: the configuration layer announces the
-        // limitation; per-profile we silently skip.
+        // construction-time decision). Per-profile we silently skip;
+        // the configuration layer is responsible for announcing the
+        // limitation if it matters.
         guard let camera else { return }
         switch camera.setPreferred(named: name) {
         case .ok:


### PR DESCRIPTION
## Summary

First PR from the slop-review pass on \`Sources/AVPainReliever/\`. Pure hygiene — no behavior changes; same 183/183 tests pass before and after.

Three small clusters land together:

### 1. OBS-V2 ghost narrative (highest-confidence finding)

The engine library carried six doc comments across four files still pitching OBS scene-switching as the V2 plan. V2 actually shipped as the native CMIO Camera Extension (per \`docs/virtual-camera.md\`, retired the OBS plan 2026-05-04). The doc rot was inconsistent with both the shipped code and CLAUDE.md's "no third-party tool in docs" rule. **All four slop-review lenses converged on this cluster** — six hits across five files made it the highest-confidence finding in the calibrated report.

- \`Config/Profile.swift\` — drop "OBS scene-switching is intentionally omitted from V1; planned for V2" header; replace the camera property's "V2's planned OBS support" paragraph with a present-tense reference to \`VirtualCameraSourceController\`.
- \`Engine/ProfileApplier.swift\` — drop the type-level "planned for V2" paragraph; rewrite the \`applyCamera\` comment that invoked an imagined "V1 OBS removal" precedent (which never happened).
- \`Adapters/CameraController.swift\` — rewrite the "V2's OBS support will let them route through OBS Virtual Camera" paragraph to describe the actual virtual-camera bridge that ships today.
- \`Config/ConfigLoader.swift\` — drop the fabricated "legacy \`obsScene\` entries left behind by an earlier OBS-routing experiment" parenthetical. Schema-tolerance behavior is unchanged.

### 2. Stale "we'll replace this" comment

\`Adapters/Notifier.swift:282-285\` — \`AppleScriptNotifier\`'s docstring promised a replacement that already shipped (\`UserNotificationsNotifier\` in the same file). Rewrote to describe its actual current role: \`swift run\` dev fallback when \`Bundle.main.bundleIdentifier\` is nil.

### 3. Magic numbers named

- \`Adapters/VirtualCamera/CMIOSinkWriter.swift\` — extract \`enqueueHeartbeatStride\` (60) and \`enqueueRejectStride\` (30) as named static constants. The previous bare \`% 60 == 0\` and \`% 30 == 1\` checks read as ad-hoc.
- \`Adapters/VirtualCamera/CameraCaptureSession.swift\` — extract \`sinkRetryLogStride\` (90) for the "sink writer still not ready" retry path.

## Net diff

7 files, **+47 / -38 LOC**.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — **183 tests pass** (same baseline as before)

**Hands-on smoke test.** Nothing in this PR is user-visible (pure docs + named constants with values preserved byte-for-byte), so the bar is "the app behaves the same as it did before."

1. Build + install:
   \`\`\`
   ./dev/build --full
   \`\`\`
   Expected: build succeeds, app launches, menu bar icon appears.
2. **Profile switch still works.** Replug the dock that triggers one of your real profiles (e.g. home office). Expected: within ~1.5 s the menu bar updates to the new profile name, the menu bar icon swaps if you have per-profile icons enabled, and your audio defaults switch to that profile's input/output.
3. **Notifications still post.** Same step as #2 — expected: a "Switched to <Profile Name>" notification appears in the macOS Notification Center top-right.
4. **Virtual camera still works** (if you have it enabled): open Photo Booth or FaceTime, select "AV Pain Reliever" as the camera, expected: live video frames from your active profile's camera. Trigger another profile switch (replug the dock); the camera should swap source within a second or two.
5. **(Optional) Confirm log cadences are unchanged.** In a separate terminal:
   \`\`\`
   log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever"' --info --style compact
   \`\`\`
   With the virtual camera live, expected log lines:
   - "Enqueued frame #N" — every 60 frames (about every 2 s at 30 fps)
   - If the queue ever rejects: "CMSimpleQueueEnqueue rejected" — every 30 rejections
   - If the extension hasn't published yet: "Sink writer still not ready" — every 90 captured frames
   These cadences are byte-equivalent to before this PR; the named constants (\`enqueueHeartbeatStride\` / \`enqueueRejectStride\` / \`sinkRetryLogStride\`) just give the literals names.

If any of steps 1–4 don't match expectations, that's a regression — but I don't expect any: the diff doesn't touch any code path, only doc comments and three integer literals → named-constant references with the same values.

## What's queued for next PRs

- **PR #2:** \`ProfileWriteError.missingProfile\` case + \`CameraDiscovery\` enum hoist + \`FourCC.pretty\` helper (mechanical refactors)
- **PR #3:** \`ApplierLogger.error\` + thread through CMIO files (protocol surface change)
- **PR #4:** Move \`Notifier\`'s impls (\`UserNotificationsNotifier\` + \`AppleScriptNotifier\`) to the app target so the engine library stops importing AppKit (architectural relocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)