### PR TITLE
Stats: per-profile rankings as their own Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -888,6 +888,14 @@ Lessons:
 
 PRs: #68 (`9b8f50f`), #69 (`a2856d3`), #70 (`f7abc81`), #71 (`6d4cba3`), #72 (`4d61c8c`), #73 (`a69b1e0`). All on `main` as of 2026-05-09.
 
+### Stats: per-profile rankings as their own Section (2026-05-09)
+
+The Stats tab's per-profile breakdown was visually confusing: the most-used profile rendered as a `LabeledContent("Most-used location", value: "Laptop (36)")` with the profile name on the *right*, while the runner-up rows rendered as `LabeledContent("Home Office", value: "18")` with the profile name on the *left*. Same data, two columns, broken eye-scan. The "Most-used location" row also lived inside the Tracking section, sandwiched between unrelated rows like "Manual overrides" and "Active days" — the section interleaved profile rankings with global counters.
+
+Restructured: dropped the "Most-used location" highlight row entirely, moved every per-profile entry into its own Form `Section` with header `Label("Switches by location", systemImage: "list.number")`, sorted by descending count. The first row IS the most-used by definition — sort order carries the meaning, no separate winner callout needed. Matches Apple's pattern for similar surfaces (Settings → Battery, Settings → General → Storage, iOS Settings → Privacy → Tracking): show a sorted list, trust the user to read the top entry as the leader.
+
+`StatsSettingsTab.topProfile` and `StatsSettingsTab.otherProfiles` collapsed into a single `rankedProfiles` computed prop. Updated the doc comment on `SettingsStore.perProfileCounts` to drop the stale "most-used location highlight" reference.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -151,8 +151,8 @@ final class SettingsStore: ObservableObject {
     }
 
     /// Count of how many times each profile (by slug) has been
-    /// applied since tracking was enabled. Powers the "most-used
-    /// location" highlight + the per-profile rankings.
+    /// applied since tracking was enabled. Powers the "Switches by
+    /// location" rankings in the Stats tab.
     @Published var perProfileCounts: [String: Int] {
         didSet { defaults.set(perProfileCounts, forKey: Key.perProfileCounts) }
     }

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -564,6 +564,16 @@ private struct StatsSettingsTab: View {
                 Label("Tracking", systemImage: "switch.2")
             }
 
+            if settings.statsTrackingEnabled, !rankedProfiles.isEmpty {
+                Section {
+                    ForEach(rankedProfiles, id: \.0) { slug, count in
+                        LabeledContent(PrettyName.format(slug), value: "\(count)")
+                    }
+                } header: {
+                    Label("Switches by location", systemImage: "list.number")
+                }
+            }
+
             if settings.hasRecordedStats {
                 Section {
                     Button(role: .destructive) {
@@ -623,12 +633,6 @@ private struct StatsSettingsTab: View {
         if let lastLine = lastSwitchedString {
             LabeledContent("Last switched", value: lastLine)
         }
-        if let (topSlug, topCount) = topProfile {
-            LabeledContent("Most-used location", value: "\(PrettyName.format(topSlug)) (\(topCount))")
-            ForEach(otherProfiles, id: \.0) { slug, count in
-                LabeledContent(PrettyName.format(slug), value: "\(count)")
-            }
-        }
         LabeledContent("Manual overrides", value: "\(settings.manualOverrideCount)")
         LabeledContent("Current streak", value: streakString(settings.currentStreakDays))
         LabeledContent("Longest streak", value: streakString(settings.longestStreakDays))
@@ -662,21 +666,12 @@ private struct StatsSettingsTab: View {
         return "\(relative) → \(PrettyName.format(slug))"
     }
 
-    /// Highest entry in `perProfileCounts`; nil when the dictionary
-    /// is empty.
-    private var topProfile: (String, Int)? {
-        settings.perProfileCounts.max { $0.value < $1.value }
-            .map { ($0.key, $0.value) }
-    }
-
-    /// All entries except the top one, sorted by descending count.
-    /// The top one is rendered as the "Most-used location" highlight
-    /// just above; this list adds the rankings without duplicating
-    /// the leader.
-    private var otherProfiles: [(String, Int)] {
-        guard let top = topProfile else { return [] }
-        return settings.perProfileCounts
-            .filter { $0.key != top.0 }
+    /// Every profile that has at least one recorded switch, sorted by
+    /// descending count. Powers the "Switches by location" section.
+    /// The first entry is implicitly the most-used: sort order carries
+    /// the meaning, no separate highlight row needed.
+    private var rankedProfiles: [(String, Int)] {
+        settings.perProfileCounts
             .sorted { $0.value > $1.value }
             .map { ($0.key, $0.value) }
     }


### PR DESCRIPTION
## Summary

- Drop the "Most-used location" highlight row from the Stats tab
- Move every per-profile entry into its own Form Section ("Switches by location"), sorted by descending count — the first row IS the most-used by definition
- `topProfile` + `otherProfiles` collapse into a single `rankedProfiles` computed prop
- Update the stale "most-used location highlight" doc comment on `SettingsStore.perProfileCounts`

## Why

The old layout had the most-used profile on the *right* (as a `LabeledContent` value) while runner-up rows had their profile name on the *left* (as the `LabeledContent` label). Same data, two columns, broken eye-scan. The highlight row also lived inside the Tracking section, sandwiched between unrelated counters like "Manual overrides" and "Active days" — the section was interleaving rankings with global counters.

The new shape matches Apple's precedent for sorted-list surfaces (Settings → Battery, Settings → General → Storage, iOS Settings → Privacy → Tracking): show the list sorted, trust the user to read the top entry as the leader. No callout needed.

## Notes

- This branches off `main`, not off [#75](https://github.com/superic/AV-Pain-Reliever/pull/75). The two PRs touch different code paths and are independent. Whichever merges first, the other rebases cleanly.
- No new tests: this is a pure SwiftUI render change with no logic shifts. The `rankedProfiles` prop is a straight sort (existing tests already cover what `perProfileCounts` looks like).

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 186 tests across 14 suites green
- [ ] Manual smoke test in the app (see steps below)

### Manual smoke test

Build:

```
./dev/build --full
```

Then in the running app:

1. **Settings → Stats**: confirm **Track usage stats locally** is on. Confirm there's data from prior testing (counts in your `perProfileCounts`).
2. Scan the tab top-to-bottom. The **Tracking** section should now contain only: Tracking since, Auto-switches, Last switched, Manual overrides, Current streak, Longest streak, Active days, Unique USB devices recognized. **No "Most-used location" row**, no per-profile rows.
3. Below the Tracking section there should be a **new Section** titled **"Switches by location"** (with the `list.number` SF Symbol in the header).
4. Inside that section, every profile with a recorded count appears as `LabeledContent(profileName, value: count)` — profile name on the left, count on the right, every row.
5. Order: top entry has the highest count, descending. Confirm the top one is the same profile that used to appear in the old "Most-used location" row.
6. Switch to a profile that's currently mid-list (Menu Bar → Switch to → pick e.g. Conference Room a couple times). Reopen Stats — that profile should bubble up.
7. **Settings → Profiles**: delete one of the ranked profiles. Reopen Stats — its row should disappear from the rankings (and the new top entry slides up if it was the leader). *(Note: the cleanup-on-delete is gated on PR #75 being merged. If #75 isn't merged, the row will persist until you also merge that one.)*
8. Turn **Track usage stats locally** off. Confirm the entire "Switches by location" section disappears (it's gated on tracking enabled + non-empty rankings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)