### PR TITLE
refactor: split Audio/CameraController into Applier + Inventory seams

### DIFF
--- a/Sources/AVPainReliever/Adapters/AudioController.swift
+++ b/Sources/AVPainReliever/Adapters/AudioController.swift
@@ -71,15 +71,20 @@ public struct AudioDefaults: Sendable {
     }
 }
 
-/// Abstraction over system audio defaults so `ProfileApplier` can be
-/// unit-tested without CoreAudio. Production uses `CoreAudioController`;
-/// tests use a recording mock.
-public protocol AudioController {
+/// Engine-side write seam — sets the system's default input/output
+/// device by name. `ProfileApplier` consumes this; tests inject a
+/// recording mock with no inventory ceremony.
+public protocol AudioApplier {
     /// Look up an audio device by name + role and set it as the system
     /// default for that role. See `AudioApplyResult` for the four
     /// possible outcomes.
     func setDefault(named: String, role: AudioDeviceRole) -> AudioApplyResult
+}
 
+/// Wizard-side read seam — enumerates available audio devices and
+/// queries current defaults. `AddProfileViewModel` consumes this;
+/// tests inject a fake that returns canned snapshots.
+public protocol AudioInventory {
     /// Snapshot of available audio devices, deduplicated by name with
     /// merged input/output capabilities. Used by the wizard UI to
     /// populate audio pickers.
@@ -90,6 +95,12 @@ public protocol AudioController {
     /// scope (rare on macOS but defensible).
     func currentDefaults() -> AudioDefaults
 }
+
+/// Composition of the two seams above. Production
+/// `CoreAudioController` conforms to this; callers that legitimately
+/// need both apply + inventory (e.g., `AppDelegate`'s dependency
+/// bundle) can ask for the umbrella.
+public protocol AudioController: AudioApplier, AudioInventory {}
 
 /// Production `AudioController` backed by raw CoreAudio. Lifted from
 /// `prototypes/audio-defaults.swift` once that prototype proved the

--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -43,12 +43,20 @@ public struct CameraSummary: Hashable, Sendable, Identifiable {
 ///   selects "AV Pain Reliever" once in each app's picker, and the
 ///   active profile drives which real camera the virtual camera
 ///   streams from.
-public protocol CameraController {
+/// Engine-side write seam — sets the system's `userPreferredCamera`
+/// by name. `ProfileApplier` consumes this; tests inject a recording
+/// mock with no inventory ceremony.
+public protocol CameraApplier {
     /// Set the system's `userPreferredCamera` to the camera with the
     /// given `localizedName`. Returns `.notFound` if no such camera
     /// is currently visible.
     func setPreferred(named: String) -> CameraApplyResult
+}
 
+/// Wizard-side read seam — enumerates available cameras and queries
+/// the current preferred name. `AddProfileViewModel` consumes this;
+/// tests inject a fake that returns canned snapshots.
+public protocol CameraInventory {
     /// Snapshot of available cameras, sorted by name. Used by the
     /// wizard UI to populate the camera picker.
     func availableCameras() -> [CameraSummary]
@@ -57,6 +65,12 @@ public protocol CameraController {
     /// `userPreferredCamera`, or nil if none is set / matches.
     func currentPreferredName() -> String?
 }
+
+/// Composition of the two seams above. Production
+/// `AVFoundationCameraController` conforms to this; callers that
+/// legitimately need both apply + inventory (e.g., `AppDelegate`'s
+/// dependency bundle) can ask for the umbrella.
+public protocol CameraController: CameraApplier, CameraInventory {}
 
 /// Drives the source camera that AV Pain Reliever's own virtual
 /// camera streams from. Conceptually parallel to `CameraController`

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -29,15 +29,15 @@ public extension ApplierLogger {
 /// debouncing USB bursts (`Debouncer`), and choosing a fallback when
 /// no profile matches. The applier just executes the side effects.
 public final class ProfileApplier {
-    private let audio: AudioController
-    private let camera: CameraController?
+    private let audio: AudioApplier
+    private let camera: CameraApplier?
     private let virtualCameraSource: VirtualCameraSourceController?
     private let logger: ApplierLogger
     private var lastAppliedName: String?
 
     public init(
-        audio: AudioController,
-        camera: CameraController? = nil,
+        audio: AudioApplier,
+        camera: CameraApplier? = nil,
         virtualCameraSource: VirtualCameraSourceController? = nil,
         logger: ApplierLogger
     ) {

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -117,8 +117,8 @@ final class AddProfileViewModel: ObservableObject {
     // MARK: - Dependencies
 
     private let watcher: USBWatcher
-    private let audioController: AudioController
-    private let cameraController: CameraController
+    private let audioController: AudioInventory
+    private let cameraController: CameraInventory
     private let configURL: URL
     private let onSaved: () -> Void
     private let editingSlug: String?
@@ -153,8 +153,8 @@ final class AddProfileViewModel: ObservableObject {
 
     init(
         watcher: USBWatcher,
-        audioController: AudioController,
-        cameraController: CameraController,
+        audioController: AudioInventory,
+        cameraController: CameraInventory,
         configURL: URL,
         editing: Profile? = nil,
         existingProfileSlugs: Set<String> = [],

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -641,9 +641,8 @@ private final class FakeWatcher: USBWatcher, @unchecked Sendable {
     func stop() {}
 }
 
-private struct FakeAudio: AudioController {
+private struct FakeAudio: AudioInventory {
     let devices: [String]
-    func setDefault(named: String, role: AudioDeviceRole) -> AudioApplyResult { .ok }
     func availableDevices() -> [AudioDeviceSummary] {
         devices.map { AudioDeviceSummary(name: $0, supportsInput: true, supportsOutput: true) }
     }
@@ -652,7 +651,7 @@ private struct FakeAudio: AudioController {
     }
 }
 
-private struct FakeCamera: CameraController {
+private struct FakeCamera: CameraInventory {
     let cameras: [String]
     let currentPreferred: String?
 
@@ -661,7 +660,6 @@ private struct FakeCamera: CameraController {
         self.currentPreferred = currentPreferred
     }
 
-    func setPreferred(named: String) -> CameraApplyResult { .ok }
     func availableCameras() -> [CameraSummary] { cameras.map { CameraSummary(name: $0) } }
     func currentPreferredName() -> String? { currentPreferred }
 }

--- a/Tests/AVPainRelieverTests/ProfileApplierTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileApplierTests.swift
@@ -7,7 +7,7 @@ struct ProfileApplierTests {
 
     // MARK: - Mocks
 
-    final class MockAudio: AudioController {
+    final class MockAudio: AudioApplier {
         struct Call: Equatable {
             let name: String
             let role: AudioDeviceRole
@@ -15,40 +15,25 @@ struct ProfileApplierTests {
         private(set) var calls: [Call] = []
         var resultsByName: [String: AudioApplyResult] = [:]
         var defaultResult: AudioApplyResult = .ok
-        var availableDevicesStub: [AudioDeviceSummary] = []
-        var currentDefaultsStub: AudioDefaults = .init(inputName: nil, outputName: nil)
 
         func setDefault(named: String, role: AudioDeviceRole) -> AudioApplyResult {
             calls.append(Call(name: named, role: role))
             return resultsByName[named] ?? defaultResult
         }
-
-        func availableDevices() -> [AudioDeviceSummary] {
-            availableDevicesStub
-        }
-
-        func currentDefaults() -> AudioDefaults {
-            currentDefaultsStub
-        }
     }
 
-    final class MockCamera: CameraController {
+    final class MockCamera: CameraApplier {
         struct Call: Equatable {
             let name: String
         }
         private(set) var calls: [Call] = []
         var resultsByName: [String: CameraApplyResult] = [:]
         var defaultResult: CameraApplyResult = .ok
-        var availableCamerasStub: [CameraSummary] = []
-        var currentPreferredNameStub: String? = nil
 
         func setPreferred(named: String) -> CameraApplyResult {
             calls.append(Call(name: named))
             return resultsByName[named] ?? defaultResult
         }
-
-        func availableCameras() -> [CameraSummary] { availableCamerasStub }
-        func currentPreferredName() -> String? { currentPreferredNameStub }
     }
 
     final class MockVirtualCameraSource: VirtualCameraSourceController {


### PR DESCRIPTION
## Summary

ISP split for the audio + camera adapter protocols. Slop-review finding S6 (calibrated 60): both protocols mixed an engine-only "apply" verb with wizard-only "inventory" verbs, so test mocks for \`ProfileApplier\` had to stub \`availableDevices\` / \`currentDefaults\` the applier never calls, and wizard tests had to stub \`setDefault\` / \`setPreferred\` the wizard never calls.

### New shape

- \`AudioApplier\` — \`setDefault(named:role:)\`. Engine seam.
- \`AudioInventory\` — \`availableDevices()\`, \`currentDefaults()\`. Wizard seam.
- \`AudioController: AudioApplier, AudioInventory\` — composition for callers that legitimately need both (\`AppDelegate\`'s dependency bundle).

Same shape for camera (\`CameraApplier\` / \`CameraInventory\` / \`CameraController\`).

### Consumer updates

- \`ProfileApplier\` ctor narrowed to \`AudioApplier\` / \`CameraApplier?\`.
- \`AddProfileViewModel\` ctor narrowed to \`AudioInventory\` / \`CameraInventory\`.
- \`AppDelegate\` / \`AddProfileDependencies\` untouched: the composition protocol still satisfies them.

### Test-mock slimming (the calibrator's stated benefit)

- \`MockAudio\` / \`MockCamera\` in \`ProfileApplierTests\`: drop \`availableDevices\` / \`currentDefaults\` / \`availableCameras\` / \`currentPreferredName\` stubs.
- \`FakeAudio\` / \`FakeCamera\` in \`AddProfileViewModelTests\`: drop \`setDefault\` / \`setPreferred\` stubs.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: \`./dev/build --full\` install. Apply path (location switch → audio + camera switch) and inventory path (wizard pickers populate, current defaults pre-selected) both verified identical to pre-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)