### PR TITLE
fix: tighten ProfileWriter section-end regex for hand-edited TOML

### DIFF
--- a/Sources/AVPainReliever/Config/ProfileWriter.swift
+++ b/Sources/AVPainReliever/Config/ProfileWriter.swift
@@ -249,6 +249,22 @@ public struct ProfileWriter {
         return try? NSRegularExpression(pattern: pattern)
     }
 
+    /// Compiled regex matching the start of any TOML section header
+    /// (`[name]`, `[name.subname]`, or `[[array.name]]`) at column 1.
+    /// Used by `sectionRange` to find where the targeted section
+    /// ends. Cached because the pattern has no per-call parameters.
+    ///
+    /// We require the bracket to enclose one or more TOML bare-key
+    /// characters and a closing `]` so a hand-edited array value
+    /// like `[1, 2],` at column 1 is not mistaken for a section
+    /// start. Quoted-key sections (`["x.y"]`) are not matched, but
+    /// the writer never produces them and they're rare in user files.
+    private static let nextSectionRegex: NSRegularExpression? = {
+        try? NSRegularExpression(
+            pattern: "(?m)^[[:space:]]*\\[\\[?[A-Za-z0-9_.\\-]+\\]\\]?"
+        )
+    }()
+
     private static func containsProfile(named: String, in toml: String) -> Bool {
         guard let regex = headerRegex(for: named) else { return false }
         let range = NSRange(toml.startIndex..., in: toml)
@@ -266,13 +282,14 @@ public struct ProfileWriter {
               let headerRange = Range(headerMatch.range, in: toml) else {
             return nil
         }
-        // Scan from after the header line for the next line that
-        // starts with `[`. That's the start of the next section, OR
-        // end of file.
+        // Scan from after the header line for the next TOML section
+        // header. The pattern lives on `nextSectionRegex` and is
+        // strict about what it counts as a header so hand-edited
+        // files with multi-line array continuations don't terminate
+        // the section early.
         let afterHeader = headerRange.upperBound
         let afterRange = NSRange(afterHeader..<toml.endIndex, in: toml)
-        let nextSectionPattern = "(?m)^[[:space:]]*\\["
-        if let nextRegex = try? NSRegularExpression(pattern: nextSectionPattern),
+        if let nextRegex = Self.nextSectionRegex,
            let nextMatch = nextRegex.firstMatch(in: toml, range: afterRange),
            let nextRange = Range(nextMatch.range, in: toml) {
             return headerRange.lowerBound..<nextRange.lowerBound

--- a/Tests/AVPainRelieverTests/ProfileWriterTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileWriterTests.swift
@@ -297,6 +297,44 @@ struct ProfileWriterTests {
         }
     }
 
+    @Test("delete spans hand-edited content with `[`-prefixed lines that aren't headers")
+    func deletePreservesNonHeaderBracketLines() throws {
+        let url = tempTOMLURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // A user has hand-edited extra TOML inside `home-office`
+        // that has `[`-prefixed lines at column 1 (a nested array
+        // value split across lines). The old loose section pattern
+        // would have terminated the section at one of those lines,
+        // leaving orphaned content + the next real section bleeding
+        // into the deleted slot.
+        let prior = """
+        [profiles.home-office]
+        audioInput = "Yeti Stereo Microphone"
+        nested_array = [
+        [1, 2],
+        [3, 4],
+        ]
+        fingerprint = [
+          { vendorID = 0x2188, productID = 0x6533 },
+        ]
+
+        [profiles.studio]
+        audioInput = "Shure MV7"
+        """
+        try prior.write(to: url, atomically: true, encoding: .utf8)
+
+        try writer.delete(named: "home-office", in: url)
+
+        let after = try String(contentsOf: url, encoding: .utf8)
+        #expect(!after.contains("[profiles.home-office]"))
+        #expect(!after.contains("nested_array"))
+        #expect(!after.contains("[1, 2]"))
+        #expect(!after.contains("[3, 4]"))
+        #expect(after.contains("[profiles.studio]"))
+        #expect(after.contains("Shure MV7"))
+    }
+
     @Test("delete on a missing file raises writeFailed")
     func deleteOnMissingFileThrows() throws {
         let url = tempTOMLURL()


### PR DESCRIPTION
## Summary

Slop-review missed-finding **M1** (calibrated 55). The \`nextSectionPattern\` used by \`sectionRange\` matched any line starting with optional whitespace and \`[\`. The writer's own output never produces a non-header \`[\`-at-column-1 line, but a hand-edited config with a multi-line nested-array value (e.g. \`nested_array = [\n[1, 2],\n[3, 4],\n]\`) has lines that the loose pattern picks up as section starts. A \`delete\` or \`replace\` on the preceding section would terminate early, leaving array content orphaned in the file.

This PR tightens the pattern to require a TOML bare-key body (\`[A-Za-z0-9_.\-]+\`) between the brackets, with optional double brackets to cover TOML's array-of-tables form. Lifts the pattern to a \`private static let\` since it has no per-call parameters (which also addresses **Q4c** from the second-pass review: "compiles a fresh regex per call").

Quoted-key sections (\`["x.y"]\`) are not matched by the new pattern, but the writer never produces them and they're rare in hand-edited files.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test\` — **184/184 pass**. Added one regression test (\`deletePreservesNonHeaderBracketLines\`) that builds a file with non-header \`[\`-prefixed lines inside a section, deletes the surrounding section, and verifies the inner content is gone.
- [x] Manual: \`./dev/build --full\` install + add/delete a profile via the wizard. Identical behavior. (The wizard never produces the affected shape; the bug only triggered on hand-edited TOML.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)