### PR TITLE
cleanup: app-target slop-review pass

### DIFF
--- a/Sources/AVPainRelieverApp/AboutView.swift
+++ b/Sources/AVPainRelieverApp/AboutView.swift
@@ -2,6 +2,26 @@ import SwiftUI
 
 let aboutWindowID = "about-window"
 
+/// Renders the version string shown in About and Settings. Falls
+/// back to "Dev build" when the binary isn't bundled (the SPM
+/// build path).
+///
+/// Format: matches Apple's standard About-panel phrasing
+/// ("Version X.Y.Z"). Drops the app name (the title above the
+/// version line already shows it) and drops the parenthesized
+/// build number (we set CFBundleVersion == CFBundleShortVersionString,
+/// so showing both was redundant).
+enum VersionInfo {
+    static var short: String {
+        let info = Bundle.main.infoDictionary
+        let shortVersion = info?["CFBundleShortVersionString"] as? String
+        switch shortVersion {
+        case let v?: return "Version \(v)"
+        default:     return "Dev build"
+        }
+    }
+}
+
 /// About scene shown via the menu item and the standard ⌘? path.
 /// Replaces `NSApp.orderFrontStandardAboutPanel`. Layout: app icon
 /// (with a slow scale-pulse), the name, the version, a small

--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -336,7 +336,7 @@ struct AddProfileView: View {
                                     // when they're away from that
                                     // location. Yellow pill makes
                                     // the unavailable state obvious.
-                                    pill(text: "Not connected", tint: Theme.Color.warn)
+                                    StatusPill(text: "Not connected", tint: Theme.Color.warn)
                                 } else if DevicePortability
                                     .portabilityCategory(deviceName: entry.name) != nil {
                                     // Muted gray "Travels with you"
@@ -348,7 +348,7 @@ struct AddProfileView: View {
                                     // informational, explaining why
                                     // the row is shown unticked. Tone
                                     // is descriptive, not directive.
-                                    pill(text: "Travels with you", tint: Theme.Color.muted)
+                                    StatusPill(text: "Travels with you", tint: .gray)
                                 } else if let category = DevicePortability
                                     .importantCategory(deviceName: entry.name) {
                                     // Green "Important" pill on the
@@ -362,7 +362,7 @@ struct AddProfileView: View {
                                     // exclusive with "Travels with you"
                                     // by classifier construction
                                     // (their keywords don't overlap).
-                                    pill(text: "Important: \(category)", tint: Theme.Color.success)
+                                    StatusPill(text: "Important: \(category)", tint: Theme.Color.success)
                                 }
                             }
                             Text(idLine(for: entry.device))
@@ -444,18 +444,6 @@ struct AddProfileView: View {
                 Text(device.name).tag(String?.some(device.name))
             }
         }
-    }
-
-    /// One-stop pill builder used by both the "Not connected" badge
-    /// and the "Suggested: untick" hint. Single source of truth for
-    /// the wizard's small status pills.
-    private func pill(text: String, tint: Color) -> some View {
-        Text(text)
-            .font(.caption2.weight(.semibold))
-            .foregroundStyle(.black)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(tint.opacity(0.85), in: Capsule())
     }
 
     /// Caption line under each device row. Shows vid/pid and the

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -36,14 +36,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// product name until the engine performs its first evaluation.
     @Published var currentProfileTitle: String = "AV Pain Reliever"
 
-    /// Camera the active profile asks the system to prefer, or nil
-    /// if the profile doesn't manage cameras. Surfaced in the menu
-    /// for at-a-glance "what camera should I be on" info — useful
-    /// because Zoom/Slack/Teams don't follow the system preference,
-    /// so the user sometimes has to manually pick the same name in
-    /// those apps.
-    @Published var currentCameraDisplay: String? = nil
-
     /// Slug of the most-recently-applied profile. Used by the menu's
     /// "Switch to" submenu to put a checkmark next to the active
     /// entry. Differs from `currentProfileTitle` (pretty-cased,
@@ -349,7 +341,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private func handleProfileApplied(_ profile: Profile) {
         let pretty = PrettyName.format(profile.name)
         currentProfileTitle = pretty
-        currentCameraDisplay = profile.camera
         activeProfileSlug = profile.name
 
         // Toast only on actual changes (different profile name from

--- a/Sources/AVPainRelieverApp/DevicePortability.swift
+++ b/Sources/AVPainRelieverApp/DevicePortability.swift
@@ -21,21 +21,6 @@ import Foundation
 /// Anything that smells like a dock, monitor, microphone, audio
 /// interface, webcam, or display = location-specific, don't flag.
 enum DevicePortability {
-    /// True if the device's name suggests it's a portable peripheral
-    /// the user probably carries between locations. Returns false
-    /// when uncertain.
-    static func isLikelyPortable(deviceName: String?) -> Bool {
-        guard let name = deviceName?.lowercased(), !name.isEmpty else {
-            // Unnamed devices (hub legs) are stable parts of a dock,
-            // not portable peripherals. Don't flag.
-            return false
-        }
-        for keyword in portableKeywords {
-            if name.contains(keyword) { return true }
-        }
-        return false
-    }
-
     /// Short label shown next to a flagged row to hint why we
     /// suggest unticking it. Returns nil when the device isn't
     /// flagged. Phrased as a category, not an instruction — the
@@ -64,19 +49,6 @@ enum DevicePortability {
         }
         return nil
     }
-
-    /// Lowercased substrings that mark a device as "probably travels
-    /// with you". Order doesn't matter — first match wins.
-    private static let portableKeywords: [String] = [
-        // Pointing devices
-        "magic mouse", "magic trackpad", "trackpad", "mouse",
-        // Keyboards
-        "keyboard", "magic keyboard",
-        // Phones / tablets
-        "iphone", "ipad", "android", "pixel",
-        // Wearables
-        "airpods", "watch", "headphones", "headset", "earbuds", "buds",
-    ]
 
     /// Short label for "headline hardware" — the standalone,
     /// dedicated devices a user is most likely to pick as their

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -73,8 +73,11 @@ final class SettingsStore: ObservableObject {
         didSet { defaults.set(menuBarIconSymbol, forKey: Key.menuBarIconSymbol) }
     }
 
-    /// Lifetime count of profile applications. Drives the easter-egg
-    /// stats line. Bumped from `AppDelegate.handleProfileApplied`.
+    /// Lifetime count of profile applications. Surfaced as the
+    /// "Auto-switches" row in the Stats settings tab. Bumped from
+    /// `AppDelegate.handleProfileApplied` on every change-of-profile
+    /// (the initial evaluation on launch is intentionally not counted;
+    /// see `lastNotifiedName` gating there).
     @Published var profileSwitchCount: Int {
         didSet { defaults.set(profileSwitchCount, forKey: Key.profileSwitchCount) }
     }

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -167,12 +167,7 @@ private struct CameraSettingsTab: View {
                 .font(.callout)
             Spacer()
             if activator.isEnvOverride {
-                Text("Debug override")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Theme.Color.warn, in: Capsule())
+                StatusPill(text: "Debug override", tint: Theme.Color.warn)
             }
         }
         .padding(.vertical, 2)
@@ -315,27 +310,6 @@ private struct GeneralSettingsTab: View {
             }
         }
         .groupedFormChrome()
-    }
-}
-
-/// Small helper to render the version string consistently across
-/// About, Settings, and any future window that needs it. Falls back
-/// to "Dev build" when the binary isn't bundled (the SPM build
-/// path).
-///
-/// Format: matches Apple's standard About-panel phrasing
-/// ("Version X.Y.Z"). Drops the app name (the title above the
-/// version line already shows it) and drops the parenthesized
-/// build number (we set CFBundleVersion == CFBundleShortVersionString,
-/// so showing both was redundant).
-enum VersionInfo {
-    static var short: String {
-        let info = Bundle.main.infoDictionary
-        let shortVersion = info?["CFBundleShortVersionString"] as? String
-        switch shortVersion {
-        case let v?: return "Version \(v)"
-        default:     return "Dev build"
-        }
     }
 }
 
@@ -483,12 +457,7 @@ private struct ProfileRow: View {
                     Text(PrettyName.format(profile.name))
                         .font(.body.weight(.medium))
                     if isActive {
-                        Text("Active")
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Theme.Color.success, in: Capsule())
+                        StatusPill(text: "Active", tint: Theme.Color.success)
                     }
                 }
                 // Vertical device list — each device on its own row

--- a/Sources/AVPainRelieverApp/StatusPill.swift
+++ b/Sources/AVPainRelieverApp/StatusPill.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Compact tinted capsule used for at-a-glance status badges
+/// across the app: "Active" on the running profile row,
+/// "Debug override" on the virtual-camera status row,
+/// "Not connected" / "Travels with you" / "Important: <category>"
+/// on wizard device rows.
+///
+/// White text on a saturated tint reads cleanly in both light
+/// and dark mode. Earlier wizard pills used `.black` text on a
+/// 0.85-opacity tint; that contrast degraded in dark mode where
+/// the tint dimmed toward the background. Settling on a single
+/// idiom (full-opacity tint, white text) keeps the pills legible
+/// in both appearances and removes the visual drift between the
+/// settings pills and the wizard pills.
+struct StatusPill: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(tint, in: Capsule())
+    }
+}

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -8,9 +8,8 @@ import AppKit
 /// direction (2026-05-02): the app should look like a plain native
 /// macOS utility, no custom accent colors. So this namespace exposes
 /// a small set of semantic system colors — success / warn / error
-/// for status pills and banner-style errors, plus muted for
-/// low-volume informational pills. Everything else (headers,
-/// captions, links, button tints) uses SwiftUI's defaults —
+/// for status pills and banner-style errors. Everything else
+/// (headers, captions, links, button tints) uses SwiftUI's defaults —
 /// `.primary` for body text, `.secondary` for hints, the system
 /// accent for prominent buttons.
 ///
@@ -29,13 +28,6 @@ enum Theme {
         /// icon. System red, same as Apple's own destructive action
         /// styling.
         static let error = SwiftUI.Color.red
-        /// Quiet, informational pills — "Travels with you" tag on
-        /// portable peripherals in the wizard. Lower visual volume
-        /// than the warn / success / error tints so the
-        /// informational signal doesn't compete with the actionable
-        /// pills (green Important, yellow error banners). System
-        /// gray adapts to light/dark mode automatically.
-        static let muted = SwiftUI.Color.gray
     }
 
     enum Symbol {

--- a/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
+++ b/Tests/AVPainRelieverAppTests/DevicePortabilityTests.swift
@@ -3,36 +3,6 @@ import Testing
 
 @Suite("DevicePortability")
 struct DevicePortabilityTests {
-    @Test("Magic Keyboard / Magic Mouse are flagged as portable")
-    func magicAccessoriesFlagged() {
-        #expect(DevicePortability.isLikelyPortable(deviceName: "Magic Keyboard"))
-        #expect(DevicePortability.isLikelyPortable(deviceName: "Magic Mouse"))
-        #expect(DevicePortability.isLikelyPortable(deviceName: "Magic Trackpad 2"))
-    }
-
-    @Test("phones and wearables are flagged")
-    func phonesFlagged() {
-        #expect(DevicePortability.isLikelyPortable(deviceName: "Eric's iPhone"))
-        #expect(DevicePortability.isLikelyPortable(deviceName: "iPad Pro"))
-        #expect(DevicePortability.isLikelyPortable(deviceName: "AirPods Pro"))
-        #expect(DevicePortability.isLikelyPortable(deviceName: "Apple Watch"))
-    }
-
-    @Test("docks, monitors, and audio interfaces are NOT flagged")
-    func locationStableNotFlagged() {
-        #expect(!DevicePortability.isLikelyPortable(deviceName: "CalDigit Thunderbolt 3 Audio"))
-        #expect(!DevicePortability.isLikelyPortable(deviceName: "LG UltraFine Display Camera"))
-        #expect(!DevicePortability.isLikelyPortable(deviceName: "Yeti Stereo Microphone"))
-        #expect(!DevicePortability.isLikelyPortable(deviceName: "Shure MV7"))
-        #expect(!DevicePortability.isLikelyPortable(deviceName: "External DAC"))
-    }
-
-    @Test("nil and empty names are not flagged (hub legs stay in)")
-    func nilOrEmptyStaysIn() {
-        #expect(!DevicePortability.isLikelyPortable(deviceName: nil))
-        #expect(!DevicePortability.isLikelyPortable(deviceName: ""))
-    }
-
     @Test("category labels classify correctly")
     func categoryLabels() {
         #expect(DevicePortability.portabilityCategory(deviceName: "Magic Keyboard") == "keyboard")


### PR DESCRIPTION
## Summary

Six items from the app-target slop review. Five are user-invisible (behavior-preserving). One has an observable change: better dark-mode pill contrast.

| # | Change | Notes |
|---|---|---|
| 1 | Delete `AppDelegate.currentCameraDisplay` | Dead `@Published`, no readers anywhere in the app target. |
| 2 | Delete `DevicePortability.isLikelyPortable` + `portableKeywords` (and matching tests) | Live app uses `portabilityCategory` / `importantCategory`. Removes the second drift-prone keyword list. |
| 3 | Move `VersionInfo` from `SettingsView.swift` to `AboutView.swift` | Its only consumer is `AboutView`. |
| 4 | Rewrite `SettingsStore.profileSwitchCount` doc | Was "easter-egg stats line"; it's now a first-class `LabeledContent("Auto-switches", ...)` row in the Stats tab. |
| 5 | Drop `Theme.Color.muted` | CLAUDE.md: status colors are the only `Theme.Color` entries. The one consumer uses `Color.gray` inline via the new pill. |
| 6 | Extract `StatusPill` and migrate 3 sites | Replaces the `AddProfileView` local `pill(...)` helper + 2 inline Capsule chromes in `SettingsView`. |

### Honest call-out on item 6

Plan said "adaptive text color (handles dark mode)". I took the simpler path: unify on the dominant existing idiom (full-opacity tint, white text — already used at `SettingsView.swift` "Active" and "Debug override"). The wizard pills (`AddProfileView`) lose two things in addition to fixing the dark-mode contrast bug:

- Hardcoded `.black` foreground → `.white`.
- `tint.opacity(0.85)` background → full-opacity tint.

So the wizard pills look slightly more saturated now. Both changes flow from the unification; if you'd prefer to keep the 0.85 opacity in the wizard, say the word and I'll thread an `opacity` param into `StatusPill`.

### Net diff

- `+60 / -127` across 8 modified files + 1 new file (`StatusPill.swift`).
- Test count: `184 → 180` (the four dead `isLikelyPortable` tests).

## Test plan

`swift build` and `swift test` both green locally on this branch.

Behavior-preserving items 1–5 should produce no observable change. Smoke test for item 6 is enough:

- [ ] Open Settings → Profiles. Plug in a known dock so a profile becomes Active. Verify the green "Active" pill renders normally with white text.
- [ ] Open Settings → Virtual camera. With `AVPR_DEBUG_OVERRIDE` set (or whatever surfaces `isEnvOverride`), verify the orange "Debug override" pill renders normally.
- [ ] Open the Add Profile wizard with hardware attached. Verify three pill variants render: yellow "Not connected" on a saved-but-unattached device, gray "Travels with you" on a portable peripheral (Magic Keyboard etc.), green "Important: <category>" on a dedicated mic / camera / audio interface.
- [ ] Toggle System Settings → Appearance between Light and Dark while the wizard is open. The pills should stay legible in both modes (white text on saturated tint). Pre-fix: the wizard pills used `.black` text on a 0.85-opacity tint, which dimmed in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)