### PR TITLE
cleanup: second-pass slop-review fixes (mostly slop-fix slop)

### DIFF
--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -25,25 +25,7 @@ public struct CameraSummary: Hashable, Sendable, Identifiable {
     public var id: String { name }
 }
 
-/// Abstraction over `AVCaptureDevice.userPreferredCamera` (macOS 14+
-/// system-wide preferred camera). Production uses
-/// `AVFoundationCameraController`; tests use a recording mock.
-///
-/// Scope and design notes:
-///
-/// - `userPreferredCamera` is the macOS-14+ system API for
-///   "preferred default camera." AVFoundation-modern apps (FaceTime,
-///   browser `getUserMedia`, native AVCapture clients) pick it up
-///   automatically.
-/// - Apps with their own camera-selection UI (Zoom, Slack, Teams)
-///   maintain their OWN selection independently. The engine
-///   intentionally does NOT try to drive those — no plist hacks, no
-///   UI scripting. For those, the V2 native virtual camera
-///   (`VirtualCameraSourceController` below) is the bridge: the user
-///   selects "AV Pain Reliever" once in each app's picker, and the
-///   active profile drives which real camera the virtual camera
-///   streams from.
-/// Engine-side write seam — sets the system's `userPreferredCamera`
+/// Engine-side write seam: sets the system's `userPreferredCamera`
 /// by name. `ProfileApplier` consumes this; tests inject a recording
 /// mock with no inventory ceremony.
 public protocol CameraApplier {
@@ -53,7 +35,7 @@ public protocol CameraApplier {
     func setPreferred(named: String) -> CameraApplyResult
 }
 
-/// Wizard-side read seam — enumerates available cameras and queries
+/// Wizard-side read seam: enumerates available cameras and queries
 /// the current preferred name. `AddProfileViewModel` consumes this;
 /// tests inject a fake that returns canned snapshots.
 public protocol CameraInventory {
@@ -66,10 +48,27 @@ public protocol CameraInventory {
     func currentPreferredName() -> String?
 }
 
-/// Composition of the two seams above. Production
-/// `AVFoundationCameraController` conforms to this; callers that
-/// legitimately need both apply + inventory (e.g., `AppDelegate`'s
-/// dependency bundle) can ask for the umbrella.
+/// Abstraction over `AVCaptureDevice.userPreferredCamera` (macOS 14+
+/// system-wide preferred camera). Composition of the apply + inventory
+/// seams above. Production uses `AVFoundationCameraController`;
+/// callers that legitimately need both (e.g., `AppDelegate`'s
+/// dependency bundle) ask for the umbrella, and tests use a recording
+/// mock per side.
+///
+/// Scope and design notes:
+///
+/// - `userPreferredCamera` is the macOS-14+ system API for
+///   "preferred default camera." AVFoundation-modern apps (FaceTime,
+///   browser `getUserMedia`, native AVCapture clients) pick it up
+///   automatically.
+/// - Apps with their own camera-selection UI (Zoom, Slack, Teams)
+///   maintain their OWN selection independently. The engine
+///   intentionally does NOT try to drive those: no plist hacks, no
+///   UI scripting. For those, the V2 native virtual camera
+///   (`VirtualCameraSourceController` below) is the bridge. The user
+///   selects "AV Pain Reliever" once in each app's picker, and the
+///   active profile drives which real camera the virtual camera
+///   streams from.
 public protocol CameraController: CameraApplier, CameraInventory {}
 
 /// Drives the source camera that AV Pain Reliever's own virtual
@@ -123,10 +122,9 @@ public extension VirtualCameraSourceController {
     var preferredCameraOverride: String? { nil }
 }
 
-/// Production `CameraController` backed by AVFoundation. Stateless —
-/// every call constructs a fresh `DiscoverySession`. Sessions are
-/// cheap (microseconds) and we want fresh results when the user
-/// docks a Continuity Camera mid-wizard.
+/// Production `CameraController` backed by AVFoundation. Stateless;
+/// every call goes through `CameraDiscovery.session()` for a fresh
+/// device list (see `CameraDiscovery` for why fresh per call).
 public struct AVFoundationCameraController: CameraController {
     public init() {}
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/FourCC.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/FourCC.swift
@@ -1,4 +1,4 @@
-import CoreVideo
+import Foundation
 
 /// Pretty-print helper for `OSType` four-character codes
 /// (`kCVPixelFormatType_*`, FourCC media tags, etc.). The host's

--- a/Sources/AVPainReliever/Config/ProfileWriter.swift
+++ b/Sources/AVPainReliever/Config/ProfileWriter.swift
@@ -99,7 +99,7 @@ public struct ProfileWriter {
         profile: Profile,
         deviceNames: [USBDevice: String?] = [:]
     ) throws -> String {
-        _ = try Self.validateName(profile.name)
+        try Self.validateName(profile.name)
         return Self.render(profile: profile, deviceNames: deviceNames)
     }
 
@@ -224,7 +224,11 @@ public struct ProfileWriter {
 
     /// TOML bare keys allow `[A-Za-z0-9_-]+`. Profile names also need
     /// to be valid for menu-bar display + the engine's
-    /// pretty-casing logic, so we apply the same restriction.
+    /// pretty-casing logic, so we apply the same restriction. Returns
+    /// the validated name unchanged on success; `@discardableResult`
+    /// because the throw is the load-bearing effect and not every
+    /// caller needs to capture the return.
+    @discardableResult
     static func validateName(_ name: String) throws -> String {
         guard !name.isEmpty else { throw ProfileWriteError.invalidName(name) }
         let allowed = CharacterSet(charactersIn:


### PR DESCRIPTION
## Summary

A second-pass slop review surfaced four findings worth fixing. **Honest accounting: two of them were introduced by the first-pass slop-review work itself.**

| # | Finding | Origin | Fix |
|---|---|---|---|
| **A1/Q2c** (88) | \`CameraController.swift\` doc-block damage from the ISP split | This session, #59 | Move umbrella prose onto \`CameraController\`; keep only the engine-write-seam summary on \`CameraApplier\` |
| **Q3c** (70) | \`ProfileWriter.render\`'s \`_ = try Self.validateName(...)\` discard | This session, #56 | \`@discardableResult\` on \`validateName\`; drop the \`_ =\` |
| **A7** (55) | Duplicate "sessions are cheap" rationale in \`CameraController\` | Prior session, #51 (\`CameraDiscovery\` extraction) | Replace with one-line pointer |
| **Q1c** (55) | \`FourCC.swift\` unused \`import CoreVideo\` | Prior session, #51 (\`FourCC\` extraction) | Swap to \`import Foundation\` |

The pattern is "refactor doesn't finish the job": ISP split adds new protocols but leaves the old protocol's prose attached to a child; extracting a helper leaves the original justification in the source file; adding a \`try\` validation discards a value the caller could have used.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: \`./dev/build --full\` install + app launches normally. (No runtime change: doc comments + import swap + \`@discardableResult\` annotation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)