### PR TITLE
fix: force new app instance on Restart (open -n)

### DIFF
--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -217,7 +217,12 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         logger.info("Relaunching host: \(bundleURL.path, privacy: .public)")
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        task.arguments = [bundleURL.path]
+        // -n forces a brand-new instance. Without it, Launch Services
+        // races our pending `terminate` and sometimes resolves the
+        // bundle to the still-alive PID, activating the about-to-die
+        // process instead of launching a fresh one. Net effect: the
+        // app quits and nothing comes back up.
+        task.arguments = ["-n", bundleURL.path]
         do {
             try task.run()
         } catch {


### PR DESCRIPTION
## Summary

- The "Restart AV Pain Reliever" button on the `.requiresRelaunch` state was sometimes terminating the app without spawning a replacement (old PID gone, no new PID).
- Root cause: `/usr/bin/open <bundle>` (no `-n`) races the pending `NSApplication.terminate`. Launch Services occasionally activates the about-to-die PID instead of launching fresh, and when termination completes nothing replaces it.
- Fix: pass `-n` so Launch Services always launches a new instance. Pre-existing bug, not introduced by the recent CMIO logger refactor (PR #52); `relaunch()` body is byte-identical to before that work.

## Test plan

- [x] `swift build` clean
- [x] `./dev/build --full` install + manual reproduction:
  - Toggle virtual camera off then on inside one session to surface the Restart button
  - Click Restart, verify a new PID appears (`pgrep -f AVPainReliever.app`)
  - Repeat several times in the same session — previously failed on a later attempt, now consistently succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)