### PR TITLE
Forget per-profile stats when a profile is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -896,6 +896,8 @@ Deleting a profile now also drops its per-slug stats. Before this, the Stats tab
 
 Wired from `AppDelegate.deleteProfile`, after the on-disk TOML delete succeeds. If the disk delete fails, the stats stay (no orphaning created).
 
+A second method, `SettingsStore.reconcileProfiles(currentSlugs:)`, runs on every config load (inside `AppDelegate.bootEngine`) and drops per-slug stats whose profile no longer exists. This serves two roles: it self-heals stats orphaned by anything that bypassed the delete-time hook (a hand-edit of `profiles.toml`), and it acts as a one-shot migration for users on a build that predates `forgetProfile`. No-op (no disk write) when nothing is orphaned, so it doesn't churn UserDefaults on every reload. Same scope as `forgetProfile`: per-slug data only, never aggregates.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -888,6 +888,14 @@ Lessons:
 
 PRs: #68 (`9b8f50f`), #69 (`a2856d3`), #70 (`f7abc81`), #71 (`6d4cba3`), #72 (`4d61c8c`), #73 (`a69b1e0`). All on `main` as of 2026-05-09.
 
+### Stats forget deleted profiles (2026-05-09)
+
+Deleting a profile now also drops its per-slug stats. Before this, the Stats tab kept rendering ghost rows for profiles the user had explicitly removed: orphaned `perProfileCounts` entries, plus a stale "Last switched … to <ghost>" line. Stats are local-only and the slug is the only key, so a deleted-then-recreated profile would just start a new count anyway. There's no honest reconciliation to do, so dropping the entries on delete is the correct shape.
+
+`SettingsStore.forgetProfile(slug:)` removes the slug's count and clears `lastSwitchSlug` / `lastSwitchDate` only when they match (so deleting an unrelated profile doesn't blank out the relative-time line). Aggregate counters (`profileSwitchCount`, streaks, active days, unique devices) are deliberately untouched: they reflect overall app usage, not which profile won each switch.
+
+Wired from `AppDelegate.deleteProfile`, after the on-disk TOML delete succeeds. If the disk delete fails, the stats stay (no orphaning created).
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -566,6 +566,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let pretty = PrettyName.format(profile.name)
         do {
             try ProfileWriter().delete(named: profile.name, in: ProfileBootstrapper.canonicalTOMLURL)
+            settings.forgetProfile(slug: profile.name)
             reloadConfig()
         } catch {
             let failure = NSAlert()

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -328,6 +328,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         let logger = ConsoleLogger()
         let profiles = ProfileBootstrapper().loadOrBootstrap(logger: logger)
         availableProfiles = profiles
+        // Self-heal stats orphaned by anything that bypassed
+        // `forgetProfile` (hand-edits to profiles.toml, or migration
+        // from a build that predates the delete-time hook).
+        settings.reconcileProfiles(currentSlugs: Set(profiles.map(\.name)))
         let engine = buildEngine(profiles: profiles, logger: logger)
         engine.onProfileApplied = { [weak self] profile in
             // Engine fires onProfileApplied on the same thread the

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -360,6 +360,25 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Drop per-slug stats whose profile no longer exists. Called on
+    /// every config load so any stats orphaned by an out-of-band path
+    /// (a hand-edit of profiles.toml, a migration from a build before
+    /// `forgetProfile` existed) self-heal on next launch. Same shape
+    /// as `forgetProfile`: only per-slug data, never aggregates.
+    /// No-op (no disk write) when nothing is orphaned.
+    func reconcileProfiles(currentSlugs: Set<String>) {
+        let staleKeys = perProfileCounts.keys.filter { !currentSlugs.contains($0) }
+        if !staleKeys.isEmpty {
+            var trimmed = perProfileCounts
+            for key in staleKeys { trimmed.removeValue(forKey: key) }
+            perProfileCounts = trimmed
+        }
+        if let last = lastSwitchSlug, !currentSlugs.contains(last) {
+            lastSwitchSlug = nil
+            lastSwitchDate = nil
+        }
+    }
+
     /// Wipe every stats counter / dictionary / last-switched field.
     /// Does NOT touch `statsTrackingEnabled` — that's a separate
     /// privacy choice. If tracking is currently on, `statsStartDate`

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -340,6 +340,26 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Drop a profile's per-slug stats when the profile itself is
+    /// deleted. Removes its `perProfileCounts` entry, and clears
+    /// `lastSwitchSlug` / `lastSwitchDate` if the deleted profile was
+    /// the most recent one applied. Without that, the Stats tab would
+    /// keep rendering "Last switched 3h ago to <ghost>".
+    ///
+    /// Aggregate counters (`profileSwitchCount`, streaks, active
+    /// days, unique devices) are intentionally left alone: they
+    /// reflect overall app usage, not which profile happened to win
+    /// each switch.
+    func forgetProfile(slug: String) {
+        if perProfileCounts[slug] != nil {
+            perProfileCounts.removeValue(forKey: slug)
+        }
+        if lastSwitchSlug == slug {
+            lastSwitchSlug = nil
+            lastSwitchDate = nil
+        }
+    }
+
     /// Wipe every stats counter / dictionary / last-switched field.
     /// Does NOT touch `statsTrackingEnabled` — that's a separate
     /// privacy choice. If tracking is currently on, `statsStartDate`

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -297,6 +297,81 @@ struct SettingsStoreTests {
         #expect(store.lastSwitchSlug == "home-office")
     }
 
+    @Test("reconcileProfiles drops stats for slugs not in the current set")
+    func reconcileProfilesDropsOrphans() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "conference-room")
+        store.recordSwitch(toSlug: "ghost-from-old-build")
+
+        let aggregateBefore = store.profileSwitchCount
+        store.reconcileProfiles(currentSlugs: ["home-office", "conference-room"])
+
+        #expect(store.perProfileCounts["home-office"] == 1)
+        #expect(store.perProfileCounts["conference-room"] == 1)
+        #expect(store.perProfileCounts["ghost-from-old-build"] == nil)
+        // Aggregates untouched by reconcile, just like forgetProfile.
+        #expect(store.profileSwitchCount == aggregateBefore)
+    }
+
+    @Test("reconcileProfiles clears lastSwitch fields when the slug is orphaned")
+    func reconcileProfilesClearsOrphanedLastSwitch() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "ghost")
+        // ghost is the most recent.
+        #expect(store.lastSwitchSlug == "ghost")
+
+        store.reconcileProfiles(currentSlugs: ["home-office"])
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+    }
+
+    @Test("reconcileProfiles preserves lastSwitch fields when the slug is still present")
+    func reconcileProfilesPreservesLiveLastSwitch() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "ghost")
+        store.recordSwitch(toSlug: "home-office")
+        #expect(store.lastSwitchSlug == "home-office")
+
+        store.reconcileProfiles(currentSlugs: ["home-office"])
+        #expect(store.lastSwitchSlug == "home-office")
+        #expect(store.lastSwitchDate != nil)
+    }
+
+    @Test("reconcileProfiles is a no-op when every slug is still present")
+    func reconcileProfilesAllPresent() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "conference-room")
+        let snapshot = store.perProfileCounts
+
+        store.reconcileProfiles(currentSlugs: ["home-office", "conference-room", "unused-extra"])
+        #expect(store.perProfileCounts == snapshot)
+        #expect(store.lastSwitchSlug == "conference-room")
+    }
+
+    @Test("reconcileProfiles with an empty set drops everything per-slug, leaves aggregates")
+    func reconcileProfilesEmptySet() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "conference-room")
+        let aggregateBefore = store.profileSwitchCount
+        let streakBefore = store.currentStreakDays
+
+        store.reconcileProfiles(currentSlugs: [])
+        #expect(store.perProfileCounts.isEmpty)
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+        #expect(store.profileSwitchCount == aggregateBefore)
+        #expect(store.currentStreakDays == streakBefore)
+    }
+
     @Test("resetStats wipes counters; tracking flag is preserved")
     func resetStatsWipes() {
         let defaults = makeSuite()

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -246,6 +246,57 @@ struct SettingsStoreTests {
         #expect(store.uniqueDevicesSeenCount == 2)
     }
 
+    @Test("forgetProfile drops per-slug count and clears last-switch fields if they match")
+    func forgetProfileClearsPerSlugData() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "conference-room")
+
+        // Aggregates that should NOT be touched by a per-profile delete.
+        let totalBefore = store.profileSwitchCount
+        let activeDaysBefore = store.activeDaysCount
+        let streakBefore = store.currentStreakDays
+
+        store.forgetProfile(slug: "home-office")
+
+        #expect(store.perProfileCounts["home-office"] == nil)
+        #expect(store.perProfileCounts["conference-room"] == 1)
+        #expect(store.profileSwitchCount == totalBefore)
+        #expect(store.activeDaysCount == activeDaysBefore)
+        #expect(store.currentStreakDays == streakBefore)
+    }
+
+    @Test("forgetProfile clears lastSwitchSlug only when it matches the deleted slug")
+    func forgetProfilePreservesUnrelatedLastSwitch() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.recordSwitch(toSlug: "conference-room")
+        // conference-room was the most recent switch.
+        #expect(store.lastSwitchSlug == "conference-room")
+
+        store.forgetProfile(slug: "home-office")
+        // Unrelated last-switch is untouched.
+        #expect(store.lastSwitchSlug == "conference-room")
+        #expect(store.lastSwitchDate != nil)
+
+        store.forgetProfile(slug: "conference-room")
+        #expect(store.lastSwitchSlug == nil)
+        #expect(store.lastSwitchDate == nil)
+    }
+
+    @Test("forgetProfile is a no-op for an unknown slug")
+    func forgetProfileUnknownSlug() {
+        let store = SettingsStore(defaults: makeSuite())
+        store.statsTrackingEnabled = true
+        store.recordSwitch(toSlug: "home-office")
+        store.forgetProfile(slug: "never-existed")
+        #expect(store.perProfileCounts["home-office"] == 1)
+        #expect(store.lastSwitchSlug == "home-office")
+    }
+
     @Test("resetStats wipes counters; tracking flag is preserved")
     func resetStatsWipes() {
         let defaults = makeSuite()


### PR DESCRIPTION
## Summary

Two commits, both about killing ghost profile stats:

1. **Delete-time hook.** `AppDelegate.deleteProfile` now drops the deleted profile's `perProfileCounts` entry and clears `lastSwitchSlug` / `lastSwitchDate` if they pointed at it. Wired only after the on-disk TOML delete succeeds, so a failed disk delete doesn't create orphans.
2. **Launch-time reconcile.** `AppDelegate.bootEngine` calls `SettingsStore.reconcileProfiles(currentSlugs:)` after every config load. Drops per-slug stats whose profile no longer exists. Self-heals data orphaned by anything that bypassed the delete-time hook (a hand-edit of `profiles.toml`), and acts as a one-shot migration for users already carrying orphaned entries from a build that predates this change. No-op (no disk write) when nothing is orphaned.

Aggregate counters (`profileSwitchCount`, streaks, active days, unique devices) are deliberately untouched in both paths: they reflect overall app usage, not which profile won each switch.

## Why

The Stats tab was rendering ghost rows for profiles the user had explicitly removed. Stats are local-only and the slug is the only key, so a deleted-then-recreated profile would just start a new count anyway. There's no honest reconciliation to do, so dropping the entries on delete (and self-healing on launch) is the correct shape.

## Test plan

- [x] `swift test` — 194 tests across 14 suites green (5 new for `reconcileProfiles`, 3 new for `forgetProfile`)
- [ ] Manual smoke test in the app (see steps below)

### Manual smoke test

Build:

```
./dev/build --full
```

Then in the running app:

**Migration check (your existing orphaned data):**

1. **Settings → Stats**: confirm the per-profile rankings now show ONLY profiles that currently exist in **Settings → Profiles**. Previous testing-leftover ghost rows should be gone.
2. If the "Last switched" line previously named a profile you've since deleted, confirm that line is now gone too.
3. Aggregates ("Auto-switches", "Manual overrides", streaks, active days, "Unique USB devices recognized") should be unchanged from before the upgrade.

**Delete-time hook:**

4. **Settings → Stats**: turn **Track usage stats locally** on if it's not already.
5. Switch between two profiles a few times each (Menu Bar → Switch to → pick A, pick B, pick A) so both have non-zero counts and both appear in the per-profile rankings.
6. **Settings → Stats**: confirm both profiles appear with their counts, and the "Last switched" line names whichever you switched to most recently.
7. **Settings → Profiles**: delete the profile that the "Last switched" line currently names. Confirm:
   - That profile's row disappears from the per-profile rankings
   - The "Last switched" row disappears entirely
   - The other profile's count is unchanged
   - "Auto-switches", "Manual overrides", streak rows, and "Unique USB devices recognized" are unchanged
8. Repeat: delete the *other* profile. Its rankings row disappears too; "Most-used location" disappears; aggregates still unchanged.
9. Re-add a profile with the same name as one you just deleted. Confirm its count starts at 0 (not the old count).

**Self-heal on hand-edit:**

10. Add a profile named e.g. `temp-test`, switch to it once so it has a count.
11. Quit the app. Open `~/Library/Application Support/com.ericwillis.AVPainReliever/profiles.toml` (or wherever the canonical TOML lives) and delete the `[[profile]]` block for `temp-test` by hand. Save.
12. Relaunch the app via `./dev/build --full`. Open **Settings → Stats**. The `temp-test` row should be gone (the launch-time reconcile dropped it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)