### PR TITLE
docs: sync decisions.md after persistent-todo walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1000,6 +1000,18 @@ Logged as `.notice` rather than `.error` because the auth cancel is an expected 
 
 PRs: builds on #79 and #80; mirrors the closure-callback pattern (`onVisibilityConfirmed`) introduced in #79.
 
+### docs/decisions.md sync after the persistent-todo walkthrough (2026-05-09)
+
+Walked the Pending review section of `tools/todo.md` (the gitignored persistent-todo file) and folded the resulting signals into `docs/decisions.md`. Doc-only PR; no code changes.
+
+**Open questions consolidation.** Four open questions had collected enough signal to settle: vid/pid collision (no hits across 3 users; was already redundant with the validated USB-fingerprinting decision), menu bar profile-name display (default works for all 3 users), external user wizard sticks (2 users completed without help), and toast notifications useful-or-annoying (a Settings toggle "Send notifications when profiles change" already ships, so the question is user preference rather than a code change). The validated notifications bullet in `docs/decisions.md` was clarified to mention the toggle. All four moved into a new "Resolved on 2026-05-09 (walkthrough)" section at the bottom of the doc so the trail is visible. The 1.5s debounce question and the non-USB-disambiguation question stay open; neither has signal yet.
+
+**Scope-creep pruning.** Five v2 candidates that the user has now decided are out-of-product were dropped: per-profile wallpaper, Karabiner profile switching, Bluetooth pairing, VPN, and focus mode / Do Not Disturb. Two stay noted for v2: per-profile display arrangement and opt-in crash + error reporting. The dropped items are listed in the Resolved section so a future reader doesn't propose them again without checking.
+
+**Persistent todo.** `tools/todo.md` was updated in lockstep: the Deferred refactors section was deleted entirely (all 5 items had real reasons-to-skip already on file in `tools/slop-plan-app-target.md`, and the natural moment to refactor came and went on PRs #79, #80, and #81 without anyone feeling the pull); the toast-cutdown work moved into Active.
+
+**Hammerspoon-era cleanup.** The Validated decisions section had four prototype-era entries that no longer described the shipped Swift app: an `obs-cmd` shell-out justification, an "OBS scenes are the right unit of switching" bullet, a "Camo is not a viable alternative" bullet, and an "OBS Virtual Camera in Zoom/Slack" bullet. Plus stray Phase-1 references elsewhere ("no Lua" in the Target product list, "manual override" in the menu-bar UI line which contradicts the validated "No manual override" decision below it, "Audio Hijack-style aggregate device hacks" naming a third-party). All removed. The `obs-cmd` / OBS-scenes / Camo bullets were dropped outright (no replacement needed, they were Phase-1 integration choices that the v0.2.0 virtual camera made moot). The "Same as System + OBS Virtual Camera" bullet was reworded to point at the app's own virtual camera. Doc header at the top retitled from "settled before the Swift app was built" to "settled by the shipped implementation," which is the accurate framing now that v0.2.x has graduated.
+
 - **When we ship a Phase 1 fix or feature**, ask: does this teach us
   something about the Swift port? If yes, add to "Lessons learned."
 - **When the user gives feedback or hits a bug**, ask: should this be

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,6 +1,6 @@
 # Decisions
 
-What we know to be true about this product. The "Validated decisions" section was settled before the Swift app was built; the "Open questions" section is the punchlist of things that still need real-world data to answer.
+What we know to be true about this product. The "Validated decisions" section is settled by the shipped implementation; the "Open questions" section is the punchlist of things that still need real-world data to answer.
 
 For ongoing implementation work see [docs/architecture.md](architecture.md). For the V2 virtual-camera design see [docs/virtual-camera.md](virtual-camera.md).
 
@@ -10,8 +10,8 @@ A distributable macOS menu-bar app that:
 
 - Ships as a signed + notarized `.app` from GitHub Releases
 - Auto-updates via Sparkle 2
-- Has a real menu-bar UI for status, manual override, profile management
-- Runs self-contained — no Lua, no shell scripts, no third-party tools
+- Has a real menu-bar UI for status and profile management
+- Runs self-contained: no shell scripts, no third-party tools
 - Configurable for non-developers (a typical non-coder collaborator should
   be able to install it without ever opening a terminal)
 
@@ -22,30 +22,22 @@ defaults + camera selection → notify.
 
 ## Validated design decisions
 
-These are settled by Phase 1 use and can be assumed when we start Swift:
+These are settled and validated by the shipped Swift implementation:
 
 - **USB vendor + product ID is enough for fingerprinting** (no serial number
   matching needed). Confirmed by user not having two identical docks; revisit
   if a future user reports collisions.
 - **1.5 second debounce window** correctly collapses dock-enumeration bursts
-  into a single evaluation. Tested on CalDigit TS3 + LG UltraFine — full burst
+  into a single evaluation. Tested on CalDigit TS3 + LG UltraFine; full burst
   takes ~1 second, well under the window.
 - **"Most-specific match wins" with alphabetical tiebreak** is the right
   resolution rule. Tested by having work-office + conference-room share the
   office dock; conference-room wins when its extra device is present.
-- **`obs-cmd` shell-out is fine** as the OBS integration. No need to write a
-  native obs-websocket WebSocket client — the CLI is stable, fast, and handles
-  the auth dance for us.
-- **OBS scenes are the right unit of switching.** Each scene bundles camera +
-  overlays + audio routing. The "one scene per location" mental model is clean.
-- **Camo is not a viable alternative.** Verified during planning: Camo's only
-  automation surface is macOS Shortcuts, which can switch the *device* but not
-  a saved overlay/scene combo by name. If overlays are wanted, OBS is the
-  answer.
-- **"Same as System" + OBS Virtual Camera in Zoom/Slack is the right
-  pattern.** No per-app routing complexity needed.
-- **`hs.notify` notifications are useful.** No real-world annoyance reported
-  yet; will revisit if user complains.
+- **"Same as System" for audio + the app's own virtual camera in Zoom/Slack
+  is the right pattern.** No per-app routing complexity needed.
+- **Notifications are useful, with a Settings toggle for users who prefer
+  them off.** No structural changes needed; users who find toasts annoying
+  can disable via Settings ("Send notifications when profiles change").
 - **Profile change triggers don't need WiFi BSSID, Bluetooth, or calendar
   signals as a fallback.** USB alone has been sufficient for Eric's 4
   locations. Revisit if a real user can't disambiguate USB-only.
@@ -61,66 +53,59 @@ These are settled by Phase 1 use and can be assumed when we start Swift:
   Confirmed by user 2026-04-30.
 - **No per-app audio routing.** "Same as System" in every app is sufficient.
   No use case for Slack mic ≠ Zoom mic. Implication: Swift never needs to
-  integrate with app-specific audio APIs (no Audio Hijack-style aggregate
-  device hacks, no per-app `defaults` plist editing). Engine only ever
+  integrate with app-specific audio APIs (no aggregate device hacks, no
+  per-app `defaults` plist editing). Engine only ever
   touches system default input/output. Confirmed by user 2026-04-30.
 
 ---
 
 ## Open questions
 
-These can only be answered by real-world Phase 1 use. Each one is tagged with
-the trigger condition that should prompt asking the user.
+These can only be answered by real-world use. Each one is tagged with the
+trigger condition that should prompt asking the user.
 
 ### Detection accuracy
 
-- **Q: Do you ever own two devices with identical (vid, pid)?**
-  Trigger: a profile resolves wrong because two locations share peripheral
-  models. Implication: Swift may need USB serial number matching, which is
-  cheap to add via IOKit but absent in `hs.usb.attachedDevices()` (the Lua
-  wrapper doesn't expose it).
 - **Q: Has the 1.5s debounce ever been wrong?**
   Trigger: profile fires twice, fires with wrong fingerprint, or takes
-  noticeably long. Implication: tune the constant in Swift, or make it
-  configurable.
+  noticeably long. Implication: tune the constant, or make it configurable.
 - **Q: Have you ever needed a non-USB signal to disambiguate locations?**
-  Trigger: two locations have the same USB peripherals. Implication: Swift
+  Trigger: two locations have the same USB peripherals. Implication: app
   may need WiFi BSSID, Bluetooth peripherals, time of day, or calendar event
   matching. Each is a real chunk of work.
 
-### User experience
-
-- **Q: After a couple weeks of use, are the notifications useful or
-  annoying?** Trigger: user complaint OR explicit ask after ~2 weeks.
-  Options: silent / banner-only / banner+sound / configurable per-profile.
-- **Q: Should the menu bar icon show the current profile name?**
-  Trigger: user asks how to tell which profile is active without opening
-  the menu. Implication: status item title shows pretty profile name.
-  *(Default: yes. Cheap to implement, useful at-a-glance signal. Revisit if
-  user finds the title bar noise distracting.)*
-
 ### Scope creep candidates
 
-These are things a real user might ask for. Not in v1, but capture them as
-they come up so we can prioritize for v2:
+Things a real user might ask for. Not in v1, but kept here for v2 prioritization:
 
 - Per-profile *display arrangement* (move windows when docking)
-- Per-profile *wallpaper*
-- Per-profile *Karabiner profile* switching
-- Per-profile *Bluetooth device* connect/disconnect
-- Per-profile *VPN* enable/disable
-- Per-profile *focus mode* / *Do Not Disturb*
 - *Crash and error reporting* (opt-in telemetry for unhandled crashes,
   plus an in-app viewer for recent OSLog failures so the user notices
   silent breakage without running `log show`)
 
-### Onboarding
+---
 
-- **Q: Did the first external user get all the way through the wizard
-  without asking for help? Where did they stick?** Trigger: after the
-  first non-author user runs the wizard. Implication: directly informs
-  whether the in-app onboarding is scalable, OR if it needs a more
-  guided first-run flow.
+## Resolved on 2026-05-09 (walkthrough)
+
+Items moved out of "Open questions" / "Scope creep" because the walkthrough
+on 2026-05-09 either confirmed enough real-world signal to settle them, or
+explicitly dropped them as out-of-product:
+
+- **vid/pid collision.** No collision across the author + 2 external users.
+  Already covered by the validated decision above; the open question was
+  redundant.
+- **Menu bar shows current profile name.** Default ("yes") shipped and
+  works for all 3 users. No noisiness complaints.
+- **External user wizard sticks.** 2 external users completed the wizard
+  without help. Save Logs for Support (PR #78) covers future stick reports.
+- **Toast notifications useful or annoying?** A Settings toggle ("Send
+  notifications when profiles change", defaults on) already ships, so
+  this is user preference, not a code question. The walkthrough surfaced
+  the question but the answer was already in the product.
+- **Dropped scope-creep candidates** (out-of-product, not pursued):
+  per-profile wallpaper; per-profile Karabiner profile switching;
+  per-profile Bluetooth device connect/disconnect; per-profile VPN
+  enable/disable; per-profile focus mode / Do Not Disturb.
 
 ---
 


### PR DESCRIPTION
## Summary

- Settles four open questions that collected enough real-world signal: vid/pid collision (no hits across 3 users; was redundant with the validated USB-fingerprinting decision anyway), menu bar profile-name display (default "yes" works for everyone), external user wizard sticks (2 external users completed without help; PR #78's Save Logs covers future stick reports), toast notifications useful-or-annoying (a Settings toggle "Send notifications when profiles change" already ships, so it's user preference rather than a code question).
- Drops five v2 scope-creep candidates the user has decided are out-of-product: per-profile wallpaper, Karabiner profile, Bluetooth pairing, VPN, and focus mode / DND. Two stay noted for v2: per-profile display arrangement and opt-in crash + error reporting.
- Strips remaining Hammerspoon-era references from `docs/decisions.md`: drops the `obs-cmd`, OBS scenes, and Camo bullets in Validated decisions; rewords the "Same as System + OBS Virtual Camera" bullet to point at the app's own virtual camera; clears stray Phase-1 phrasing ("no Lua", "manual override" which contradicts the validated "No manual override" decision, "Audio Hijack-style" naming a third-party); retitles the doc header to "settled by the shipped implementation."
- New "Resolved on 2026-05-09 (walkthrough)" section at the bottom of `docs/decisions.md` so the trail is visible to future readers.
- CHANGELOG entry covers both the walkthrough decisions and the Hammerspoon cleanup.

Doc-only; no code changes.

## Test plan

- [ ] `docs/decisions.md` renders correctly on GitHub (sections, bullets, code spans)
- [ ] CHANGELOG entry is dated 2026-05-09 and ordered after the visibility-race PRs (#79, #80, #81)
- [ ] No remaining Hammerspoon / OBS / Camo / Audio Hijack references in `docs/decisions.md`
- [ ] Test workflow (`swift build` + `swift test`) passes despite no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)