### PR TITLE
refactor: ProfileWriteError.missingProfile + CameraDiscovery + FourCC helpers

### DIFF
--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -117,7 +117,7 @@ public struct AVFoundationCameraController: CameraController {
     public init() {}
 
     public func setPreferred(named: String) -> CameraApplyResult {
-        let devices = Self.discoverySession().devices
+        let devices = CameraDiscovery.session().devices
         guard let device = devices.first(where: { $0.localizedName == named }) else {
             return .notFound
         }
@@ -126,7 +126,7 @@ public struct AVFoundationCameraController: CameraController {
     }
 
     public func availableCameras() -> [CameraSummary] {
-        Self.discoverySession()
+        CameraDiscovery.session()
             .devices
             .map { CameraSummary(name: $0.localizedName) }
             .sorted { $0.name < $1.name }
@@ -153,26 +153,6 @@ public struct AVFoundationCameraController: CameraController {
         if let system = AVCaptureDevice.systemPreferredCamera {
             return system.localizedName
         }
-        return Self.discoverySession().devices.first?.localizedName
-    }
-
-    private static func discoverySession() -> AVCaptureDevice.DiscoverySession {
-        // Include every camera type that surfaces on macOS 14+:
-        //   - builtInWideAngleCamera: the Mac's own webcam
-        //   - external: USB / Thunderbolt cameras (LG UltraFine,
-        //     capture cards routed as cameras, etc.)
-        //   - continuityCamera: iPhone-as-webcam
-        //   - deskViewCamera: Apple's perspective-corrected
-        //     ultra-wide variant
-        AVCaptureDevice.DiscoverySession(
-            deviceTypes: [
-                .builtInWideAngleCamera,
-                .external,
-                .continuityCamera,
-                .deskViewCamera,
-            ],
-            mediaType: .video,
-            position: .unspecified
-        )
+        return CameraDiscovery.session().devices.first?.localizedName
     }
 }

--- a/Sources/AVPainReliever/Adapters/CameraDiscovery.swift
+++ b/Sources/AVPainReliever/Adapters/CameraDiscovery.swift
@@ -1,0 +1,36 @@
+import AVFoundation
+
+/// Single source of truth for `AVCaptureDevice.DiscoverySession`
+/// configuration shared across the engine's camera adapters.
+///
+/// `AVFoundationCameraController` (sets `userPreferredCamera` for
+/// AVFoundation-modern apps) and `CameraCaptureSession` (the host
+/// capture pipeline that feeds the virtual camera) both need to
+/// enumerate the same device-type set. Centralising the list here
+/// keeps them in lockstep when the supported camera kinds evolve
+/// (e.g. when Apple adds another `AVCaptureDevice.DeviceType`).
+///
+/// The session is constructed fresh on every call — sessions are
+/// cheap (microseconds) and we want fresh results when the user
+/// docks a Continuity Camera mid-wizard.
+enum CameraDiscovery {
+    /// Includes every camera type that surfaces on macOS 14+:
+    ///   - `builtInWideAngleCamera`: the Mac's own webcam
+    ///   - `external`: USB / Thunderbolt cameras (LG UltraFine,
+    ///     capture cards routed as cameras, etc.)
+    ///   - `continuityCamera`: iPhone-as-webcam
+    ///   - `deskViewCamera`: Apple's perspective-corrected
+    ///     ultra-wide variant
+    static func session() -> AVCaptureDevice.DiscoverySession {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .external,
+                .continuityCamera,
+                .deskViewCamera,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+    }
+}

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
@@ -437,12 +437,7 @@ public final class CMIOSinkWriter {
         )
         if signature == lastLoggedInputSignature { return }
         lastLoggedInputSignature = signature
-        let fourcc = String(bytes: [
-            UInt8((signature.0 >> 24) & 0xFF),
-            UInt8((signature.0 >> 16) & 0xFF),
-            UInt8((signature.0 >> 8) & 0xFF),
-            UInt8(signature.0 & 0xFF),
-        ], encoding: .ascii) ?? "????"
+        let fourcc = FourCC.pretty(signature.0)
         let needsConversion = signature.0 != Self.outputFormat
             || signature.1 != Self.outputWidth
             || signature.2 != Self.outputHeight

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -217,7 +217,7 @@ public final class CameraCaptureSession: NSObject {
         {
             return system
         }
-        return Self.discoverySession().devices
+        return CameraDiscovery.session().devices
             .first { !Self.isVirtualCamera($0) }
     }
 
@@ -313,22 +313,9 @@ public final class CameraCaptureSession: NSObject {
     }
 
     private static func findDevice(named name: String) -> AVCaptureDevice? {
-        discoverySession().devices.first {
+        CameraDiscovery.session().devices.first {
             $0.localizedName == name && !isVirtualCamera($0)
         }
-    }
-
-    private static func discoverySession() -> AVCaptureDevice.DiscoverySession {
-        AVCaptureDevice.DiscoverySession(
-            deviceTypes: [
-                .builtInWideAngleCamera,
-                .external,
-                .continuityCamera,
-                .deskViewCamera,
-            ],
-            mediaType: .video,
-            position: .unspecified
-        )
     }
 }
 
@@ -342,14 +329,7 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
         if capturedFrameCount == 1, let pb = CMSampleBufferGetImageBuffer(sampleBuffer) {
             let w = CVPixelBufferGetWidth(pb)
             let h = CVPixelBufferGetHeight(pb)
-            let pf = CVPixelBufferGetPixelFormatType(pb)
-            // Pretty-print FourCC
-            let fourcc = String(bytes: [
-                UInt8((pf >> 24) & 0xFF),
-                UInt8((pf >> 16) & 0xFF),
-                UInt8((pf >> 8) & 0xFF),
-                UInt8(pf & 0xFF)
-            ], encoding: .ascii) ?? "????"
+            let fourcc = FourCC.pretty(CVPixelBufferGetPixelFormatType(pb))
             logger.info("First frame from webcam: \(w, privacy: .public)x\(h, privacy: .public) format=\(fourcc, privacy: .public)")
         }
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/FourCC.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/FourCC.swift
@@ -1,0 +1,22 @@
+import CoreVideo
+
+/// Pretty-print helper for `OSType` four-character codes
+/// (`kCVPixelFormatType_*`, FourCC media tags, etc.). The host's
+/// capture pipeline and the CMIO sink writer both log incoming pixel
+/// formats this way; centralising the conversion keeps the log
+/// output consistent and avoids per-call-site byte-shift gymnastics.
+enum FourCC {
+    /// Render a four-character code as a 4-byte ASCII string.
+    /// Returns "????" if any byte isn't printable ASCII (which
+    /// shouldn't happen for real CV/CM format types — they're all
+    /// human-typed FourCCs by design).
+    static func pretty(_ code: OSType) -> String {
+        let bytes: [UInt8] = [
+            UInt8((code >> 24) & 0xFF),
+            UInt8((code >> 16) & 0xFF),
+            UInt8((code >> 8) & 0xFF),
+            UInt8(code & 0xFF),
+        ]
+        return String(bytes: bytes, encoding: .ascii) ?? "????"
+    }
+}

--- a/Sources/AVPainReliever/Config/ProfileWriter.swift
+++ b/Sources/AVPainReliever/Config/ProfileWriter.swift
@@ -6,6 +6,11 @@ public enum ProfileWriteError: Error, Equatable {
     /// target file. Caller decides whether to ask the user to pick a
     /// new name or replace.
     case duplicateProfile(name: String)
+    /// `delete` or `replace` was called for a section the caller
+    /// expected to be present, but it wasn't found in the file. In
+    /// practice this means a concurrent edit removed the section
+    /// between the caller's collision check and the write.
+    case missingProfile(name: String)
     /// The new profile's `name` isn't a legal TOML bare key
     /// (alphanumerics, hyphen, underscore only). Quoting would work
     /// but we keep names simple so they look clean in the file AND in
@@ -123,10 +128,9 @@ public struct ProfileWriter {
     /// `url`. The section header line through everything before the
     /// next `[...]` section (or end of file) is excised; surrounding
     /// content (other profiles, header banner, comments) is preserved.
-    /// Throws `.duplicateProfile` (re-using the "expected this section
-    /// to be present, it wasn't" code path) when the section is
-    /// missing — the caller has already established it's there, so
-    /// missing means a concurrent edit raced us.
+    /// Throws `.missingProfile` when the section isn't found — the
+    /// caller has already established it's there, so missing means a
+    /// concurrent edit raced us.
     public func delete(named name: String, in url: URL) throws {
         let validatedName = try Self.validateName(name)
         guard FileManager.default.fileExists(atPath: url.path) else {
@@ -141,7 +145,7 @@ public struct ProfileWriter {
             )
         }
         guard let span = Self.sectionRange(named: validatedName, in: existing) else {
-            throw ProfileWriteError.duplicateProfile(name: validatedName)
+            throw ProfileWriteError.missingProfile(name: validatedName)
         }
         var output = existing
         output.replaceSubrange(span, with: "")
@@ -167,8 +171,9 @@ public struct ProfileWriter {
     ///
     /// `profile.name` must equal the existing section's name — the
     /// caller has already established this is the section to replace.
-    /// Throws `.duplicateProfile` if no matching section is found
-    /// (use `append` for the new-profile case).
+    /// Throws `.missingProfile` if no matching section is found —
+    /// in practice this means a concurrent edit raced the caller's
+    /// collision check (use `append` for the genuine new-profile case).
     public func replace(
         profile: Profile,
         deviceNames: [USBDevice: String?] = [:],
@@ -188,11 +193,12 @@ public struct ProfileWriter {
         }
         guard let span = Self.sectionRange(named: validatedName, in: existing) else {
             // Caller invariant: replace assumes the section is there.
-            // Surface this as duplicateProfile-shaped because the
-            // higher-level wizard already routed here based on a
-            // collision check; if the file changed under us, fall
-            // back to caller-handled flow.
-            throw ProfileWriteError.duplicateProfile(name: validatedName)
+            // If the file changed under us between the higher-level
+            // collision check and this write, surface that as
+            // .missingProfile so the wizard's catch site can route
+            // to the "section disappeared, ask the user what to do"
+            // recovery flow.
+            throw ProfileWriteError.missingProfile(name: validatedName)
         }
         let rendered = Self.render(profile: profile, deviceNames: deviceNames)
         var output = existing

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -520,6 +520,11 @@ final class AddProfileViewModel: ObservableObject {
             // Race: collision check passed but the file changed
             // before write. Surface it.
             lastError = "Couldn't save: profile \"\(PrettyName.format(name))\" already exists."
+        } catch let ProfileWriteError.missingProfile(name) {
+            // Race: replace expected the section to be there but
+            // someone (the user editing the TOML by hand, another
+            // tool) removed it between collision check and write.
+            lastError = "Couldn't save: profile \"\(PrettyName.format(name))\" is no longer in the config — try Add Profile instead."
         } catch let ProfileWriteError.invalidName(name) {
             lastError = "Couldn't save: \"\(name)\" isn't a valid profile name."
         } catch let ProfileWriteError.writeFailed(reason) {

--- a/Tests/AVPainRelieverTests/ProfileWriterTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileWriterTests.swift
@@ -278,7 +278,7 @@ struct ProfileWriterTests {
         #expect(Set(loaded.map(\.name)) == ["laptop", "studio"])
     }
 
-    @Test("delete on a missing section raises duplicateProfile")
+    @Test("delete on a missing section raises missingProfile")
     func deleteOnMissingSectionThrows() throws {
         let url = tempTOMLURL()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -289,11 +289,11 @@ struct ProfileWriterTests {
 
         do {
             try writer.delete(named: "home-office", in: url)
-            Issue.record("expected duplicateProfile for missing section")
-        } catch ProfileWriteError.duplicateProfile {
-            // expected
+            Issue.record("expected missingProfile for missing section")
+        } catch let ProfileWriteError.missingProfile(name) {
+            #expect(name == "home-office")
         } catch {
-            Issue.record("expected duplicateProfile, got \(error)")
+            Issue.record("expected missingProfile, got \(error)")
         }
     }
 


### PR DESCRIPTION
## Summary

Three mechanical refactors from the slop-review's borderline tier, landed together. All single-purpose; no behavior changes; **same 183/183 tests pass**.

### 1. \`ProfileWriteError.missingProfile\`

\`ProfileWriter.delete(named:)\` and \`ProfileWriter.replace(profile:)\` were reusing \`.duplicateProfile\` to signal "the section you asked me to mutate isn't here." That's the inverse of what \`.duplicateProfile\` means in \`append\` ("section already exists, can't add again"). Doc comments in both methods apologized for the misuse — the calibration's exact "apologetic-comment-as-AI-tell" pattern.

Added a proper case:
\`\`\`swift
public enum ProfileWriteError: Error, Equatable {
    case duplicateProfile(name: String)
    case missingProfile(name: String)   // new
    case invalidName(String)
    case writeFailed(reason: String)
}
\`\`\`

- \`delete\` and \`replace\` now throw \`.missingProfile(name:)\` when the named section isn't present.
- \`AddProfileViewModel\` gains a catch arm that surfaces "profile X is no longer in the config — try Add Profile instead" instead of routing the missing-section race through the duplicate-name copy.
- \`AppDelegate.deleteProfile\`'s generic \`catch\` already handled this transparently — no edit needed there.
- The existing test \`delete on a missing section\` now asserts \`.missingProfile\` and verifies the name payload.

### 2. \`CameraDiscovery\` enum

\`AVFoundationCameraController\` and \`CameraCaptureSession\` each declared a private static \`discoverySession()\` with the same 4-element device-types array (\`.builtInWideAngleCamera\`, \`.external\`, \`.continuityCamera\`, \`.deskViewCamera\`). Hoisted into a new internal-scoped enum in \`Sources/AVPainReliever/Adapters/CameraDiscovery.swift\`:

\`\`\`swift
enum CameraDiscovery {
    static func session() -> AVCaptureDevice.DiscoverySession { ... }
}
\`\`\`

Both adapters now call \`CameraDiscovery.session()\`. Future device-type additions (e.g. when Apple ships another \`AVCaptureDevice.DeviceType\`) land in one place. Per-adapter filters (\`CameraCaptureSession\`'s \`!isVirtualCamera\` check) stay local — they're each adapter's concern.

### 3. \`FourCC.pretty()\` helper

\`CameraCaptureSession.captureOutput(_:didOutput:from:)\` and \`CMIOSinkWriter.logIncomingFormatIfChanged(pixelBuffer:)\` had byte-identical 4-byte big-endian \`OSType\` → ASCII string blocks for log output. Extracted as \`FourCC.pretty(_:)\` in \`Sources/AVPainReliever/Adapters/VirtualCamera/FourCC.swift\`. Both call sites now read as one line; ASCII fallback is \`"????"\` as before.

## Net diff

8 files, **+93 / -69 LOC** (two new tiny helper files + significant deletions in the two adapter files).

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — **183 tests pass** (same baseline; the existing \`delete on a missing section\` test now asserts \`.missingProfile\` instead of \`.duplicateProfile\`)

**Hands-on verification.** Build and install:

\`\`\`
./dev/build --full
\`\`\`

Then walk through:

1. **App launches normally.** Menu bar icon appears. Active profile applies.
2. **Wizard works.** Open Settings → Profiles, click an existing profile to edit it. Save without changes — should write back cleanly. (This exercises \`ProfileWriter.replace\` through the happy path; the new error case fires only on a race condition that's hard to trigger manually.)
3. **Delete a profile.** Settings → Profiles → swipe-or-right-click a profile → Delete. Confirm. The profile disappears from the list and from the menu bar's Switch To submenu. (Exercises \`AppDelegate.deleteProfile\` → \`ProfileWriter.delete\` happy path. The new error case is the "what if someone manually edited the TOML between this dialog opening and Delete being clicked" race.)
4. **Camera picker shows the same cameras as before.** Open the wizard, get to the camera step, confirm the picker shows the cameras you'd expect (built-in webcam, any external USB cameras, an iPhone if it's nearby and Continuity Camera-eligible). Both the wizard's picker (uses \`AVFoundationCameraController.availableCameras\`) and the virtual camera's source switching (uses \`CameraCaptureSession.findDevice\`) now share \`CameraDiscovery.session()\` — they should show identical results.
5. **Virtual camera still works** (if you have it enabled). Open Photo Booth, select "AV Pain Reliever," confirm live frames. Trigger a profile switch (replug the dock); the camera should swap source and the OSLog should show "First frame from webcam: 1280x720 format=BGRA" (or whatever the new camera's native format is — the FourCC.pretty output is unchanged byte-for-byte).
6. **(Optional) Force the new error case.** With Settings → Profiles open and a profile listed, manually \`rm\` that profile's section from \`~/Library/Application Support/AVPainReliever/profiles.toml\` while the dialog is up, then click Delete in the UI. Expected: an alert with the error text \"Couldn't delete '<Pretty Name>': missingProfile…\" (the engine's generic catch surfaces the new case as before).

If any of steps 1-5 don't match expectations, that's a regression. Step 6 is the only one that exercises the actual new error path; it's optional because triggering it requires manual TOML editing.

## What's queued for next PRs

- **PR #3:** \`ApplierLogger.error\` + thread through CMIO files (protocol surface change)
- **PR #4:** Move \`Notifier\`'s impls (\`UserNotificationsNotifier\` + \`AppleScriptNotifier\`) to the app target so the engine library stops importing AppKit (architectural relocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)