### PR TITLE
fix: re-focus the name field on every wizard open

### DIFF
--- a/Sources/AVPainRelieverApp/AddProfileView.swift
+++ b/Sources/AVPainRelieverApp/AddProfileView.swift
@@ -12,6 +12,14 @@ struct AddProfileView: View {
     /// Drives the icon-picker popover anchored to the icon button.
     @State private var showIconPicker = false
 
+    /// Programmatic focus on the name field. SwiftUI's Window scene
+    /// keeps the same NSWindow across open/dismiss cycles, and the
+    /// macOS first-responder is preserved across the `.id`-driven
+    /// view rebuild — so the second-and-later wizard opens land
+    /// without any field focused. Pushing focus on `.onAppear` makes
+    /// every open feel like the first.
+    @FocusState private var nameFieldFocused: Bool
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Form {
@@ -25,6 +33,7 @@ struct AddProfileView: View {
                             TextField("e.g. Home Office", text: $viewModel.name)
                                 .textFieldStyle(.roundedBorder)
                                 .labelsHidden()
+                                .focused($nameFieldFocused)
                                 .frame(maxWidth: .infinity)
                             // Tappable icon preview — defaults to the
                             // slug-driven auto-pick, but clicking opens
@@ -203,6 +212,16 @@ struct AddProfileView: View {
         // dynamically so the title bar tracks Add vs Edit mode.
         .navigationTitle(viewModel.editingExisting ? "Edit Profile" : "Add Profile")
         .centeredOnScreen()
+        .onAppear {
+            // Defer one runloop tick so the TextField's underlying
+            // NSResponder exists by the time we ask for focus —
+            // setting `nameFieldFocused = true` synchronously inside
+            // `.onAppear` no-ops on macOS 14 because the field's
+            // first-responder isn't wired up yet at that point.
+            DispatchQueue.main.async {
+                nameFieldFocused = true
+            }
+        }
         .onChange(of: viewModel.didSave) { _, saved in
             // Brief save-success window (~0.45 s) so the green check
             // and "Saved" affordance read as a beat of feedback rather


### PR DESCRIPTION
## Summary

User report: the first Add Profile open lands with the cursor in the name TextField; subsequent opens land with no field focused, so the user has to click the field before typing.

### Why it happens

The wizard's Window scene reuses the same NSWindow across open/dismiss cycles. The SwiftUI `.id(wizardOpenToken)` trick rebuilds the view tree (and gives us a fresh `@StateObject` view model — see `App.swift:385-409`'s commentary), but it doesn't reset the window's first responder. First-time-only focus comes from macOS auto-picking the first focusable view when the window is initially created; on subsequent opens that auto-pick doesn't run again.

### Fix shape

Add a `@FocusState` to `AddProfileView`, bind it to the name TextField with `.focused(...)`, and push it true on `.onAppear` (deferred one runloop tick via `DispatchQueue.main.async` because the TextField's underlying NSResponder isn't wired up at the moment `.onAppear` fires on macOS 14).

`+19 / -0` in a single file ([AddProfileView.swift](Sources/AVPainRelieverApp/AddProfileView.swift)). `swift build` + `swift test` green locally (no test count change — focus state isn't covered by the view-model unit tests, would need a UI test harness this project doesn't have).

### Relationship to PRs #69 and #70

Independent. Different file, different concern. Branch is off `main`, not stacked.

## Test plan

- [ ] Build with `./dev/build`. Open Add Profile. Cursor should land in the name field. Type something to confirm focus. Cancel/dismiss.
- [ ] Open Add Profile again (without restarting the app). Cursor should land in the name field again. Type to confirm.
- [ ] Open Add Profile a third time. Same behavior.
- [ ] Edit any existing profile. The name field is pre-filled; cursor should land in it (positioned at the end of the existing name on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)