### PR TITLE
refactor: ApplierLogger.error + thread injected logger through CMIO files

### DIFF
--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
@@ -3,12 +3,6 @@ import CoreMediaIO
 import CoreMedia
 import CoreVideo
 import VideoToolbox
-import os.log
-
-private let logger = Logger(
-    subsystem: "com.ericwillis.avpainreliever",
-    category: "CMIOSinkWriter"
-)
 
 /// Opens the AV Pain Reliever virtual camera as a CMIO consumer
 /// and writes frames into its sink stream's `CMSimpleQueue`. The
@@ -26,6 +20,7 @@ private let logger = Logger(
 /// (referenced for architecture, not code).
 public final class CMIOSinkWriter {
     private let deviceUID: String
+    private let logger: ApplierLogger
     private var deviceID: CMIODeviceID = 0
     private var streamID: CMIOStreamID = 0
     private var queue: CMSimpleQueue?
@@ -77,8 +72,9 @@ public final class CMIOSinkWriter {
     private static let enqueueHeartbeatStride: UInt64 = 60
     private static let enqueueRejectStride: UInt64 = 30
 
-    public init(deviceUID: String) {
+    public init(deviceUID: String, logger: ApplierLogger) {
         self.deviceUID = deviceUID
+        self.logger = logger
     }
 
     /// Discovers the device, opens its sink stream, primes the
@@ -90,14 +86,14 @@ public final class CMIOSinkWriter {
             return false
         }
         deviceID = device
-        logger.info("Found device id=\(device, privacy: .public)")
+        logger.info("Found device id=\(device)")
 
         guard let sink = findSinkStream(deviceID: device) else {
             logger.error("sink stream not found on device")
             return false
         }
         streamID = sink
-        logger.info("Picked sink stream id=\(sink, privacy: .public)")
+        logger.info("Picked sink stream id=\(sink)")
 
         var unmanaged: Unmanaged<CMSimpleQueue>?
         let copyStatus = CMIOStreamCopyBufferQueue(sink, { _, _, _ in }, nil, &unmanaged)
@@ -199,7 +195,7 @@ public final class CMIOSinkWriter {
         enqueueCount += 1
         if enqueueCount == 1 || enqueueCount % Self.enqueueHeartbeatStride == 0 {
             logger.info(
-                "Enqueued frame #\(self.enqueueCount, privacy: .public) (rejects=\(self.enqueueRejectCount, privacy: .public))"
+                "Enqueued frame #\(self.enqueueCount) (rejects=\(self.enqueueRejectCount))"
             )
         }
     }
@@ -281,7 +277,7 @@ public final class CMIOSinkWriter {
             ) == noErr
         else { return nil }
 
-        logger.info("Device exposes \(count, privacy: .public) stream(s): \(streams.map(String.init).joined(separator: ", "), privacy: .public)")
+        logger.info("Device exposes \(count) stream(s): \(streams.map(String.init).joined(separator: ", "))")
 
         // Don't trust ordering — query each stream's direction
         // property and return the first sink. CMIO assigns IDs in
@@ -289,7 +285,7 @@ public final class CMIOSinkWriter {
         // CameraExtensionDeviceSource.init added them.
         for stream in streams {
             if let direction = streamDirection(streamID: stream) {
-                logger.info("Stream \(stream, privacy: .public) direction=\(direction, privacy: .public)")
+                logger.info("Stream \(stream) direction=\(direction)")
                 // direction 0 = output (host → device, i.e. sink)
                 // direction 1 = input  (device → host, i.e. source)
                 if direction == 0 {
@@ -359,7 +355,7 @@ public final class CMIOSinkWriter {
         )
         guard createStatus == kCVReturnSuccess, let destination else {
             logger.error(
-                "CVPixelBufferPoolCreatePixelBuffer failed: \(createStatus, privacy: .public)"
+                "CVPixelBufferPoolCreatePixelBuffer failed: \(createStatus)"
             )
             return nil
         }
@@ -371,7 +367,7 @@ public final class CMIOSinkWriter {
         )
         guard xferStatus == noErr else {
             logger.error(
-                "VTPixelTransferSessionTransferImage failed: \(xferStatus, privacy: .public)"
+                "VTPixelTransferSessionTransferImage failed: \(xferStatus)"
             )
             return nil
         }
@@ -386,7 +382,7 @@ public final class CMIOSinkWriter {
             pixelTransferSessionOut: &session
         )
         guard status == noErr, let session else {
-            logger.error("VTPixelTransferSessionCreate failed: \(status, privacy: .public)")
+            logger.error("VTPixelTransferSessionCreate failed: \(status)")
             return nil
         }
         // High-quality scaling — hardware path on Apple Silicon,
@@ -422,7 +418,7 @@ public final class CMIOSinkWriter {
             &pool
         )
         guard status == kCVReturnSuccess, let pool else {
-            logger.error("CVPixelBufferPoolCreate failed: \(status, privacy: .public)")
+            logger.error("CVPixelBufferPoolCreate failed: \(status)")
             return nil
         }
         bufferPool = pool
@@ -442,7 +438,7 @@ public final class CMIOSinkWriter {
             || signature.1 != Self.outputWidth
             || signature.2 != Self.outputHeight
         logger.info(
-            "Host frame format: \(fourcc, privacy: .public) \(signature.1, privacy: .public)x\(signature.2, privacy: .public) — \(needsConversion ? "convert+scale" : "passthrough", privacy: .public)"
+            "Host frame format: \(fourcc) \(signature.1)x\(signature.2) — \(needsConversion ? "convert+scale" : "passthrough")"
         )
     }
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -1,12 +1,6 @@
 import Foundation
 import AVFoundation
 import CoreVideo
-import os.log
-
-private let logger = Logger(
-    subsystem: "com.ericwillis.avpainreliever",
-    category: "CameraCaptureSession"
-)
 
 /// Captures from a webcam and hands each frame to `CMIOSinkWriter`,
 /// which enqueues it on the virtual camera's sink stream. The host
@@ -36,6 +30,7 @@ public final class CameraCaptureSession: NSObject {
         qos: .userInteractive
     )
     private let sink: CMIOSinkWriter
+    private let logger: ApplierLogger
     private var sinkStarted = false
     private var capturedFrameCount: UInt64 = 0
     private var output: AVCaptureVideoDataOutput?
@@ -59,8 +54,13 @@ public final class CameraCaptureSession: NSObject {
     /// would create a self-source feedback loop.
     private let initialSourceName: String?
 
-    public init(sink: CMIOSinkWriter, initialSourceName: String? = nil) {
+    public init(
+        sink: CMIOSinkWriter,
+        logger: ApplierLogger,
+        initialSourceName: String? = nil
+    ) {
         self.sink = sink
+        self.logger = logger
         self.initialSourceName = initialSourceName
         super.init()
         NotificationCenter.default.addObserver(
@@ -79,7 +79,7 @@ public final class CameraCaptureSession: NSObject {
 
     @objc private func handleRuntimeError(_ notification: Notification) {
         let error = notification.userInfo?[AVCaptureSessionErrorKey] as? Error
-        logger.error("AVCaptureSession runtime error: \(error?.localizedDescription ?? "unknown", privacy: .public)")
+        logger.error("AVCaptureSession runtime error: \(error?.localizedDescription ?? "unknown")")
     }
 
     @objc private func handleSessionStarted(_ notification: Notification) {
@@ -107,18 +107,18 @@ public final class CameraCaptureSession: NSObject {
 
     private func bootIfAuthorized() {
         let status = AVCaptureDevice.authorizationStatus(for: .video)
-        logger.info("Camera authorization status: \(status.rawValue, privacy: .public) (0=notDetermined 1=restricted 2=denied 3=authorized)")
+        logger.info("Camera authorization status: \(status.rawValue) (0=notDetermined 1=restricted 2=denied 3=authorized)")
         switch status {
         case .authorized:
             installAndStart()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
-                logger.info("Camera access request: granted=\(granted, privacy: .public)")
+                self?.logger.info("Camera access request: granted=\(granted)")
                 self?.captureQueue.async {
                     if granted {
                         self?.installAndStart()
                     } else {
-                        logger.error("Camera access denied; virtual camera will see no frames")
+                        self?.logger.error("Camera access denied; virtual camera will see no frames")
                     }
                 }
             }
@@ -139,7 +139,7 @@ public final class CameraCaptureSession: NSObject {
             logger.error("No video capture devices available")
             return
         }
-        logger.info("Initial capture device: \(device.localizedName, privacy: .public) (\(device.uniqueID, privacy: .public))")
+        logger.info("Initial capture device: \(device.localizedName) (\(device.uniqueID))")
 
         session.beginConfiguration()
         session.sessionPreset = .hd1280x720
@@ -179,10 +179,10 @@ public final class CameraCaptureSession: NSObject {
 
         logger.info("Calling session.startRunning()")
         session.startRunning()
-        logger.info("session.isRunning=\(self.session.isRunning, privacy: .public)")
+        logger.info("session.isRunning=\(self.session.isRunning)")
 
         sinkStarted = sink.start()
-        logger.info("sink.start() returned \(self.sinkStarted, privacy: .public)")
+        logger.info("sink.start() returned \(self.sinkStarted)")
     }
 
     /// Initial source pick. Priority:
@@ -236,7 +236,7 @@ public final class CameraCaptureSession: NSObject {
         do {
             let input = try AVCaptureDeviceInput(device: device)
             guard session.canAddInput(input) else {
-                logger.error("Cannot add input for \(device.localizedName, privacy: .public)")
+                logger.error("Cannot add input for \(device.localizedName)")
                 return false
             }
             session.addInput(input)
@@ -244,7 +244,7 @@ public final class CameraCaptureSession: NSObject {
             currentDeviceUniqueID = device.uniqueID
             return true
         } catch {
-            logger.error("AVCaptureDeviceInput failed for \(device.localizedName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.error("AVCaptureDeviceInput failed for \(device.localizedName): \(error.localizedDescription)")
             return false
         }
     }
@@ -261,15 +261,15 @@ public final class CameraCaptureSession: NSObject {
 
     private func swapInputLocked(toLocalizedName name: String) {
         guard let device = Self.findDevice(named: name) else {
-            logger.error("switchSource: no camera with localizedName '\(name, privacy: .public)' — skipping")
+            logger.error("switchSource: no camera with localizedName '\(name)' — skipping")
             return
         }
         if device.uniqueID == currentDeviceUniqueID {
-            logger.info("switchSource: already on '\(name, privacy: .public)' — no-op")
+            logger.info("switchSource: already on '\(name)' — no-op")
             return
         }
 
-        logger.info("switchSource: '\(self.currentDeviceUniqueID ?? "<none>", privacy: .public)' → '\(device.uniqueID, privacy: .public)' (\(name, privacy: .public))")
+        logger.info("switchSource: '\(self.currentDeviceUniqueID ?? "<none>")' → '\(device.uniqueID)' (\(name))")
 
         session.beginConfiguration()
         // Stash the previous input so we can put it back if the new
@@ -290,7 +290,7 @@ public final class CameraCaptureSession: NSObject {
                 session.addInput(previousInput)
                 self.currentInput = previousInput
                 self.currentDeviceUniqueID = previousUID
-                logger.warning("switchSource: install failed; restored previous source '\(previousUID ?? "<none>", privacy: .public)'")
+                logger.warn("switchSource: install failed; restored previous source '\(previousUID ?? "<none>")'")
             } else {
                 logger.error("switchSource: install failed and no previous source could be restored — session has no input")
             }
@@ -330,7 +330,7 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
             let w = CVPixelBufferGetWidth(pb)
             let h = CVPixelBufferGetHeight(pb)
             let fourcc = FourCC.pretty(CVPixelBufferGetPixelFormatType(pb))
-            logger.info("First frame from webcam: \(w, privacy: .public)x\(h, privacy: .public) format=\(fourcc, privacy: .public)")
+            logger.info("First frame from webcam: \(w)x\(h) format=\(fourcc)")
         }
 
         // If sink wasn't ready when capture started (extension not
@@ -338,9 +338,9 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
         if !sinkStarted {
             sinkStarted = sink.start()
             if sinkStarted {
-                logger.info("Sink writer connected on retry (after \(self.capturedFrameCount, privacy: .public) frames)")
+                logger.info("Sink writer connected on retry (after \(self.capturedFrameCount) frames)")
             } else if capturedFrameCount % Self.sinkRetryLogStride == 1 {
-                logger.error("Sink writer still not ready after \(self.capturedFrameCount, privacy: .public) frames")
+                logger.error("Sink writer still not ready after \(self.capturedFrameCount) frames")
             }
             if !sinkStarted { return }
         }

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -1,11 +1,22 @@
 import Foundation
 
-/// Two-level logger interface for engine components. Production
+/// Three-level logger interface for engine components. Production
 /// wires this to `os.Logger` (Apple's unified logging); tests use a
-/// recording mock.
+/// recording mock. `error` exists for unrecoverable failures
+/// (CMIO/AVFoundation hard errors); `warn` for recoverable issues
+/// the engine logged-and-continued through.
 public protocol ApplierLogger {
     func info(_ message: String)
     func warn(_ message: String)
+    func error(_ message: String)
+}
+
+public extension ApplierLogger {
+    /// Default routes `error` to `warn` so existing two-level
+    /// conformers stay source-compatible. Conformers that can
+    /// distinguish severities (the production `ConsoleLogger`)
+    /// implement `error` directly.
+    func error(_ message: String) { warn(message) }
 }
 
 /// Applies a resolved profile: switches default audio in/out and the

--- a/Sources/AVPainRelieverApp/ConsoleLogger.swift
+++ b/Sources/AVPainRelieverApp/ConsoleLogger.swift
@@ -6,29 +6,46 @@ import AVPainReliever
 /// logging system. Visible in Console.app and via:
 ///
 /// ```sh
-/// log stream --predicate 'subsystem == "com.ericwillis.avpainreliever"'
+/// log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever"' --info --style compact
 /// ```
+///
+/// Each instance carries its own `os.Logger` category so different
+/// engine adapters log under filterable categories ("engine",
+/// "CMIOSinkWriter", "CameraCaptureSession", etc.). The category
+/// also gets prefixed onto the stderr mirror so `swift run` output
+/// stays readable when multiple subsystems log concurrently.
 struct ConsoleLogger: ApplierLogger {
-    private static let logger = Logger(
-        subsystem: "com.ericwillis.avpainreliever",
-        category: "engine"
-    )
+    private let logger: Logger
+    private let category: String
+
+    init(category: String = "engine") {
+        self.logger = Logger(
+            subsystem: "com.ericwillis.avpainreliever",
+            category: category
+        )
+        self.category = category
+    }
 
     func info(_ message: String) {
-        Self.logger.info("\(message, privacy: .public)")
-        Self.writeStderr("[info] \(message)")
+        logger.info("\(message, privacy: .public)")
+        writeStderr("[\(category)] [info] \(message)")
     }
 
     func warn(_ message: String) {
-        Self.logger.warning("\(message, privacy: .public)")
-        Self.writeStderr("[warn] \(message)")
+        logger.warning("\(message, privacy: .public)")
+        writeStderr("[\(category)] [warn] \(message)")
+    }
+
+    func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+        writeStderr("[\(category)] [error] \(message)")
     }
 
     /// Mirror to stderr so `swift run` shows engine activity directly
     /// in the terminal. Especially useful for unbundled SPM builds,
     /// where `os.Logger` capture under the explicit subsystem isn't
     /// always reliable.
-    private static func writeStderr(_ message: String) {
+    private func writeStderr(_ message: String) {
         FileHandle.standardError.write(Data("\(message)\n".utf8))
     }
 }

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -231,9 +231,17 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
 
     private func startCapturePipeline() {
         guard captureSession == nil else { return }
-        let writer = CMIOSinkWriter(deviceUID: Self.virtualCameraUID)
+        // Per-adapter ConsoleLogger instances so `os.log`'s category
+        // filter (`log stream --predicate 'category == "CMIOSinkWriter"'`)
+        // still works even though both adapters now go through the
+        // engine library's `ApplierLogger` protocol seam.
+        let writer = CMIOSinkWriter(
+            deviceUID: Self.virtualCameraUID,
+            logger: ConsoleLogger(category: "CMIOSinkWriter")
+        )
         let session = CameraCaptureSession(
             sink: writer,
+            logger: ConsoleLogger(category: "CameraCaptureSession"),
             initialSourceName: pendingSourceName
         )
         session.start()


### PR DESCRIPTION
## Summary

The two virtual-camera adapters (\`CMIOSinkWriter\`, \`CameraCaptureSession\`) were the last engine-library files importing \`os.log\` directly. PR #43 moved them in from the app shell with their file-scope \`Logger\` instances intact; the calibration's diagnosis was that \`ApplierLogger\` only defined \`info\` and \`warn\`, so the CMIO adapters' ~17 error-level calls had nowhere to land in the protocol — they reached for \`os.Logger\` to compensate.

This PR fixes the root cause (add \`error\`) and threads the protocol through both adapters. Engine library now imports \`os.log\` from zero files.

**No behavior changes.** Same 183/183 tests pass. Per-adapter os.log category filtering is preserved.

## Changes

### \`ApplierLogger\` (Engine/ProfileApplier.swift)

\`\`\`swift
public protocol ApplierLogger {
    func info(_ message: String)
    func warn(_ message: String)
    func error(_ message: String)   // new
}

public extension ApplierLogger {
    func error(_ message: String) { warn(message) }   // default for source compat
}
\`\`\`

The default extension means existing two-level conformers (the test \`MockLogger\`) keep compiling without edits — they get the protocol-default error→warn routing automatically.

### \`ConsoleLogger\` (Sources/AVPainRelieverApp/)

Becomes instance-based with \`init(category: String = "engine")\`:

\`\`\`swift
struct ConsoleLogger: ApplierLogger {
    private let logger: Logger
    private let category: String

    init(category: String = "engine") {
        self.logger = Logger(subsystem: "...", category: category)
        self.category = category
    }
    // info / warn / error all log to os.Logger AND mirror to stderr
    // with a [<category>] [<level>] prefix.
}
\`\`\`

Different engine subsystems can now construct \`ConsoleLogger\` with their own categories, keeping \`log stream --predicate 'category == "CMIOSinkWriter"'\` filtering working.

### \`CMIOSinkWriter\` and \`CameraCaptureSession\` (engine target)

- Drop \`import os.log\` and the file-scope \`private let logger\` global.
- Add \`private let logger: ApplierLogger\` instance property.
- Constructor gains a \`logger:\` parameter:
  - \`init(deviceUID:logger:)\` for \`CMIOSinkWriter\`
  - \`init(sink:logger:initialSourceName:)\` for \`CameraCaptureSession\`
- All \`, privacy: .public\` interpolations stripped (ApplierLogger takes plain Strings; ConsoleLogger applies privacy at the os.log boundary).
- One \`logger.warning(...)\` call in \`CameraCaptureSession.swapInputLocked\` becomes \`logger.warn(...)\` to match the protocol's spelling.
- The closure-capture site in \`bootIfAuthorized\` (AVCaptureDevice.requestAccess callback) switches from file-scope \`logger.info\` to \`self?.logger.info\`.

### \`VirtualCameraActivator\` (app target)

\`startCapturePipeline\` now constructs per-category ConsoleLoggers and injects them:

\`\`\`swift
let writer = CMIOSinkWriter(
    deviceUID: Self.virtualCameraUID,
    logger: ConsoleLogger(category: "CMIOSinkWriter")
)
let session = CameraCaptureSession(
    sink: writer,
    logger: ConsoleLogger(category: "CameraCaptureSession"),
    initialSourceName: pendingSourceName
)
\`\`\`

This is the only call site for these constructors; \`AVPainRelieverActivator\` lives in the app target so it can keep using its own \`os.Logger\` for the \`Activator\` category (the engine-library rule applies to the engine target only).

## Net diff

5 files, **+85 / -53 LOC**.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test\` — **183 tests pass** (same baseline)

**Hands-on verification.** Build and install:

\`\`\`
./dev/build --full
\`\`\`

In a separate terminal, start tailing logs:

\`\`\`
log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever"' --info --style compact
\`\`\`

Then walk through:

1. **App launches normally.** Menu bar icon appears. Active profile applies. Expected log output: \`[engine] [info] loaded N profiles from /path/to/profiles.toml\`. The \`[engine]\` prefix is the new stderr-mirror category prefix from the updated ConsoleLogger; in the OS log stream, the same line shows \`category=engine\`.
2. **Virtual camera activates** (if enabled). Expected: \`[Activator] [info] ...\` lines from \`VirtualCameraActivator\` (these come from its own \`os.Logger\`, unchanged). Then when a consumer connects (open Photo Booth, select "AV Pain Reliever"), expected: \`[CMIOSinkWriter] [info] Found device id=...\` and \`[CMIOSinkWriter] [info] Picked sink stream id=...\`. **The category is the key signal** — those lines previously came from a file-scope os.Logger with category "CMIOSinkWriter", they should still come from category "CMIOSinkWriter" now via the injected ConsoleLogger.
3. **Camera switches.** Trigger a profile switch (replug a dock). Expected: \`[CameraCaptureSession] [info] switchSource: ... → ...\` and \`[CameraCaptureSession] [info] First frame from webcam: 1280x720 format=...\`. Same per-category filtering as before.
4. **Filter by category to confirm preservation:**
   \`\`\`
   log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever" AND category == "CMIOSinkWriter"' --info --style compact
   \`\`\`
   Expected: only CMIOSinkWriter lines stream past. If this command returns nothing during steady-state capture, that's a regression — the category injection didn't take.
5. **Force an error path** (optional). Disable the virtual camera in Settings while a consumer is connected, then re-enable in the same session. Expected: \`[Activator] ... .requiresRelaunch ...\` and a \`[CMIOSinkWriter] [error]\` line if the sink fails to (re)open. The new \`ApplierLogger.error\` path is what carries those error-level lines now.

If any of steps 1-4 don't match expectations — particularly the per-category prefix in the stderr mirror or the os.log category filtering in step 4 — that's a regression. Step 5 is bonus coverage of the new error level.

## What's queued for next PRs

- **PR #4:** Move \`Notifier\`'s impls (\`UserNotificationsNotifier\` + \`AppleScriptNotifier\`) to the app target so the engine library stops importing AppKit. That's the last architectural finding from the engine slop review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)