### PR TITLE
cleanup: doc-comment fixes from second-pass slop review

### DIFF
--- a/Sources/AVPainReliever/Adapters/CameraController.swift
+++ b/Sources/AVPainReliever/Adapters/CameraController.swift
@@ -109,9 +109,15 @@ public protocol VirtualCameraSourceController {
     /// camera's source to match.
     ///
     /// Returns nil when the controller is in any non-live state
-    /// (off, activating, requires-relaunch) — `ProfileApplier`
+    /// (off, activating, requires-relaunch); `ProfileApplier`
     /// then sets the system preference to the profile's literal
     /// camera as it did pre-virtual-camera.
+    ///
+    /// This is host-routing policy expressed at an engine seam.
+    /// Carrying it here (rather than asking the host to rewrite
+    /// each profile's `camera` field before handing it to the
+    /// engine) keeps `apply()` synchronous and the engine free of
+    /// reverse-direction host queries.
     var preferredCameraOverride: String? { get }
 }
 

--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -151,12 +151,13 @@ public final class CameraCaptureSession: NSObject {
 
         let output = AVCaptureVideoDataOutput()
         // Deliver the device's NATIVE pixel format and dimensions.
-        // M2 forced 1280×720 BGRA via `videoSettings`, which works
-        // for the FaceTime HD camera but silently produces zero
-        // frames on USB capture cards (HDMI to U3 capture
-        // 0x1e4e/0x701f is the user's known case — it advertises
-        // BGRA in `availableVideoPixelFormatTypes` but the actual
-        // delivery path drops every frame). Letting the device
+        // An earlier iteration forced 1280×720 BGRA via
+        // `videoSettings`, which works for the FaceTime HD camera
+        // but silently produces zero frames on USB capture cards
+        // (HDMI to U3 capture 0x1e4e/0x701f is the user's known
+        // case: it advertises BGRA in
+        // `availableVideoPixelFormatTypes` but the actual delivery
+        // path drops every frame). Letting the device
         // pick its own format makes the AVCaptureSession work for
         // every camera; `CMIOSinkWriter` then converts to
         // 1280×720 BGRA via `VTPixelTransferSession` before

--- a/Sources/AVPainReliever/Config/Profile.swift
+++ b/Sources/AVPainReliever/Config/Profile.swift
@@ -75,11 +75,12 @@ public struct Profile: Hashable, Sendable {
         self.fingerprintNames = fingerprintNames
     }
 
-    // Manual Hashable / Equatable that excludes `fingerprintNames`.
-    // The names are display-only metadata; a profile loaded from a
-    // TOML with `name = "..."` annotations should compare equal to
-    // the same profile loaded without them, so existing tests + any
-    // semantic identity check stays unaffected by this addition.
+    // Manual Hashable / Equatable that excludes both
+    // `fingerprintNames` and `icon`. They're display-only metadata,
+    // so two semantically-identical profiles compare equal whether
+    // or not one carries names or a custom icon. Per-field rationale
+    // lives on each field's own doc comment; the operator just
+    // mirrors that policy.
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.name == rhs.name
             && lhs.fingerprint == rhs.fingerprint

--- a/Sources/AVPainReliever/Engine/ProfileApplier.swift
+++ b/Sources/AVPainReliever/Engine/ProfileApplier.swift
@@ -63,12 +63,20 @@ public final class ProfileApplier {
         if let cameraName = profile.camera {
             // When the virtual camera is the active routing layer,
             // the *system-wide* preferred camera should point at the
-            // virtual camera itself — that's what FaceTime / Safari
-            // / any AVFoundation-modern client picks up, mirroring
+            // virtual camera itself: that's what FaceTime, Safari,
+            // and any AVFoundation-modern client picks up, mirroring
             // what Zoom/Slack/Teams see once the user has manually
             // selected "AV Pain Reliever". The profile's literal
             // camera name still drives the virtual camera's *source*
             // (the real webcam frames feed in there).
+            //
+            // Failure-mode note: if `setSource` returns `.notFound`
+            // (transient unplug between override-publish and source-
+            // apply), the system preference still points at the
+            // virtual camera while the virtual camera has no live
+            // source. The Camera Extension holds the last frame, so
+            // the symptom is a frozen frame rather than no video.
+            // Next `apply()` cycle re-resolves and recovers.
             let preferredName = virtualCameraSource?.preferredCameraOverride
                 ?? cameraName
             applyCamera(preferredName)
@@ -101,10 +109,10 @@ public final class ProfileApplier {
     }
 
     private func applyCamera(_ name: String) {
-        // No CameraController configured (e.g., older macOS, or
-        // construction-time decision). Per-profile we silently skip;
-        // the configuration layer is responsible for announcing the
-        // limitation if it matters.
+        // CameraApplier is optional in the init: callers can wire
+        // the engine without one (audio-only configurations).
+        // Per-profile we silently skip; the configuration layer is
+        // responsible for announcing the limitation if it matters.
         guard let camera else { return }
         switch camera.setPreferred(named: name) {
         case .ok:


### PR DESCRIPTION
## Summary

Five borderline doc-comment findings from the second-pass slop review, all behavior-preserving.

| # | File | Fix |
|---|---|---|
| **A6** | \`ProfileApplier.swift:103-108\` | "e.g., older macOS" cited a constraint that doesn't exist (deployment target is macOS 14, \`userPreferredCamera\` is macOS 14+). Replaced with the actual reason: \`CameraApplier\` is optional for audio-only configurations. |
| **M2** | \`ProfileApplier.swift:72-76\` | Added a failure-mode note for the \`preferredCameraOverride\` + \`setSource\` \`.notFound\` interaction (frozen-frame symptom; recovers on next \`apply()\`). |
| **A2** | \`Profile.swift:78-82\` | Operator-site comment now mentions both excluded fields (\`fingerprintNames\` AND \`icon\`). |
| **F2** | \`CameraController.swift\` (\`preferredCameraOverride\` doc) | One-line note acknowledging that this carries host-routing policy at an engine seam, and why the alternative was rejected. |
| **Q5c** | \`CameraCaptureSession.swift:154\` | "M2 forced 1280×720 BGRA…" → "An earlier iteration forced…" (the original read as Apple Silicon M2 chip). |

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] No runtime change (doc comments only); build-passing is the strongest signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)