### PR TITLE
fix: spell out the deletion side effect in edit-rename collisions

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -229,7 +229,11 @@ struct AddProfileView: View {
                 viewModel.cancelCollision()
             }
         } message: { collision in
-            Text("There's already a profile called “\(collision.existingPrettyName)”. Did you mean to update it with the devices and audio you've selected, or is this a different location?")
+            if let editingName = collision.editingPrettyName {
+                Text("There's already a profile called “\(collision.existingPrettyName)”. Updating replaces “\(collision.existingPrettyName)” and deletes “\(editingName)” (the one you're editing). Saving as new renames “\(editingName)” to “\(collision.newPrettyName)” instead.")
+            } else {
+                Text("There's already a profile called “\(collision.existingPrettyName)”. Did you mean to update it with the devices and audio you've selected, or is this a different location?")
+            }
         }
     }
 

--- a/Sources/AVPainRelieverApp/AddProfileViewModel.swift
+++ b/Sources/AVPainRelieverApp/AddProfileViewModel.swift
@@ -20,6 +20,15 @@ struct PendingCollision: Identifiable, Equatable {
     var newPrettyName: String { PrettyName.format(newSlug) }
     /// Slug of the existing profile we'd replace.
     let existingSlug: String
+    /// Pretty-cased name of the profile the user is editing, when
+    /// they got here by renaming an existing profile into a colliding
+    /// slug. Nil when the wizard is creating a new profile and the
+    /// typed name happened to collide. Drives the alert body so the
+    /// edit-rename case can spell out that the profile being edited
+    /// will also be deleted (both the "Update existing" and "Save as
+    /// new" paths drop the original section, see `performSave`'s
+    /// `editingSlug != slug` cleanup).
+    let editingPrettyName: String?
 }
 
 /// Owns the editable state of the Add-Profile form and runs the save
@@ -431,10 +440,16 @@ final class AddProfileViewModel: ObservableObject {
         if writer.profileExists(named: slug, in: configURL) {
             // Don't write yet — surface the collision dialog and let
             // the user pick (update existing / save as new / cancel).
+            // editingSlug is non-nil here only when the user is
+            // editing an existing profile and renamed it into a
+            // colliding slug — `save()`'s in-place fast-path above
+            // already returned for the `slug == editingSlug` case,
+            // so reaching this branch means we're truly renaming.
             pendingCollision = PendingCollision(
                 existingPrettyName: PrettyName.format(slug),
                 newSlug: writer.nextAvailableName(base: slug, in: configURL),
-                existingSlug: slug
+                existingSlug: slug,
+                editingPrettyName: editingSlug.map(PrettyName.format)
             )
             return
         }

--- a/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
+++ b/Tests/AVPainRelieverAppTests/AddProfileViewModelTests.swift
@@ -804,6 +804,74 @@ struct AddProfileViewModelTests {
         #expect(receivedForceApplySlug == "home-office")
     }
 
+    @Test("collision from new-profile creation has nil editingPrettyName")
+    func collisionFromNewProfileLeavesEditingNil() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vm-collision-new-\(UUID()).toml")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try """
+        [profiles.home-office]
+        audioInput = "Existing Mic"
+        """.write(to: url, atomically: true, encoding: .utf8)
+
+        let vm = AddProfileViewModel(
+            watcher: FakeWatcher(),
+            audioController: FakeAudio(devices: []),
+            cameraController: FakeCamera(cameras: []),
+            configURL: url,
+            existingProfileSlugs: ["home-office"],
+            onSaved: { _ in }
+        )
+        vm.name = "home-office"
+        vm.save()
+        // Wizard surfaces the collision; editingPrettyName stays nil
+        // because no profile is being edited. The alert body uses
+        // this to pick the "is this a different location?" wording.
+        #expect(vm.pendingCollision != nil)
+        #expect(vm.pendingCollision?.editingPrettyName == nil)
+    }
+
+    @Test("collision from edit-rename carries the editing profile's pretty name")
+    func collisionFromEditRenameCarriesEditingName() throws {
+        // Regression for the misleading-collision-dialog case: when
+        // the user edits "Studio" and renames it into the existing
+        // "Home Office" slug, the alert body needs to spell out that
+        // BOTH paths through the dialog will delete "Studio". The
+        // edit-rename signal is the editingPrettyName field — when
+        // non-nil, AddProfileView renders the deletion-aware copy.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vm-collision-edit-\(UUID()).toml")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try """
+        [profiles.home-office]
+        audioInput = "Existing Mic"
+
+        [profiles.studio]
+        audioInput = "Studio Mic"
+        """.write(to: url, atomically: true, encoding: .utf8)
+
+        let editing = Profile(
+            name: "studio",
+            fingerprint: [],
+            audioInput: "Studio Mic"
+        )
+        let vm = AddProfileViewModel(
+            watcher: FakeWatcher(),
+            audioController: FakeAudio(devices: ["Studio Mic"]),
+            cameraController: FakeCamera(cameras: []),
+            configURL: url,
+            editing: editing,
+            existingProfileSlugs: ["home-office", "studio"],
+            onSaved: { _ in }
+        )
+        vm.name = "home-office"
+        vm.save()
+
+        #expect(vm.pendingCollision != nil)
+        #expect(vm.pendingCollision?.existingPrettyName == "Home Office")
+        #expect(vm.pendingCollision?.editingPrettyName == "Studio")
+    }
+
     @Test("currentPreferredName fallback skips the virtual camera")
     func preFillSkipsVirtualCamera() {
         // Mirrors a real machine where userPreferredCamera was set


### PR DESCRIPTION
## Summary

User-reported edge case while testing PR #69: editing profile A, renaming to an existing profile B's name, picking "Update existing" wiped the profile they were editing without warning.

The behavior is correct (see [AddProfileViewModel.swift:521-527](Sources/AVPainRelieverApp/AddProfileViewModel.swift:521) — renaming a profile drops its old slug, by design). The dialog wording is what's wrong: the copy was written for the new-profile creation context and doesn't acknowledge that BOTH non-cancel paths delete A in the edit-rename case.

| Path | New-profile context | Edit-rename context |
|---|---|---|
| Update existing | Overwrites B, no other change | Overwrites B, **deletes A** |
| Save as new | Creates B-2, no other change | Creates B-2 with A's edits, **deletes A** |

### Fix shape

- Add `editingPrettyName: String?` to `PendingCollision`, populated from `editingSlug` at collision-detect time. Nil for the new-profile case.
- Branch the alert body on whether `editingPrettyName` is set:

> **New-profile (unchanged):** "There's already a profile called \"B\". Did you mean to update it with the devices and audio you've selected, or is this a different location?"
>
> **Edit-rename (new):** "There's already a profile called \"B\". Updating replaces \"B\" and deletes \"A\" (the one you're editing). Saving as new renames \"A\" to \"B-2\" instead."

Buttons stay the same. Behavior under each button is unchanged. Only the body adapts.

### Tests

Two new tests in `AddProfileViewModelTests`:

- `collision from new-profile creation has nil editingPrettyName` — guards the create-new path.
- `collision from edit-rename carries the editing profile's pretty name` — guards the new context-aware path.

Test count: 180 → 182 (3-file diff, +89 / -2). `swift build` + `swift test` green locally.

### Relationship to PR #69

Independent — this branch is off `main`, not stacked on `#69`. The two PRs touch different surfaces (`#69`: `onSaved` callback signature + AppDelegate force-apply; this PR: `PendingCollision` shape + alert body). Whichever lands first, the other rebases cleanly.

## Test plan

Build with `./dev/build`. The dialog wording is the whole fix, so each scenario is "open Add Profile, drive it to the alert, read the body":

- [ ] **New-profile collision (unchanged copy).** Add Profile → type the name of an existing profile → Save. Body reads "Did you mean to update it with the devices and audio you've selected, or is this a different location?". (No regression.)
- [ ] **Edit-rename collision (the new copy).** Settings → Profiles → Edit any profile → change its name to another existing profile's name → Save. Body reads "Updating replaces \"B\" and deletes \"A\" (the one you're editing). Saving as new renames \"A\" to \"B-2\" instead." with the actual profile names substituted in.
- [ ] (Optional) Pick each button in the edit-rename dialog and confirm the behavior matches what the body now promises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)