### PR TITLE
fix: release IOKit notification iterators in USBWatcher.stop()

### DIFF
--- a/Sources/AVPainReliever/Engine/USBWatcher.swift
+++ b/Sources/AVPainReliever/Engine/USBWatcher.swift
@@ -216,6 +216,14 @@ public final class IOKitUSBWatcher: USBWatcher {
 
     public func stop() {
         guard let port = notifyPort else { return }
+        // Release the iterators returned by IOServiceAddMatchingNotification
+        // before destroying the port. Per Apple's IOKitLib.h
+        // documentation, those iterators "should be released by the
+        // caller when the notification is to be destroyed", and
+        // IONotificationPortDestroy only releases the port + its
+        // mach_ports + CFRunLoopSources — not the iterators themselves.
+        if addedIter != 0 { IOObjectRelease(addedIter) }
+        if removedIter != 0 { IOObjectRelease(removedIter) }
         IONotificationPortDestroy(port)
         notifyPort = nil
         addedIter = 0


### PR DESCRIPTION
## Summary

Slop-review missed-finding fix (Phase 2 calibrated 55).

\`IOServiceAddMatchingNotification\` returns an \`io_iterator_t\` per subscription, and \`IOKitLib.h\`'s doc says those "should be released by the caller when the notification is to be destroyed." \`IONotificationPortDestroy\`'s contract only covers the port + its \`mach_port\`s + \`CFRunLoopSource\`s — not the iterators themselves.

\`stop()\` was zeroing \`addedIter\` / \`removedIter\` without releasing them. Each \`start→stop\` cycle leaked two iterator references. In practice the watcher is created once per app launch and torn down at quit, so the leak is bounded by app lifetime — but the explicit lifecycle is now correct, and a future re-init flow won't grow.

Cited Apple's doc inline so the \`IOObjectRelease\` calls don't look superstitious.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: \`./dev/build --full\` install, launch, USB plug/unplug verified, clean quit, relaunch — \`IOObjectRelease\` on the iterators doesn't crash on quit, watcher still works on relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)