### PR TITLE
fix: trim chrome on Sparkle's update-available window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1036,6 +1036,10 @@ The Scope creep candidates list grew by two entries to keep the canonical list c
 
 Doc-only PR; no code changes.
 
+### Trim chrome on Sparkle's update-available window (2026-05-09)
+
+The Sparkle "Update Available" window shipped with the full traffic-light set (close + minimize + zoom). For a transient utility dialog those extra two buttons read as wrong; a software-update prompt isn't something you'd want to minimize or maximize. Extended the existing Sparkle-window detector in `Updater.swift` (formerly `installWindowTitleObserver`, renamed to `installSparkleWindowCustomizer` to reflect the wider scope) to also remove `.miniaturizable` and `.resizable` from the window's `styleMask` and disable the standard miniaturize and zoom buttons. Matches the project pattern in `WindowChrome.applyDialogChrome` (greyed-out rather than hidden, the macOS-idiomatic way to indicate "this window doesn't do that"). Idempotent on every `didBecomeKeyNotification` for a Sparkle window, same as the title-set behavior it sits next to.
+
 ### Decouple appcast publish from tag push (2026-05-09)
 
 Moved the appcast `<item>` insertion out of `release.yml` into a new `appcast-publish.yml` workflow that triggers on `release: published`. The old flow auto-spliced the appcast item the moment a tag landed, using GitHub's auto-generated PR list as the description. That meant the in-app "Check for Updates" panel showed users a wall of PR titles instead of the polished Vince Vaughn voice that was meant for `appcast.xml`. By the time the maintainer edited the draft release body into the right voice and clicked Publish, the appcast had already shipped to users with the wrong content.

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -84,7 +84,7 @@ final class Updater {
         self.controller = controller
         let feedDescription = controller.updater.feedURL?.absoluteString ?? "nil"
         Self.logger.notice("Sparkle updater started; feed=\(feedDescription, privacy: .public)")
-        installWindowTitleObserver()
+        installSparkleWindowCustomizer()
         // The delegate's `allowedChannels` is re-queried on every
         // check, but Sparkle caches its parsed/filtered appcast result
         // for a window between checks. A user who flips the
@@ -104,30 +104,38 @@ final class Updater {
             .store(in: &cancellables)
     }
 
-    /// Sparkle's update alert XIB doesn't set a window title, so its
-    /// windows render with a blank title bar. We can't override the
-    /// XIB without forking Sparkle, but we can name the window at
-    /// runtime: when any window keys, check whether its window
-    /// controller (or the window itself) is one of Sparkle's
-    /// `SU…` / `SPU…` classes and, if so, give it a title.
-    /// Heuristic but cheap; a Sparkle internal class rename would
-    /// silently drop the title back to blank — acceptable downside.
-    private func installWindowTitleObserver() {
+    /// Sparkle's update alert XIB ships with a blank title and the
+    /// full traffic-light set (close + minimize + zoom). Neither fits
+    /// a transient utility dialog. We can't override the XIB without
+    /// forking Sparkle, but we can fix both at runtime: when any
+    /// window becomes key, check whether its window controller (or
+    /// the window itself) is one of Sparkle's `SU…` / `SPU…` classes,
+    /// and if so give it a title and trim the chrome to dialog style
+    /// (title + close only). Heuristic but cheap; a Sparkle internal
+    /// class rename would silently drop the customizations,
+    /// acceptable downside.
+    private func installSparkleWindowCustomizer() {
         NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: nil,
             queue: .main
         ) { notification in
             guard let window = notification.object as? NSWindow else { return }
-            guard window.title.isEmpty else { return }
             let controllerClass = window.windowController.map { NSStringFromClass(type(of: $0)) } ?? ""
             let windowClass = NSStringFromClass(type(of: window))
             let looksLikeSparkle =
                 controllerClass.hasPrefix("SU") || controllerClass.hasPrefix("SPU") ||
                 windowClass.hasPrefix("SU") || windowClass.hasPrefix("SPU")
-            if looksLikeSparkle {
+            guard looksLikeSparkle else { return }
+            if window.title.isEmpty {
                 window.title = "Software Update"
             }
+            // Trim to dialog chrome: title + close only. Idempotent;
+            // safe to apply on every key event.
+            window.styleMask.remove(.miniaturizable)
+            window.styleMask.remove(.resizable)
+            window.standardWindowButton(.miniaturizeButton)?.isEnabled = false
+            window.standardWindowButton(.zoomButton)?.isEnabled = false
         }
     }
 


### PR DESCRIPTION
## Summary

Sparkle's "Update Available" window ships with the full traffic-light set (close + minimize + zoom). For a transient update dialog the extra two buttons read as wrong; a software-update prompt isn't something the user would want to minimize or maximize.

Extended the existing Sparkle-window detector in [`Updater.swift`](Sources/AVPainRelieverApp/Updater.swift) (formerly `installWindowTitleObserver`, renamed to `installSparkleWindowCustomizer` to reflect the wider scope) to also strip `.miniaturizable` and `.resizable` from the window's `styleMask` and disable the standard miniaturize and zoom buttons when a Sparkle window becomes key.

Matches the existing project pattern in [`WindowChrome.applyDialogChrome`](Sources/AVPainRelieverApp/WindowChrome.swift) — greyed-out rather than hidden, the macOS-idiomatic way to indicate "this window doesn't do that."

## What changed

- `Sources/AVPainRelieverApp/Updater.swift`: extended the existing `didBecomeKeyNotification` handler to also remove `.miniaturizable`/`.resizable` from `styleMask` and `isEnabled = false` on the miniaturize and zoom buttons. Renamed the helper for honesty (it now does title + chrome). Idempotent on every key event for a Sparkle window.
- `CHANGELOG.md`: dated entry.

## Test plan

User explicitly opted out of the local-test gate ("doesn't seem like a scary commit not to test"). The change is small and bounded; if it goes wrong, the next release surfaces the issue and we revert.

For curiosity:
- [ ] CI test workflow passes (`swift build` + `swift test`)
- [ ] On the next release where users see the update-available window, verify only the close button is active (yellow and green should be greyed out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)