### PR TITLE
refactor: closure-token observers in CameraCaptureSession

### DIFF
--- a/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
+++ b/Sources/AVPainReliever/Adapters/VirtualCamera/CameraCaptureSession.swift
@@ -54,6 +54,13 @@ public final class CameraCaptureSession: NSObject {
     /// would create a self-source feedback loop.
     private let initialSourceName: String?
 
+    /// Tokens returned by `NotificationCenter.addObserver(forName:…)`.
+    /// Released in `deinit` so the runtime stops calling the closures
+    /// after the capture session is gone. The selector-based form
+    /// auto-zeroed, but the closure-token form requires explicit
+    /// teardown.
+    private var observers: [NSObjectProtocol] = []
+
     public init(
         sink: CMIOSinkWriter,
         logger: ApplierLogger,
@@ -63,27 +70,29 @@ public final class CameraCaptureSession: NSObject {
         self.logger = logger
         self.initialSourceName = initialSourceName
         super.init()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleRuntimeError(_:)),
-            name: .AVCaptureSessionRuntimeError,
-            object: session
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleSessionStarted(_:)),
-            name: .AVCaptureSessionDidStartRunning,
-            object: session
-        )
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: .AVCaptureSessionRuntimeError,
+            object: session,
+            queue: nil
+        ) { [weak self] note in
+            let error = note.userInfo?[AVCaptureSessionErrorKey] as? Error
+            self?.logger.error("AVCaptureSession runtime error: \(error?.localizedDescription ?? "unknown")")
+        })
+        observers.append(center.addObserver(
+            forName: .AVCaptureSessionDidStartRunning,
+            object: session,
+            queue: nil
+        ) { [weak self] _ in
+            self?.logger.info("AVCaptureSession reported running")
+        })
     }
 
-    @objc private func handleRuntimeError(_ notification: Notification) {
-        let error = notification.userInfo?[AVCaptureSessionErrorKey] as? Error
-        logger.error("AVCaptureSession runtime error: \(error?.localizedDescription ?? "unknown")")
-    }
-
-    @objc private func handleSessionStarted(_ notification: Notification) {
-        logger.info("AVCaptureSession reported running")
+    deinit {
+        let center = NotificationCenter.default
+        for token in observers {
+            center.removeObserver(token)
+        }
     }
 
     /// Boots up capture asynchronously. Returns immediately.


### PR DESCRIPTION
## Summary

Slop-review findings A5 + I5b (calibrated 38 and 32 respectively).

The two \`NotificationCenter\` observers in \`CameraCaptureSession.init\` were selector-based, forcing two \`@objc\` private methods and the only \`@objc\` surface in the engine library. The class was also the only long-lived engine object without explicit observer cleanup (\`USBWatcher\` has \`deinit { stop() }\`; this one relied on the runtime's auto-zeroing of selector observers).

This PR:
- Converts to \`addObserver(forName:object:queue:using:)\`, stores the returned tokens in a \`[NSObjectProtocol]\`, and adds a \`deinit\` that removes them.
- Drops the two \`@objc\` methods (\`handleRuntimeError\`, \`handleSessionStarted\`); their bodies move into the closures inline.
- Behavior is identical: same notifications, same posting-thread dispatch (\`queue: nil\` matches the selector form's behavior).
- The \`[weak self]\` capture makes the lifetime story explicit at the closure site.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — 183/183 pass
- [x] Manual: \`./dev/build --full\` install + virtual camera streaming via Photo Booth. The \`AVCaptureSession reported running\` log line still fires from the new closure observer (on the posting thread, distinct from the boot thread). Confirmed via \`log stream --info\` filtered to \`category == "CameraCaptureSession"\`.
- [x] Manual: clean quit + relaunch. Pipeline boots normally on the new process; \`deinit\`'s \`removeObserver\` calls didn't crash on teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)