### PR TITLE
refactor: idiomatic Swift cleanups in engine adapters

### DIFF
--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CMIOSinkWriter.swift
@@ -36,7 +36,7 @@ public final class CMIOSinkWriter {
     /// wrapping. The pool recycles a small handful of buffers, so
     /// in steady state the cache hits 90%+ even with this strict
     /// keying.
-    private var lastFormatBufferPtr: UnsafeRawPointer?
+    private var lastFormatBufferID: ObjectIdentifier?
     private var lastFormatDescription: CMFormatDescription?
 
     /// Convert + scale arbitrary input pixel buffers (any format,
@@ -52,10 +52,17 @@ public final class CMIOSinkWriter {
     /// a couple of buffers in flight.
     private var bufferPool: CVPixelBufferPool?
 
-    /// Logged once per (format, dimensions) pair the host
-    /// delivers, so a profile change shows up in the log without
-    /// flooding with one line per frame.
-    private var lastLoggedInputSignature: (OSType, Int, Int) = (0, 0, 0)
+    /// Format + dimensions of the most recently logged host frame,
+    /// or nil before the first frame. Used to log once per
+    /// (format, dimensions) pair the host delivers, so a profile
+    /// change shows up in the log without flooding with one line
+    /// per frame.
+    private struct InputSignature: Equatable {
+        let format: OSType
+        let width: Int
+        let height: Int
+    }
+    private var lastLoggedInputSignature: InputSignature?
 
     /// Output target. The extension's source stream advertises
     /// 1280×720 BGRA; matching here avoids a format mismatch on
@@ -123,9 +130,9 @@ public final class CMIOSinkWriter {
         queue = nil
         transferSession = nil
         bufferPool = nil
-        lastFormatBufferPtr = nil
+        lastFormatBufferID = nil
         lastFormatDescription = nil
-        lastLoggedInputSignature = (0, 0, 0)
+        lastLoggedInputSignature = nil
     }
 
     private var enqueueCount: UInt64 = 0
@@ -306,9 +313,9 @@ public final class CMIOSinkWriter {
     private func ensureOutputFormatDescription(for pixelBuffer: CVPixelBuffer)
         -> CMFormatDescription?
     {
-        let ptr = Unmanaged.passUnretained(pixelBuffer).toOpaque()
+        let id = ObjectIdentifier(pixelBuffer)
         if let cached = lastFormatDescription,
-           lastFormatBufferPtr == UnsafeRawPointer(ptr)
+           lastFormatBufferID == id
         {
             return cached
         }
@@ -322,7 +329,7 @@ public final class CMIOSinkWriter {
             logger.error("CMVideoFormatDescriptionCreateForImageBuffer failed: \(status)")
             return nil
         }
-        lastFormatBufferPtr = UnsafeRawPointer(ptr)
+        lastFormatBufferID = id
         lastFormatDescription = fmt
         return fmt
     }
@@ -427,19 +434,19 @@ public final class CMIOSinkWriter {
     }
 
     private func logIncomingFormatIfChanged(pixelBuffer: CVPixelBuffer) {
-        let signature = (
-            CVPixelBufferGetPixelFormatType(pixelBuffer),
-            CVPixelBufferGetWidth(pixelBuffer),
-            CVPixelBufferGetHeight(pixelBuffer)
+        let signature = InputSignature(
+            format: CVPixelBufferGetPixelFormatType(pixelBuffer),
+            width: CVPixelBufferGetWidth(pixelBuffer),
+            height: CVPixelBufferGetHeight(pixelBuffer)
         )
         if signature == lastLoggedInputSignature { return }
         lastLoggedInputSignature = signature
-        let fourcc = FourCC.pretty(signature.0)
-        let needsConversion = signature.0 != Self.outputFormat
-            || signature.1 != Self.outputWidth
-            || signature.2 != Self.outputHeight
+        let fourcc = FourCC.pretty(signature.format)
+        let needsConversion = signature.format != Self.outputFormat
+            || signature.width != Self.outputWidth
+            || signature.height != Self.outputHeight
         logger.info(
-            "Host frame format: \(fourcc) \(signature.1)x\(signature.2) — \(needsConversion ? "convert+scale" : "passthrough")"
+            "Host frame format: \(fourcc) \(signature.width)x\(signature.height) — \(needsConversion ? "convert+scale" : "passthrough")"
         )
     }
 

--- a/Sources/AVPainReliever/Engine/USBWatcher.swift
+++ b/Sources/AVPainReliever/Engine/USBWatcher.swift
@@ -318,6 +318,6 @@ public final class IOKitUSBWatcher: USBWatcher {
         ) else {
             return nil
         }
-        return (raw.takeRetainedValue() as? NSNumber)?.intValue
+        return raw.takeRetainedValue() as? Int
     }
 }


### PR DESCRIPTION
## Summary

Three borderline findings from the slop-review pass, all behavior-preserving refactors.

- **I1** \`USBWatcher.intProperty\` drops the \`NSNumber\` bridging hop in favor of \`as? Int\` directly. Matches the file's existing \`as? String\` pattern for the other property readers.
- **I3** \`CMIOSinkWriter.lastLoggedInputSignature\` replaces the \`(OSType, Int, Int)\` tuple sentinel \`(0, 0, 0)\` with a named \`struct InputSignature: Equatable\` and an \`Optional\` sentinel of \`nil\`. Removes positional \`.0/.1/.2\` access at the log site; matches the rest of the codebase where every other multi-field value is a named struct.
- **I4** \`CMIOSinkWriter\` format-description cache key swaps \`Unmanaged.passUnretained(pixelBuffer).toOpaque()\` for \`ObjectIdentifier(pixelBuffer)\`. CF types bridge to \`AnyObject\` in Swift, so \`ObjectIdentifier\` is the native reference-identity comparison.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: virtual camera streaming via Photo Booth verified through \`log stream --info --predicate 'subsystem == "com.ericwillis.avpainreliever" AND (category == "CMIOSinkWriter" OR category == "CameraCaptureSession")'\`. \`Host frame format: 420v 1920x1080 — convert+scale\` logged once at first frame; heartbeats at frames 1/60/120/…/720; zero rejects across 720 frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)