### PR TITLE
ci: move appcast publish from tag-push to release-publish

### DIFF
--- a/.github/workflows/appcast-publish.yml
+++ b/.github/workflows/appcast-publish.yml
@@ -1,0 +1,193 @@
+# Appcast publishing pipeline.
+#
+# Trigger: a GitHub Release is *published* (taken out of draft state).
+# This is the "Click Publish on the draft" step in the maintainer's
+# release flow. It runs after `release.yml` has built, signed,
+# notarized, and created the draft release with its .app.zip asset.
+#
+# Why a separate workflow: the appcast description is what users see
+# in Sparkle's "Check for Updates" panel. We want it to carry the
+# polished, human-written release notes (Vince Vaughn voice), not the
+# auto-generated PR list that exists at tag-push time. Decoupling
+# appcast publication from tag push means:
+#   - The maintainer edits the draft release body before clicking
+#     Publish, and what users see in-app matches what they see on the
+#     GitHub release page.
+#   - Tagging a release no longer auto-publishes to users; releases
+#     are deliberate by construction.
+#
+# Behavior: rebuilds the signed appcast <item> from the published
+# release body and upserts it into appcast.xml on main. If an item
+# with the matching <sparkle:version> already exists (e.g. because
+# this release was previously published, edited, and re-published),
+# its content is replaced; otherwise the new item is spliced in
+# before </channel>.
+
+name: Appcast publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write  # to push appcast.xml to main
+
+jobs:
+  publish:
+    # Same self-hosted runner as release.yml so we share the
+    # SPARKLE_PRIVATE_KEY secret context and the resolved Swift
+    # package artifacts (sign_update binary).
+    runs-on: [self-hosted, macos-arm64, xcode-26-4-1]
+    timeout-minutes: 10
+
+    env:
+      VERSION_TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version number
+        run: echo "VERSION_NUM=${VERSION_TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Skip dryrun tags
+        run: |
+          set -euo pipefail
+          case "$VERSION_TAG" in
+              *dryrun*)
+                  echo "::notice::Skipping appcast publish for dryrun tag $VERSION_TAG"
+                  echo "SKIP_APPCAST=1" >> "$GITHUB_ENV"
+                  ;;
+          esac
+
+      - name: Resolve Swift package (sign_update binary)
+        if: env.SKIP_APPCAST != '1'
+        run: swift package resolve
+
+      - name: Download release asset
+        if: env.SKIP_APPCAST != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$VERSION_TAG" \
+              --pattern "AVPainReliever.app.zip" \
+              --dir dist
+
+      - name: Render release notes to HTML
+        if: env.SKIP_APPCAST != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BODY="$(gh release view "$VERSION_TAG" --json body --jq .body 2>/dev/null || true)"
+          if [[ -z "$BODY" ]]; then
+              echo "::notice::Release body is empty; appcast item will not include a description"
+              echo "RELEASE_NOTES_HTML=" >> "$GITHUB_ENV"
+              exit 0
+          fi
+          # GitHub's /markdown API renders GFM exactly like the release
+          # page does, so the appcast HTML matches what the user sees on
+          # the release page.
+          HTML="$(gh api -X POST /markdown -f text="$BODY" -f mode=gfm)"
+          {
+              echo "RELEASE_NOTES_HTML<<APPCAST_EOF"
+              echo "$HTML"
+              echo "APPCAST_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Sign appcast item
+        if: env.SKIP_APPCAST != '1'
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          VERSION: ${{ env.VERSION_NUM }}
+          RELEASE_NOTES_HTML: ${{ env.RELEASE_NOTES_HTML }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SPARKLE_PRIVATE_KEY:-}" ]]; then
+              echo "::error::SPARKLE_PRIVATE_KEY is empty; cannot sign the appcast item"
+              exit 1
+          fi
+          # Stable by default. To opt a release into the experimental
+          # Sparkle channel, append `-experimental` (or
+          # `-experimental.N`) to the tag, e.g. `v0.2.1.0-experimental.1`.
+          # Only installs that have allowlisted "experimental" via
+          # Settings → General → Updates → "Receive experimental
+          # updates" see those items.
+          case "$VERSION_TAG" in
+              *-experimental*) export CHANNEL=experimental ;;
+              *)               export CHANNEL= ;;
+          esac
+          echo "Appcast channel: ${CHANNEL:-<stable>}"
+          ITEM_FILE="$RUNNER_TEMP/appcast-item.xml"
+          scripts/sign-appcast.sh dist/AVPainReliever.app.zip > "$ITEM_FILE"
+          echo "APPCAST_ITEM_FILE=$ITEM_FILE" >> "$GITHUB_ENV"
+
+      - name: Upsert item into appcast.xml on main
+        if: env.SKIP_APPCAST != '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ITEM_FILE: ${{ env.APPCAST_ITEM_FILE }}
+          VERSION: ${{ env.VERSION_NUM }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${ITEM_FILE:-}" || ! -f "${ITEM_FILE:-}" ]]; then
+              echo "::error::No signed appcast item to publish"
+              exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Pull again in case main moved between checkout and now.
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+          # Upsert: if an <item> block with <sparkle:version>$VERSION</sparkle:version>
+          # exists, replace it with the new signed item. Otherwise splice
+          # the new item before </channel>. awk buffers each <item>...</item>
+          # block so the version-match check operates on the full block,
+          # not a single line.
+          awk \
+              -v item_file="$ITEM_FILE" \
+              -v target_version="$VERSION" \
+              '
+              BEGIN { in_item = 0; item_buf = ""; replaced = 0 }
+              /<item>/ {
+                  in_item = 1
+                  item_buf = $0
+                  next
+              }
+              in_item == 1 && /<\/item>/ {
+                  item_buf = item_buf "\n" $0
+                  marker = "<sparkle:version>" target_version "</sparkle:version>"
+                  if (index(item_buf, marker) > 0) {
+                      while ((getline line < item_file) > 0) print line
+                      close(item_file)
+                      replaced = 1
+                  } else {
+                      print item_buf
+                  }
+                  in_item = 0
+                  item_buf = ""
+                  next
+              }
+              in_item == 1 {
+                  item_buf = item_buf "\n" $0
+                  next
+              }
+              /<\/channel>/ && !replaced {
+                  while ((getline line < item_file) > 0) print line
+                  close(item_file)
+              }
+              { print }
+              ' appcast.xml > appcast.xml.new
+          mv appcast.xml.new appcast.xml
+          git add appcast.xml
+          git commit -m "appcast: publish $VERSION_TAG
+
+          [skip ci]"
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,86 +227,11 @@ jobs:
                   --title "$VERSION_TAG"
           fi
 
-      - name: Render release notes to HTML
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          BODY="$(gh release view "$VERSION_TAG" --json body --jq .body 2>/dev/null || true)"
-          if [[ -z "$BODY" ]]; then
-              echo "::notice::Release body is empty; appcast item will not include a description"
-              echo "RELEASE_NOTES_HTML=" >> "$GITHUB_ENV"
-              exit 0
-          fi
-          # GitHub's /markdown API renders GFM exactly like the release
-          # page does, so the appcast HTML matches what the user sees on
-          # the release page.
-          HTML="$(gh api -X POST /markdown -f text="$BODY" -f mode=gfm)"
-          {
-              echo "RELEASE_NOTES_HTML<<APPCAST_EOF"
-              echo "$HTML"
-              echo "APPCAST_EOF"
-          } >> "$GITHUB_ENV"
-
-      - name: Sign appcast item
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          VERSION: ${{ env.VERSION_NUM }}
-          RELEASE_NOTES_HTML: ${{ env.RELEASE_NOTES_HTML }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${SPARKLE_PRIVATE_KEY:-}" ]]; then
-              echo "::warning::SPARKLE_PRIVATE_KEY empty — appcast item will not be signed/published"
-              echo "APPCAST_ITEM_FILE=" >> "$GITHUB_ENV"
-              exit 0
-          fi
-          # Stable by default. To opt a release into the experimental
-          # Sparkle channel, append `-experimental` (or
-          # `-experimental.N`) to the tag — e.g. `v0.2.1.0-experimental.1`.
-          # Only installs that have allowlisted "experimental" via
-          # Settings → General → Updates → "Receive experimental
-          # updates" see those items.
-          #
-          # Earlier rule was the inverse (v0.2.x defaulted to
-          # experimental during the virtual-camera development track).
-          # That track graduated to stable in 2026-05; the new default
-          # matches how most apps work and is future-proof for major
-          # version bumps without workflow edits.
-          case "$VERSION_TAG" in
-              *-experimental*) export CHANNEL=experimental ;;
-              *)               export CHANNEL= ;;
-          esac
-          echo "Appcast channel: ${CHANNEL:-<stable>}"
-          ITEM_FILE="$RUNNER_TEMP/appcast-item.xml"
-          scripts/sign-appcast.sh dist/AVPainReliever.app.zip > "$ITEM_FILE"
-          echo "APPCAST_ITEM_FILE=$ITEM_FILE" >> "$GITHUB_ENV"
-
-      - name: Append item to appcast.xml on main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${APPCAST_ITEM_FILE:-}" || ! -f "${APPCAST_ITEM_FILE:-}" ]]; then
-              echo "::warning::No signed appcast item to publish"
-              exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          # Splice the new <item> in immediately before </channel>.
-          # awk over sed because sed's behavior across BSD/GNU on
-          # multi-line replaces is annoying to make portable.
-          awk -v item_file="$APPCAST_ITEM_FILE" '
-              /<\/channel>/ {
-                  while ((getline line < item_file) > 0) print line
-                  close(item_file)
-              }
-              { print }
-          ' appcast.xml > appcast.xml.new
-          mv appcast.xml.new appcast.xml
-          git add appcast.xml
-          git commit -m "appcast: publish $VERSION_TAG
-
-          [skip ci]"
-          git push origin main
+      # Appcast publishing happens in a separate workflow
+      # (.github/workflows/appcast-publish.yml) triggered by
+      # `release: published`. That decouples "binary is built and
+      # available" from "users see it via Check for Updates": the
+      # maintainer edits the draft release notes (typically into the
+      # Vince Vaughn voice) before clicking Publish, and the appcast
+      # item gets the published body as its description rather than
+      # the auto-generated PR list. Releases become deliberate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1036,6 +1036,18 @@ The Scope creep candidates list grew by two entries to keep the canonical list c
 
 Doc-only PR; no code changes.
 
+### Decouple appcast publish from tag push (2026-05-09)
+
+Moved the appcast `<item>` insertion out of `release.yml` into a new `appcast-publish.yml` workflow that triggers on `release: published`. The old flow auto-spliced the appcast item the moment a tag landed, using GitHub's auto-generated PR list as the description. That meant the in-app "Check for Updates" panel showed users a wall of PR titles instead of the polished Vince Vaughn voice that was meant for `appcast.xml`. By the time the maintainer edited the draft release body into the right voice and clicked Publish, the appcast had already shipped to users with the wrong content.
+
+New flow: `release.yml` builds, signs, notarizes, and creates the draft release with the .app.zip asset; nothing touches `appcast.xml`. After the maintainer edits the draft notes and clicks Publish, `appcast-publish.yml` runs on the same self-hosted runner, pulls the published body via `gh release view`, renders it through GitHub's `/markdown` API (same renderer the release page uses, so the in-app HTML matches what users see on the release page), re-signs the appcast item with the EdDSA private key via `scripts/sign-appcast.sh`, and upserts it into `appcast.xml` on `main`. Releases are now deliberate by construction, the version isn't visible to auto-updating users until the maintainer signals "I'm ready" by clicking Publish.
+
+The upsert logic is awk over `appcast.xml`: buffer each `<item>...</item>` block, check whether `<sparkle:version>$VERSION</sparkle:version>` is inside the buffer, replace if found and splice before `</channel>` if not. Tested locally against the live `appcast.xml`: replacing v0.2.0.16's existing item kept the count at 36; splicing a fictional v9.9.9 item bumped the count to 37 and preserved the channel/RSS closing tags. Channel-suffix dispatch (`-experimental.N` → experimental channel, bare tag → stable) moved to the new workflow unchanged. Dryrun tags (`*dryrun*`) skip appcast publishing entirely, same as before.
+
+Side benefit: `appcast.xml` updates can no longer race the maintainer's editing window. Two callers, one source of truth (the published release body), and the GitHub Release page and the Sparkle update panel will always agree.
+
+CI-only PR; no app code changes.
+
 ## V1 design pass (2026-05-01)
 
 The functional engine + wizard was complete (94 tests, end-to-end


### PR DESCRIPTION
## Summary

Moves the appcast `<item>` insertion out of `release.yml` and into a new `appcast-publish.yml` workflow that triggers on `release: published`.

**Why:** the old flow auto-spliced the appcast item the moment a tag landed, using GitHub's auto-generated PR list as the description. That meant in-app "Check for Updates" showed users a wall of PR titles instead of the Vince Vaughn voice the maintainer eventually wrote into the GitHub Release body. By the time the maintainer edited the draft body and clicked Publish, the appcast had already shipped to users with the wrong content.

**New flow:**
1. Tag push → `release.yml` builds, signs, notarizes, creates the draft GitHub Release with the .app.zip asset. Nothing touches `appcast.xml`.
2. Maintainer edits the draft notes into Vince Vaughn voice.
3. Maintainer clicks Publish → `appcast-publish.yml` triggers, pulls the published body, re-renders to HTML via the `/markdown` API (same renderer the release page uses), re-signs the appcast item via `scripts/sign-appcast.sh`, and upserts into `appcast.xml` on main.

Releases become deliberate by construction; the in-app description matches the GitHub release page.

## What changed

- **`.github/workflows/release.yml`**: deleted three steps (Render release notes to HTML, Sign appcast item, Append item to appcast.xml on main) and replaced with a comment pointing at the new workflow.
- **`.github/workflows/appcast-publish.yml`** (new): triggers on `release: published`, runs on the same self-hosted runner so secrets are shared, mirrors the channel-suffix dispatch (`-experimental.N` → experimental, bare tag → stable), and uses an upsert awk that replaces an existing `<item>` matching `<sparkle:version>$VERSION</sparkle:version>` if present, otherwise splices before `</channel>`.
- **`CHANGELOG.md`**: dated entry covering the design and the local testing.

## Validation

- **Awk upsert path**: tested locally against `appcast.xml` with a fake item carrying `<sparkle:version>0.2.0.16</sparkle:version>`. Result: item count stayed at 36, the existing v0.2.0.16 block was replaced with the new content, no duplicates.
- **Awk splice path**: tested locally with a fake `<sparkle:version>9.9.9</sparkle:version>`. Result: item count went 36 → 37, new block landed before `</channel>`, RSS structure intact.
- **Workflow YAML syntax**: parses (no GitHub Actions linter run, but structure mirrors the existing `release.yml`).

## End-to-end test on this PR

The current `v0.2.0.16` GitHub Release is still in draft state with the auto-generated body. After this PR merges, the maintainer can:
1. Edit the v0.2.0.16 draft release notes into Vince Vaughn voice.
2. Click Publish.
3. Watch `appcast-publish.yml` run.
4. Verify `appcast.xml` on main now shows the v0.2.0.16 item with the new description (replacing the auto-generated PR list that release.yml inserted earlier today).

That's the live test. If the workflow misbehaves, the worst case is `appcast.xml` doesn't get updated; users still see the (current) auto-generated description until the next release.

## Test plan

- [ ] CI test workflow passes (`swift build` + `swift test`)
- [ ] After merge: edit v0.2.0.16 release notes, click Publish, watch the new workflow run
- [ ] Verify `appcast.xml` v0.2.0.16 description now matches the published GitHub Release body

🤖 Generated with [Claude Code](https://claude.com/claude-code)