### PR TITLE
fix: poll for camera-extension visibility instead of one-shot checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -976,6 +976,16 @@ The first apply on launch (from `engine.start()`) still happens before visibilit
 
 PR: #79.
 
+### Poll for visibility instead of one-shot checking (2026-05-09)
+
+Follow-up to PR #79. Hands-on testing surfaced a second visibility-race symptom on the in-session toggle-off-then-on path: the auto-relaunch's first visibility check at 1.5s frequently fails because the OS hasn't fully republished the Camera Extension yet (it was just deactivated and reactivated within a few seconds). State escalates to `.requiresRelaunch` again, and the user has to click Restart a *second* time. Empirically the OS needs another ~3-5s after that, at which point the cache is healthy and Photo Booth/Zoom see the virtual camera fine.
+
+`scheduleHostVisibilityCheck` previously did a one-shot `asyncAfter(deadline: .now() + 1.5)`. Now it uses a small polling loop: first check at 1.5s (so the fresh-launch happy path's latency stays the same), and on failure poll every 1s up to an 8s total budget. As soon as `hostCanSeeVirtualCamera()` returns true, fire `onVisibilityConfirmed` and stop polling. Only escalate to `.requiresRelaunch` once the budget is exhausted.
+
+Net effect: the toggle-off-then-on path now needs one auto-relaunch instead of two. The fresh-launch path is unchanged (the first check at 1.5s passes and we exit immediately). Failure mode (extension truly broken) takes 8s instead of 1.5s before showing the Restart button — acceptable tradeoff because the success rate of the eventual poll is high enough that the additional dead time on the rare honest-failure case isn't worse than the false-escalation rate of the one-shot check.
+
+Recursion via `DispatchQueue.main.asyncAfter` (each poll schedules the next) is safe: the closure captures `[weak self]`, so a deallocated activator bails on the `guard let self`. State changes during polling (user disables, manual override) bail via `guard self.state == .on`.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -320,25 +320,39 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     /// `.requiresRelaunch` so Settings can offer the same Restart
     /// affordance the disable→enable path uses.
     private func scheduleHostVisibilityCheck() {
-        // ~1.5 s is enough for CMIO to publish after activation on
-        // every machine I've measured. Too short and a healthy
-        // first-activation gets misclassified; longer adds dead time
-        // before the wizard's camera list reflects reality.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+        // First check at 1.5s (the calibrated minimum for fresh-launch
+        // where CMIO has published and AVFoundation's DiscoverySession
+        // cache has refreshed). On failure, poll every 1s up to 8s
+        // total. The auto-relaunch path (host restarted after a
+        // toggle-off-then-on cycle) often needs 3-5s for the OS to
+        // fully republish the extension; a one-shot 1.5s check
+        // escalates to `.requiresRelaunch` every time and forces a
+        // second relaunch.
+        let deadline = Date().addingTimeInterval(8.0)
+        pollHostVisibility(deadline: deadline, nextAttemptIn: 1.5)
+    }
+
+    private func pollHostVisibility(deadline: Date, nextAttemptIn delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self, self.state == .on else { return }
             if Self.hostCanSeeVirtualCamera() {
                 logger.notice("Visibility check: host sees the virtual camera in DiscoverySession")
                 self.onVisibilityConfirmed?()
                 return
             }
-            logger.error("Visibility check: host process can't see its own Camera Extension — escalating to .requiresRelaunch")
-            self.endConsumerWatch()
-            self.stopGraceTimer?.cancel()
-            self.stopGraceTimer = nil
-            self.consumerActive = false
-            self.pendingSourceName = nil
-            self.stopCapturePipeline()
-            self.state = .requiresRelaunch
+            if Date() >= deadline {
+                logger.error("Visibility check: host process can't see its own Camera Extension within budget; escalating to .requiresRelaunch")
+                self.endConsumerWatch()
+                self.stopGraceTimer?.cancel()
+                self.stopGraceTimer = nil
+                self.consumerActive = false
+                self.pendingSourceName = nil
+                self.stopCapturePipeline()
+                self.state = .requiresRelaunch
+                return
+            }
+            logger.debug("Visibility check: not yet visible, retrying in 1s")
+            self.pollHostVisibility(deadline: deadline, nextAttemptIn: 1.0)
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to [#79](https://github.com/superic/AV-Pain-Reliever/pull/79). Replaces the one-shot 1.5s visibility check with a polling loop that retries every 1s up to an 8s total budget.

## Why

Hands-on testing of [#79](https://github.com/superic/AV-Pain-Reliever/pull/79) revealed a second symptom of the same race. The fresh-launch path now works (PR #79 fixed that), but the **in-session toggle-off-then-on path** still fails:

1. User toggles virtual camera OFF in Settings → activator calls `deactivate`.
2. User toggles back ON → in-session-deactivation rule → state = `.requiresRelaunch` → host auto-relaunches.
3. New process activates the Camera Extension. State `activating → on`. Visibility check at 1.5s fires.
4. **Visibility fails** — the OS hasn't fully republished the extension yet (it was just deactivated and reactivated seconds ago).
5. State `.on → .requiresRelaunch`. Host auto-relaunches *again*.
6. Third process. Visibility check at 1.5s fires. Now it passes (the OS has had ~12s of cumulative time to settle).

Net: the user clicks Restart once, then watches the app double-relaunch. From the [#79](https://github.com/superic/AV-Pain-Reliever/pull/79) verification logs (timestamps 19:35:21 → 19:35:33):

```
19:35:21.697 [Activator] state: activating → on
19:35:23.272 E [Activator] Visibility check: host process can't see its own Camera Extension — escalating to .requiresRelaunch
19:35:33.016 [Activator] Relaunching host: /Applications/AVPainReliever.app
19:35:33.573 [Activator] state: activating → on  ← fresh process
19:35:35.147 [Activator] Visibility check: host sees the virtual camera in DiscoverySession  ← finally
```

## Approach

`scheduleHostVisibilityCheck` keeps the same first-check timing (1.5s) but on failure polls every 1s until either the camera becomes visible OR an 8s total budget elapses. The fresh-launch happy path is untouched (1.5s check → success → exit). The auto-relaunch path now succeeds at 3-5s instead of escalating to a second relaunch.

```swift
let deadline = Date().addingTimeInterval(8.0)
pollHostVisibility(deadline: deadline, nextAttemptIn: 1.5)
```

`pollHostVisibility` recurses via `DispatchQueue.main.asyncAfter`. Each poll captures `[weak self]`, so:
- Deallocated activator → `guard let self` bails, no leak.
- User disables / manual override during polling → `guard self.state == .on` bails, no double-escalation.

Genuine extension failure (e.g. user denied approval, hardware borked) takes 8s before showing the Restart button instead of 1.5s. Acceptable tradeoff — most cases that hit this path are transient OS catch-up, not true failures.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 194 tests across 14 suites green
- [x] Self-review of diff (small enough; checked recursion safety, state guards, em-dash style)
- [ ] Manual smoke test (see below — requires real Camera Extension activation)

### Manual smoke test

In a separate terminal:

```
log stream --predicate 'subsystem CONTAINS "ericwillis.avpainreliever"' --level debug --style compact
```

Build:

```
./dev/build --full
```

**Test 1 — Fresh-launch path (no regression):**

1. With virtual camera enabled, launch via the build above.
2. Watch the log: should see `state: activating → on`, then **at 1.5s exactly** `Visibility check: host sees the virtual camera in DiscoverySession`. Same latency as before.
3. Open Photo Booth → AV Pain Reliever → live frames within ~2s.

**Test 2 — Toggle-off-then-on path (the new fix):**

4. Settings → Camera → toggle OFF.
5. Wait ~2s.
6. Toggle back ON. Confirm the log shows:
   - `enable() blocked: in-session deactivation requires a host relaunch`
   - `state: off → requiresRelaunch`
   - `Relaunching host: /Applications/AVPainReliever.app`
7. New process starts. Watch for the polling sequence:
   - `state: activating → on`
   - At 1.5s: maybe `Visibility check: not yet visible, retrying in 1s` (debug-level, only with `--level debug`)
   - At 2.5s, 3.5s, ..., up to ~5s: maybe more retry lines
   - Eventually: `Visibility check: host sees the virtual camera in DiscoverySession`
   - **Then `onVisibilityConfirmed` fires once, reapply runs, `set preferred camera: AV Pain Reliever`**
8. Settings → Camera should show **green** indicator (state .on), NOT orange. **No second auto-relaunch should occur.**
9. Open Photo Booth → AV Pain Reliever → live frames.

**Test 3 — Genuine failure path:**

10. (Optional) If you can simulate a state where the visibility check truly never succeeds (e.g. revoke approval mid-session), confirm that after 8s of polling the log shows:
    - `Visibility check: host process can't see its own Camera Extension within budget; escalating to .requiresRelaunch`
    - State goes to `.requiresRelaunch`, Restart button appears.

## Notes

- No new tests. `AVCaptureDevice.DiscoverySession` cache freshness can't be meaningfully mocked; this is verified by hands-on testing on real hardware.
- Recursion depth is bounded at ~7 retries (1.5s + 1s × 6.5 ≈ 8s budget). No stack growth — each call is async.

🤖 Generated with [Claude Code](https://claude.com/claude-code)