### PR TITLE
docs: write down v1 graduation criteria + add two v2 candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1025,6 +1025,17 @@ Walked the Pending review section of `tools/todo.md` (the gitignored persistent-
   capture it under "Locked architectural choices" with the rationale.
 - **Before starting Phase 2**, do a final pass through this doc to confirm
   every "open question" has been answered or explicitly deferred.
+
+### v1 graduation criteria + two new v2 candidates (2026-05-09)
+
+`docs/decisions.md` gained a "v1 graduation criteria" section so the bar for tagging `v1.0.0` is written down rather than implicit. Five "already met" bullets capture state today: virtual camera path battle-tested across PRs #79, #80, and #81; wizard validated on 2 external users; Save Logs for Support shipped (#78); Sparkle release flow stable across 15 v0.2.x releases; engine test coverage at 73-100% on pure logic. Three forward-looking gate items: 14-day soak with no critical-class bug PRs landing on `main` (clock starts 2026-05-09 since today shipped 3 visibility-race fixes); `tools/todo.md` Active section empty at tag time; author judgment as the actual trigger (no mechanical date).
+
+The section also lists what was considered and explicitly *not* a v1 gate, with reasons: crash + error reporting (deferred to v2), app-target test coverage at engine parity (active fun work targeting 80% on non-UI files), live virtual-camera preview in Settings (v2), localization (v2), and external user count thresholds (chasing a number distracts from quality signal).
+
+The Scope creep candidates list grew by two entries to keep the canonical list current: localization and the live virtual-camera preview in Settings → Camera. The latter is interesting because it doubles as a self-diagnostic (a user can see the feed without opening Zoom) and because the host process consuming its own virtual camera output is the same shape as the "self-source feedback loop on late consumer connect" bug class from 2026-05-05; that lesson is cross-referenced.
+
+Doc-only PR; no code changes.
+
 ## V1 design pass (2026-05-01)
 
 The functional engine + wizard was complete (94 tests, end-to-end

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -82,6 +82,64 @@ Things a real user might ask for. Not in v1, but kept here for v2 prioritization
 - *Crash and error reporting* (opt-in telemetry for unhandled crashes,
   plus an in-app viewer for recent OSLog failures so the user notices
   silent breakage without running `log show`)
+- *Localization.* All in-app strings are currently English literals;
+  v2 would migrate to `LocalizedStringResource` / `String(localized:)`
+  with `.xcstrings` catalogs. Cool-to-have, not a v1 gate.
+- *Live virtual-camera preview in Settings → Camera tab.* Settings UI
+  becomes a consumer of the virtual camera the same way Zoom is.
+  Doubles as a self-diagnostic so users can see the feed without
+  opening Zoom. Caveat: host-as-consumer interaction has a known bug
+  class (see CHANGELOG "Self-source feedback loop on late consumer
+  connect", 2026-05-05); relevant lesson when implementing.
+
+---
+
+## v1 graduation criteria
+
+What needs to be true to commit to a stable v1.0 feature surface and tag
+`v1.0.0`. The "Already met" bullets capture what's done today; the gate
+is the short forward-looking list at the bottom.
+
+### Already met (as of 2026-05-09)
+
+- **Virtual camera path battle-tested.** The visibility-race cluster
+  (PRs #79, #80, #81) closed out the bug class that was surfacing
+  repeatedly. Hold-last-frame, format conversion, and the
+  extension-activation flow are all stable.
+- **Wizard validated on external users.** 2 external users completed
+  Add Profile without help.
+- **Save Logs for Support shipped (PR #78).** External users have a
+  path to surface bugs.
+- **Sparkle release flow stable.** 15 v0.2.x releases shipped;
+  auto-update working end-to-end.
+- **Engine has substantial test coverage.** Resolver tiebreak fixes
+  (PRs #69, #70, #71) covered. Pure logic at 73-100% line coverage
+  across the engine target.
+
+### Forward-looking gate
+
+- **Soak time.** No new critical-class bug PR landing on `main` for
+  14 consecutive days. Today (2026-05-09) shipped 3 visibility-race
+  fixes; clock starts now.
+- **`tools/todo.md` Active section is empty at tag time.** Graduation
+  lands at a stable resting point, not mid-feature.
+- **Author judgment.** A few more weeks of daily use without surprise.
+  No mechanical trigger; the author calls when ready.
+
+### Explicitly NOT v1 gates
+
+These were considered and deferred:
+
+- *Crash + error reporting:* listed in Scope creep candidates for v2.
+- *App-target test coverage at engine parity:* active fun work in the
+  persistent todo, not a gate. Target is 80% line coverage on non-UI
+  files; SwiftUI views and OS-integration code excluded by design
+  (they need snapshot or integration tests, not unit tests).
+- *Live virtual-camera preview in Settings:* listed in Scope creep
+  candidates for v2.
+- *Localization:* listed in Scope creep candidates for v2.
+- *External user count threshold:* considered, dropped as a gate
+  because chasing a number distracts from quality signal.
 
 ---
 


### PR DESCRIPTION
## Summary

- New "v1 graduation criteria" section in `docs/decisions.md` so the bar for tagging `v1.0.0` is written down rather than implicit. Five "already met" bullets (virtual camera battle-tested, wizard validated on 2 external users, Save Logs for Support shipped, Sparkle release flow stable, engine test coverage 73-100% on pure logic) and three forward-looking gate items (14-day soak with no critical-class bug PRs, `tools/todo.md` Active empty at tag time, author judgment as the actual trigger).
- Same section documents what was considered and explicitly NOT a v1 gate, with reasons: crash + error reporting (v2), app-target test coverage at engine parity (active fun work targeting 80% on non-UI files; SwiftUI views and OS-integration code excluded by design), virtual-camera preview (v2), localization (v2), external user count threshold (chasing a number distracts from quality signal).
- Two new Scope creep candidates: localization (English literals → `LocalizedStringResource` / `String(localized:)` + `.xcstrings`) and live virtual-camera preview in Settings → Camera (consumer-of-self design with the self-source feedback-loop bug class cross-referenced).

Doc-only; no code changes.

## Test plan

- [ ] `docs/decisions.md` renders correctly on GitHub (sections, bullets, code spans)
- [ ] CHANGELOG entry dated 2026-05-09 lands after the previous walkthrough-sync entry
- [ ] Test workflow (`swift build` + `swift test`) passes despite no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)