### PR TITLE
fix: roll back virtual-camera toggle when deactivate auth prompt is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -986,6 +986,20 @@ Net effect: the toggle-off-then-on path now needs one auto-relaunch instead of t
 
 Recursion via `DispatchQueue.main.asyncAfter` (each poll schedules the next) is safe: the closure captures `[weak self]`, so a deallocated activator bails on the `guard let self`. State changes during polling (user disables, manual override) bail via `guard self.state == .on`.
 
+### Roll back the virtual-camera toggle when the deactivate auth prompt is cancelled (2026-05-09)
+
+User-visible bug: with the virtual camera on, flipping Settings → Camera off, then clicking Cancel on the macOS admin-password prompt, left the app in a `.failed` state. Toggling back on tripped the in-session deactivation guard and forced a `.requiresRelaunch` auto-relaunch — five seconds of dance for an action the user explicitly cancelled.
+
+The OS-level deactivate never went through (Cancel meant Cancel), so the extension was still alive. The only thing wrong was the host's view of state: `disable()` flips state to `.off` synchronously before submitting the deactivation request, and the existing `didFailWithError` path indiscriminately escalated every failure to `.failed(message)`.
+
+Fix: in `VirtualCameraActivator.didFailWithError`, detect the auth-cancel-during-deactivate case (`state == .off` AND error domain `OSSystemExtensionErrorDomain` AND code `OSSystemExtensionError.Code.authorizationRequired` (13)). Roll back: restore `state = .on`, clear `deactivatedThisSession`, restart the consumer watch that `disable()` ended, and fire a new `onDeactivateAuthCancelled` callback. AppDelegate's handler sets `settings.virtualCameraEnabled = true` so the Settings UI bounces back, and calls `engine.reapply()` so the active profile re-routes to the virtual camera (disable's synchronous teardown had pointed the system-preferred camera at the real fallback).
+
+Activate cancels keep the existing `.failed(message)` behavior because "user said no" to an activation means leave the camera off. Distinguishing the two cases by the activator's state at failure time (`.off` for deactivate, `.activating`/`.needsApproval` for activate) is robust without needing a separate "kind of request" flag.
+
+Logged as `.notice` rather than `.error` because the auth cancel is an expected user action, not a bug.
+
+PRs: builds on #79 and #80; mirrors the closure-callback pattern (`onVisibilityConfirmed`) introduced in #79.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -180,6 +180,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         virtualCameraActivator.onVisibilityConfirmed = { [weak self] in
             self?.engine?.reapply()
         }
+        // User cancelled the macOS auth prompt for a deactivate.
+        // Activator already restored its state to `.on`; sync the
+        // persisted setting so the Settings toggle bounces back, and
+        // re-apply the active profile so the system-wide preferred
+        // camera flips from the real fallback (set by disable()'s
+        // synchronous path) back to the virtual camera.
+        virtualCameraActivator.onDeactivateAuthCancelled = { [weak self] in
+            guard let self else { return }
+            self.settings.virtualCameraEnabled = true
+            self.engine?.reapply()
+        }
     }
 
     /// The most recent profile name we surfaced through

--- a/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
+++ b/Sources/AVPainRelieverApp/VirtualCameraActivator.swift
@@ -101,6 +101,15 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
     /// the consumer's wiring site.
     var onVisibilityConfirmed: (() -> Void)?
 
+    /// Fires on the main thread when the user cancels the macOS auth
+    /// prompt that gates a deactivate request. The OS-level deactivate
+    /// never happened so the extension is still alive — the activator
+    /// has already restored its own state to `.on`. The host wires this
+    /// to roll the persisted Settings toggle back to `true` and re-apply
+    /// the active profile so the system-wide preferred camera flips
+    /// back to the virtual camera. Set once during host setup.
+    var onDeactivateAuthCancelled: (() -> Void)?
+
     /// True when the env var override forced enable on launch.
     /// Settings UI hides the toggle's persistence-driven semantics
     /// and shows a "debug override active" badge instead so the
@@ -544,6 +553,26 @@ final class VirtualCameraActivator: NSObject, ObservableObject,
         _ request: OSSystemExtensionRequest,
         didFailWithError error: Error
     ) {
+        // Auth-cancel during deactivate: the prompt was declined, so
+        // the extension is still alive on the OS side and only the
+        // host's view of state is wrong (disable() flipped to .off
+        // synchronously). Roll back to .on. Activate-side cancels
+        // still escalate to .failed via the path below.
+        let nsError = error as NSError
+        let isDeactivateAuthCancel = state == .off
+            && nsError.domain == OSSystemExtensionErrorDomain
+            && nsError.code == OSSystemExtensionError.Code.authorizationRequired.rawValue
+        if isDeactivateAuthCancel {
+            logger.notice("Camera Extension deactivate cancelled by user (auth prompt declined); rolling back toggle to on")
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.deactivatedThisSession = false
+                self.beginConsumerWatch()
+                self.state = .on
+                self.onDeactivateAuthCancelled?()
+            }
+            return
+        }
         let message = error.localizedDescription
         logger.error("Camera Extension request failed: \(message, privacy: .public)")
         DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
## Summary

- When the user toggles the virtual camera off and clicks **Cancel** on the macOS admin-password prompt, the OS-level deactivate never went through but the host's state still escalated to `.failed`. Toggling back on then forced an in-session `.requiresRelaunch` auto-relaunch — five seconds of dance for an action the user explicitly cancelled.
- Detect the auth-cancel-during-deactivate case in `VirtualCameraActivator.didFailWithError` (`state == .off` + `OSSystemExtensionErrorDomain` + code 13 / `authorizationRequired`), restore `state = .on`, restart the consumer watch that `disable()` ended, and fire a new `onDeactivateAuthCancelled` callback. AppDelegate uses it to roll the persisted Settings toggle back to `true` and re-apply the active profile so the system-preferred camera flips back to the virtual camera.
- Activate-side cancels and any other failure code keep the existing `.failed(message)` path. Logged as `.notice` (not `.error`) because the auth cancel is an expected user action, not a bug.

Mirrors the closure-callback pattern (`onVisibilityConfirmed`) introduced in #79.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 194/194 passing
- [x] Pre-PR `/code-quality:slop` review — grade A (one paragraph-length comment caught and trimmed)
- [x] Hands-on test of the fix path: toggle vcam off → click Cancel on password prompt → log shows the new `.notice` rollback line, `state: off → on`, toggle bounces back to on, no auto-relaunch
- [x] Hands-on test of the unchanged path: existing `.failed(message)` behavior preserved for activate-side cancels and non-13 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)