### PR TITLE
docs: codify the "docs that move with the code" rules in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -908,6 +908,12 @@ Restructured: dropped the "Most-used location" highlight row entirely, moved eve
 
 `StatsSettingsTab.topProfile` and `StatsSettingsTab.otherProfiles` collapsed into a single `rankedProfiles` computed prop. Updated the doc comment on `SettingsStore.perProfileCounts` to drop the stale "most-used location highlight" reference.
 
+### CLAUDE.md: codify the "docs that move with the code" rules (2026-05-09)
+
+Added a "Docs that move with the code" subsection to CLAUDE.md under "Project-wide conventions" so the CHANGELOG-on-every-PR and README-when-user-visible-changes rules are part of the auto-loaded operational ruleset, not just personal memory. Without this, only sessions that happen to carry the right memory entries would know to keep the journal current and the README in sync; codifying it in CLAUDE.md means every fresh agent session in this repo inherits the rule.
+
+The triggers are explicit: CHANGELOG gets a dated H3 entry on every non-mechanical PR; README updates only when a PR changes user-visible behavior (a new setting, renamed menu item, removed feature, install-flow change). Internal refactors, doc-only edits, and test-only changes don't touch README — an executive reader wouldn't notice them. Same operational-rule shape as the other CLAUDE.md subsections, ~6 lines added.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ Shared SF Symbol names live in `Theme.Symbol` enum. Don't sprinkle string litera
 - Repo-root meta files (`README.md`, `LICENSE`, `CHANGELOG.md`, `CLAUDE.md`) → UPPERCASE.
 - Content under `docs/` → lowercase-hyphenated.
 
+### Docs that move with the code
+
+- **CHANGELOG.md**: every non-mechanical PR adds a dated H3 entry. Internal design notes are plain prose; user-facing release notes use the Vince Vaughn voice (see Release notes above).
+- **README.md**: update when a PR changes user-visible behavior — a new setting, renamed menu item, removed feature, install-flow change. Skip for internal refactors, doc-only edits, and test-only changes (an executive reader wouldn't notice them).
+
 ### Avoiding slop
 
 Patterns to watch when writing code. Detailed history lives in CHANGELOG.


### PR DESCRIPTION
## Summary

Adds a six-line subsection under "Project-wide conventions" in CLAUDE.md:

```markdown
### Docs that move with the code

- **CHANGELOG.md**: every non-mechanical PR adds a dated H3 entry. Internal design notes are plain prose; user-facing release notes use the Vince Vaughn voice (see Release notes above).
- **README.md**: update when a PR changes user-visible behavior — a new setting, renamed menu item, removed feature, install-flow change. Skip for internal refactors, doc-only edits, and test-only changes (an executive reader wouldn't notice them).
```

Plus a CHANGELOG entry recording the rule addition (per the rule itself).

## Why

Both rules previously existed only in personal memory, which meant a fresh agent session in this repo wouldn't carry them. CLAUDE.md is auto-loaded into every session, so codifying the rules there makes them part of the operational ruleset instead of relying on whichever agent happens to have the right memory entries.

The triggers are explicit so the rules don't drift back into "should I update this?" cycles per PR. CHANGELOG updates on every non-mechanical PR; README updates only when a PR changes user-visible behavior.

## Test plan

- [ ] Doc-only change. Nothing to build or test functionally.
- [ ] Sanity-check the formatting renders correctly on GitHub (the rendered subsection should appear between "Markdown filenames" and "Avoiding slop").

🤖 Generated with [Claude Code](https://claude.com/claude-code)