### PR TITLE
refactor: drop CameraCaptureSession's VirtualCameraSourceController conformance

### DIFF
--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -354,7 +354,15 @@ extension CameraCaptureSession: AVCaptureVideoDataOutputSampleBufferDelegate {
     }
 }
 
-extension CameraCaptureSession: VirtualCameraSourceController {
+// MARK: - Engine-facing source swap
+
+extension CameraCaptureSession {
+    /// Swap the running session's input to the camera with the given
+    /// `localizedName`. The `VirtualCameraSourceController` plumbed
+    /// into `ProfileApplier` is the host's activator (it gates on the
+    /// extension's lifecycle); it forwards into this method when the
+    /// virtual camera is live. Returns `.notFound` if no such camera
+    /// is currently visible, `.ok` otherwise.
     public func setSource(named: String) -> CameraApplyResult {
         guard Self.findDevice(named: named) != nil else {
             return .notFound


### PR DESCRIPTION
## Summary

Slop-review finding S4 (calibrated 55) flagged \`CameraCaptureSession\` as carrying mixed responsibilities: \`AVCaptureSession\` owner + sample-buffer delegate + \`VirtualCameraSourceController\` conformer.

Investigation showed the protocol conformance is **dead weight**. \`ProfileApplier\` consumes a \`VirtualCameraSourceController\`, but the value it actually receives in production is the host's \`VirtualCameraActivator\` (app target, gates on the Camera Extension's lifecycle). The activator forwards into \`CameraCaptureSession.setSource(named:)\` via the concrete type — no production code uses \`CameraCaptureSession\` typed as \`VirtualCameraSourceController\`. \`MockVirtualCameraSource\` in \`ProfileApplierTests\` is independent of this class.

Smaller fix than the calibrator's "extract a thin wrapper" suggestion: drop the conformance, keep \`setSource(named:)\` as a plain public method in a regular extension. The class's declared responsibility narrows to "capture + delegate" without changing any call site.

\`grep -rn "as VirtualCameraSourceController" Sources/ Tests/\` returns empty.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: \`./dev/build --full\` install + virtual camera in Photo Booth + profile-driven source re-apply. The \`switchSource: already on '<name>' — no-op\` log line fired at the expected moment, proving the activator → \`setSource(named:)\` → \`switchSource\` chain still works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)