### PR TITLE
cleanup: borderline-backlog trivial wins (A4 + M3 + I1b)

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -216,7 +216,7 @@ struct AddProfileView: View {
         }
         .alert(
             "Profile already exists",
-            isPresented: collisionPresented,
+            isPresented: .isPresent($viewModel.pendingCollision),
             presenting: viewModel.pendingCollision
         ) { collision in
             Button("Update “\(collision.existingPrettyName)”") {
@@ -231,18 +231,6 @@ struct AddProfileView: View {
         } message: { collision in
             Text("There's already a profile called “\(collision.existingPrettyName)”. Did you mean to update it with the devices and audio you've selected, or is this a different location?")
         }
-    }
-
-    /// Glue between SwiftUI's `isPresented` Binding API and our
-    /// `Identifiable?` collision state — bound to true whenever a
-    /// pending collision exists; setting it false clears the state.
-    private var collisionPresented: Binding<Bool> {
-        Binding(
-            get: { viewModel.pendingCollision != nil },
-            set: { presented in
-                if !presented { viewModel.cancelCollision() }
-            }
-        )
     }
 
     // MARK: - Subviews

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -338,7 +338,7 @@ private struct MenuContentView: View {
             // weight (semibold when active) that NSMenuItem honours
             // via `attributedTitle`.
             Label {
-                Text(menuLabel(for: profile, pretty: pretty, isActive: isActive))
+                Text(menuLabel(pretty: pretty, isActive: isActive))
             } icon: {
                 Image(systemName: iconSymbol)
             }
@@ -353,7 +353,6 @@ private struct MenuContentView: View {
     /// Alignment with `Edit Profiles…` is handled by the menu's image
     /// column (see `profileMenuEntry`).
     private func menuLabel(
-        for profile: Profile,
         pretty: String,
         isActive: Bool
     ) -> AttributedString {

--- a/Sources/AVPainRelieverApp/BindingExtensions.swift
+++ b/Sources/AVPainRelieverApp/BindingExtensions.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension Binding {
+    /// Bridges a `Binding<T?>` to a `Binding<Bool>` for SwiftUI APIs
+    /// that take an `isPresented:` flag (`.alert`, `.sheet`, etc.).
+    /// Reads true while the source is non-nil; writing false clears
+    /// the source. Writing true is a no-op because the source's
+    /// payload is what determines the presented state, not the bool.
+    static func isPresent<Wrapped>(_ source: Binding<Wrapped?>) -> Binding<Bool> where Value == Bool {
+        Binding<Bool>(
+            get: { source.wrappedValue != nil },
+            set: { presented in
+                if !presented { source.wrappedValue = nil }
+            }
+        )
+    }
+}

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -345,10 +345,7 @@ private struct ProfilesSettingsTab: View {
         }
         .alert(
             "Delete “\(PrettyName.format(profilePendingDeletion?.name ?? ""))”?",
-            isPresented: Binding(
-                get: { profilePendingDeletion != nil },
-                set: { if !$0 { profilePendingDeletion = nil } }
-            ),
+            isPresented: .isPresent($profilePendingDeletion),
             presenting: profilePendingDeletion
         ) { profile in
             // Cancel first → bound to .cancelAction (Return key) → safe

--- a/Sources/AVPainRelieverApp/WelcomeView.swift
+++ b/Sources/AVPainRelieverApp/WelcomeView.swift
@@ -61,13 +61,15 @@ struct WelcomeView: View {
     /// first name when available so first launch reads as a hello to
     /// the human at the keyboard, not the product. `NSFullUserName()`
     /// is set by macOS at account creation and almost always non-empty,
-    /// but the fallback covers headless / unusual setups.
-    private static var greetingTitle: String {
+    /// but the fallback covers headless / unusual setups. `static let`
+    /// caches the result for the process lifetime; the username doesn't
+    /// change at runtime.
+    private static let greetingTitle: String = {
         let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
         let firstName = full.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? ""
         if firstName.isEmpty {
             return "Welcome to \(Theme.Copy.appName)"
         }
         return "Welcome, \(firstName)."
-    }
+    }()
 }


### PR DESCRIPTION
## Summary

Three small behavior-preserving items from the slop-review borderline backlog. I dropped three more candidates after reading the actual code — they didn't survive verification.

| # | Change | Notes |
|---|---|---|
| A4 | Drop dead `profile` param from `menuLabel(for:pretty:isActive:)` in App.swift | Param was unused inside the function and at the single call site. |
| M3 | `WelcomeView.greetingTitle`: `static var` → `static let` | Was re-evaluating `NSFullUserName()` per access. The username doesn't change at runtime, so caching is correct. |
| I1b | Add `Binding.isPresent(_:)`; migrate two `isPresented:` glue sites | Replaces an inline `Binding(get:set:)` block in SettingsView (delete-confirmation alert) and a 7-line `collisionPresented` helper in AddProfileView (collision alert). `AddProfileViewModel.cancelCollision()` stays — still called by the alert's explicit Cancel button. |

### Dropped after verification

- **M4 (ProfileIcon predicate-closure → dict).** Plan recommended a prefix-keyed dict, but the predicates mix `hasPrefix`, `contains`, `==`, and `||` (e.g. `hasPrefix("conference") || contains("meeting")`). The closure list is the right shape for that.
- **M6 (count phrasing → macOS 14 inflect idiom).** Real drift, but migrating to `Text("^[\(count) day](inflect: true)")` changes `streakString` and `trackingSinceString` from `String` returns to `Text` / `LocalizedStringResource`, propagating to `LabeledContent("...", value: ...)` call sites. Cost outweighs benefit on an un-localized codebase.
- **F12 (three `@Published` derivations from one event).** Already resolved by Q2c in PR #66 — only two derivations remain (`currentProfileTitle` for menu-bar title, `activeProfileSlug` for menu-checkmark logic), and they legitimately serve different views with different formats.

Net `+25 / -22` across 4 modified + 1 new file (`BindingExtensions.swift`). Test count unchanged at 180. `swift build` + `swift test` green locally.

## Test plan

All three items are behavior-preserving. Two 30-second smoke tests cover the observable surfaces:

- [ ] **Profile delete confirmation alert (I1b site #1).** Settings → Profiles → click delete on any profile row. Expected: alert appears asking "Delete <name>?". Click Cancel → alert dismisses, profile stays. Click again → click Delete → profile is gone. (Pre-fix and post-fix should be identical.)
- [ ] **Add Profile name-collision alert (I1b site #2).** Add Profile → enter the name of an existing profile → click Save. Expected: collision alert appears offering "Update existing" / "Save as new" / Cancel. Click Cancel → alert dismisses, you stay on the form. Click each of the other two paths in separate runs → both should land their saves correctly.

Items A4 and M3 are not user-observable (dead-param removal, same-result-cached-once). The first time anyone hits the Welcome screen on a fresh launch, the title still says "Welcome, <FirstName>." identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)