### PR TITLE
ui: confetti pop bigger, fall slower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1036,6 +1036,10 @@ The Scope creep candidates list grew by two entries to keep the canonical list c
 
 Doc-only PR; no code changes.
 
+### Confetti: bigger pop, slower fall (2026-05-09)
+
+Tuned `ConfettiBurst` to feel less rushed. The launch power range bumped from `200...420` to `280...520` (~30% more reach, so the apex is higher and the spread wider). The per-particle fall duration went from `1.4...2.2`s to `2.2...3.4`s (~55% slower descent). The `oneShotConfetti` cleanup timer moved from 3.2s to 4.5s to cover the longer trajectory and updated the doc comment to match. No structural changes; same `KeyframeAnimator` driving the same trajectory shape, just different numbers.
+
 ### Trim chrome on Sparkle's update-available window (2026-05-09)
 
 The Sparkle "Update Available" window shipped with the full traffic-light set (close + minimize + zoom). For a transient utility dialog those extra two buttons read as wrong; a software-update prompt isn't something you'd want to minimize or maximize. Extended the existing Sparkle-window detector in `Updater.swift` (formerly `installWindowTitleObserver`, renamed to `installSparkleWindowCustomizer` to reflect the wider scope) to also remove `.miniaturizable` and `.resizable` from the window's `styleMask` and disable the standard miniaturize and zoom buttons. Matches the project pattern in `WindowChrome.applyDialogChrome` (greyed-out rather than hidden, the macOS-idiomatic way to indicate "this window doesn't do that"). Idempotent on every `didBecomeKeyNotification` for a Sparkle window, same as the title-set behavior it sits next to.

--- a/Sources/AVPainRelieverApp/ConfettiBurst.swift
+++ b/Sources/AVPainRelieverApp/ConfettiBurst.swift
@@ -139,7 +139,7 @@ private struct ConfettiParticle: View {
             // the existing Window scene; rendering truly outside the
             // window requires a borderless transparent host window,
             // which is a separate change.
-            let power = Double.random(in: 200...420)
+            let power = Double.random(in: 280...520)
             let peakDX = CGFloat(cos(angle) * power)
             // sin(angle) is negative across the upward cone; flip to a
             // positive rise so the trajectory keyframe can subtract it
@@ -151,7 +151,7 @@ private struct ConfettiParticle: View {
                 driftDX: CGFloat.random(in: -40...40),
                 fallTarget: CGFloat.random(in: 360...560),
                 riseDuration: Double.random(in: 0.5...0.85),
-                fallDuration: Double.random(in: 1.4...2.2),
+                fallDuration: Double.random(in: 2.2...3.4),
                 spin: Double.random(in: -900...900),
                 size: CGFloat.random(in: 8...14),
                 color: palette.randomElement() ?? .accentColor,
@@ -165,12 +165,13 @@ extension View {
     /// Overlay a one-shot `ConfettiBurst` when `isPresented` is true.
     /// After `duration` the binding flips back to false so the overlay
     /// unmounts and no animations keep ticking. Default duration
-    /// outlasts the longest particle trajectory (≈ 2.4s rise + fall).
-    /// Used by the About + Welcome dialogs to keep the celebratory
-    /// burst self-contained — the caller just toggles the flag.
+    /// outlasts the longest particle trajectory (≈ 4.25s rise + fall,
+    /// rounded up for buffer). Used by the About + Welcome dialogs to
+    /// keep the celebratory burst self-contained; the caller just
+    /// toggles the flag.
     func oneShotConfetti(
         isPresented: Binding<Bool>,
-        duration: Duration = .seconds(3.2)
+        duration: Duration = .seconds(4.5)
     ) -> some View {
         overlay {
             if isPresented.wrappedValue {


### PR DESCRIPTION
## Summary

The party-popper burst was reading as too fast and too small. Three number tweaks in `ConfettiBurst`, no structural changes:

- `power` range `200...420` → `280...520` (~30% more reach; apex higher, spread wider)
- per-particle `fallDuration` `1.4...2.2`s → `2.2...3.4`s (~55% slower)
- `oneShotConfetti` cleanup timer `3.2`s → `4.5`s so the longer trajectories aren't cut off mid-fall

## Why not switch to `CAEmitterLayer`?

Considered. It would be GPU-accelerated and is what most third-party confetti libraries wrap. But it's an AppKit/Core Animation world (NSViewRepresentable boilerplate), and the existing SwiftUI `KeyframeAnimator` implementation works fine for a burst that fires twice in the app. Not worth a rewrite to chase performance on something that already feels native.

## Test plan

User authorized skipping local test ("This update is good. Make a PR.").

For curiosity:
- [ ] CI test workflow passes (`swift build` + `swift test`)
- [ ] On the next release: confetti looks bigger and falls slower in the About + Welcome dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)