### PR TITLE
feat: add a third Sparkle release channel (dev)

### DIFF
--- a/.github/workflows/appcast-publish.yml
+++ b/.github/workflows/appcast-publish.yml
@@ -120,6 +120,7 @@ jobs:
           # Settings → General → Updates → "Receive experimental
           # updates" see those items.
           case "$VERSION_TAG" in
+              *-dev*)          export CHANNEL=dev ;;
               *-experimental*) export CHANNEL=experimental ;;
               *)               export CHANNEL= ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1036,6 +1036,20 @@ The Scope creep candidates list grew by two entries to keep the canonical list c
 
 Doc-only PR; no code changes.
 
+### Add a third Sparkle release channel: dev (2026-05-09)
+
+The release flow grew from two channels (stable + experimental) to three (stable + dev + experimental). Project convention for what goes where: stable carries normal-sized features and bug fixes for everyone, dev carries small in-flight features (ships more often than stable, low-risk per change), experimental carries moonshot work that may break things. Dev and experimental are independent toggles in Settings, not points on a single stability axis, so the user can opt in to either, both, or neither.
+
+**Settings UI.** Settings → General → Updates gained a second toggle: "Receive dev updates" alongside the existing "Receive experimental updates," each with its own caption. Listed dev first since it's the lower-risk opt-in. Both default off.
+
+**SettingsStore.** New `devUpdates: Bool` mirrors `experimentalUpdates` exactly (same lazy-default pattern, same `didSet` write). No migration needed; new key, additive.
+
+**ChannelGatingDelegate.** `allowedChannels(for:)` now returns a `Set<String>` constructed from both bools: `dev` if `devUpdates`, `experimental` if `experimentalUpdates`. Sparkle treats the returned set as a union, so a user with both flipped on sees the union of stable + dev + experimental. Updater also gained a Combine subscriber for `$devUpdates` matching the existing `$experimentalUpdates` one, plus `.notice` log lines on each toggle change so the toggle-driven re-check is visible in the app's own log stream (Sparkle's internal background-check logs go to its own subsystem, not ours).
+
+**Workflow.** `appcast-publish.yml`'s tag-suffix dispatch grew a `*-dev*) export CHANNEL=dev ;;` arm before the experimental one. `release.yml` doesn't touch channels anymore (decoupled in #84), so no changes there. `scripts/sign-appcast.sh` already accepts any `$CHANNEL` value and emits `<sparkle:channel>$CHANNEL</sparkle:channel>`, so the script needs no edit.
+
+**Known follow-up** (not in this PR): the pre-check intercept in `Updater.checkForUpdates()` uses `isExperimentalVersion(_:)` to detect a running experimental version and nudge the user to enable the toggle. That heuristic was already stale after the 2026-05-05 graduation (it infers channel from major/minor numbers, but the rule flipped to tag-suffix dispatch). Adding "dev" doesn't make it more wrong; it's the same gap. The clean fix is to bake the channel into the build at release time (a new `SUChannel` key in `Info.plist` set by the workflow based on tag suffix) and have the intercept compare bundled vs. enabled channels. Out of scope for this PR.
+
 ### Confetti: bigger pop, slower fall (2026-05-09)
 
 Tuned `ConfettiBurst` to feel less rushed. The launch power range bumped from `200...420` to `280...520` (~30% more reach, so the apex is higher and the spread wider). The per-particle fall duration went from `1.4...2.2`s to `2.2...3.4`s (~55% slower descent). The `oneShotConfetti` cleanup timer moved from 3.2s to 4.5s to cover the longer trajectory and updated the doc comment to match. No structural changes; same `KeyframeAnimator` driving the same trajectory shape, just different numbers.

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -22,6 +22,7 @@ final class SettingsStore: ObservableObject {
         static let launchAtLogin = "launchAtLogin"
         static let virtualCameraEnabled = "virtualCameraEnabled"
         static let experimentalUpdates = "experimentalUpdates"
+        static let devUpdates = "devUpdates"
         static let statsTrackingEnabled = "statsTrackingEnabled"
         static let statsStartDate = "statsStartDate"
         static let perProfileCounts = "perProfileCounts"
@@ -113,14 +114,25 @@ final class SettingsStore: ObservableObject {
         didSet { write(virtualCameraEnabled, forKey: Key.virtualCameraEnabled) }
     }
 
+    /// Opt-in to updates from the `dev` Sparkle channel. Default off.
+    /// When on, the Updater's `allowedChannels` delegate hook adds
+    /// `"dev"` to the returned set, so feed items tagged
+    /// `<sparkle:channel>dev</sparkle:channel>` become eligible.
+    /// Project convention: dev releases carry small in-flight features
+    /// that ship more frequently than the stable line. Independent of
+    /// `experimentalUpdates`; users can opt in to either, both, or
+    /// neither.
+    @Published var devUpdates: Bool {
+        didSet { write(devUpdates, forKey: Key.devUpdates) }
+    }
+
     /// Opt-in to updates from the `experimental` Sparkle channel.
-    /// Default off — only stable releases reach the user. When on,
-    /// the Updater's allowedChannels delegate hook returns
-    /// `["experimental"]`, so feed items tagged
-    /// `<sparkle:channel>experimental</sparkle:channel>` become
-    /// eligible upgrades. Used to gate the v0.2.x virtual-camera
-    /// builds behind a deliberate user choice while the feature is
-    /// still maturing.
+    /// Default off. When on, the Updater's `allowedChannels` delegate
+    /// hook adds `"experimental"` to the returned set, so feed items
+    /// tagged `<sparkle:channel>experimental</sparkle:channel>` become
+    /// eligible. Project convention: experimental releases carry
+    /// moonshot work that may break things. Independent of
+    /// `devUpdates`; users can opt in to either, both, or neither.
     @Published var experimentalUpdates: Bool {
         didSet { write(experimentalUpdates, forKey: Key.experimentalUpdates) }
     }
@@ -269,6 +281,7 @@ final class SettingsStore: ObservableObject {
         self.launchAtLogin = (defaults.object(forKey: Key.launchAtLogin) as? Bool) ?? false
         self.virtualCameraEnabled = (defaults.object(forKey: Key.virtualCameraEnabled) as? Bool) ?? false
         self.experimentalUpdates = (defaults.object(forKey: Key.experimentalUpdates) as? Bool) ?? false
+        self.devUpdates = (defaults.object(forKey: Key.devUpdates) as? Bool) ?? false
         // Stats tracking ships off by default for privacy. Every
         // record / increment method early-returns when this is false.
         self.statsTrackingEnabled = (defaults.object(forKey: Key.statsTrackingEnabled) as? Bool) ?? false

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -300,8 +300,13 @@ private struct GeneralSettingsTab: View {
             }
 
             Section {
+                Toggle("Receive dev updates", isOn: $settings.devUpdates)
+                Text("Opt in to small in-flight features. Dev releases ship more often than the stable line and usually carry one or two finished tweaks at a time. Off by default.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 Toggle("Receive experimental updates", isOn: $settings.experimentalUpdates)
-                Text("Opt in to early-access builds. Experimental releases may include unfinished features and be less stable than the regular release line. Off by default.")
+                Text("Opt in to moonshot builds. Experimental releases may include unfinished features and break things. Off by default. Independent of the dev toggle above; flip either, both, or neither.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/AVPainRelieverApp/Updater.swift
+++ b/Sources/AVPainRelieverApp/Updater.swift
@@ -98,7 +98,16 @@ final class Updater {
         settings.$experimentalUpdates
             .removeDuplicates()
             .dropFirst()
-            .sink { [weak self] _ in
+            .sink { [weak self] enabled in
+                Self.logger.notice("experimentalUpdates → \(enabled, privacy: .public); forcing background check")
+                self?.controller.updater.checkForUpdatesInBackground()
+            }
+            .store(in: &cancellables)
+        settings.$devUpdates
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] enabled in
+                Self.logger.notice("devUpdates → \(enabled, privacy: .public); forcing background check")
                 self?.controller.updater.checkForUpdatesInBackground()
             }
             .store(in: &cancellables)
@@ -229,10 +238,15 @@ final class Updater {
 /// Sparkle delegate that controls which release channels the user is
 /// willing to receive. Default-empty allow-list means Sparkle only
 /// considers feed items WITHOUT a `<sparkle:channel>` tag — i.e.
-/// stable. When the user opts in via Settings, we return
-/// `["experimental"]` and items tagged with that channel become
-/// eligible. Multiple channels can be allowed simultaneously; for
-/// now there's only one experimental channel.
+/// stable. When the user opts in via Settings, the relevant channel
+/// names get added to the returned set:
+///
+/// - `experimentalUpdates` → `"experimental"` (moonshot work)
+/// - `devUpdates` → `"dev"` (small in-flight features)
+///
+/// The two toggles are independent. Sparkle considers feed items
+/// matching ANY of the allowed channels, so a user with both flipped
+/// on sees the union (stable + dev + experimental).
 ///
 /// Held strongly by `Updater` because Sparkle stores its delegates
 /// as weak references — without our retention, the delegate would
@@ -247,6 +261,9 @@ private final class ChannelGatingDelegate: NSObject, SPUUpdaterDelegate {
     }
 
     func allowedChannels(for updater: SPUUpdater) -> Set<String> {
-        settings.experimentalUpdates ? ["experimental"] : []
+        var channels: Set<String> = []
+        if settings.devUpdates { channels.insert("dev") }
+        if settings.experimentalUpdates { channels.insert("experimental") }
+        return channels
     }
 }


### PR DESCRIPTION
## Summary

Adds a third Sparkle release channel — `dev` — alongside the existing `stable` and `experimental`. Project convention for what goes where:

- **Stable** — normal-sized features and bug fixes; reaches all users on auto-update.
- **Dev** — small in-flight features; ships more often than stable, low-risk per change.
- **Experimental** — moonshot work that may break things.

Dev and experimental are independent toggles in Settings, not points on a single stability axis. Users can opt in to either, both, or neither.

## What changed

- **`SettingsStore.swift`** — `devUpdates: Bool` mirrors `experimentalUpdates` exactly (same lazy-default pattern, same `didSet` write). No migration; additive.
- **`SettingsView.swift`** — second `Toggle` "Receive dev updates" with caption text, listed above the experimental one (lower-risk opt-in first).
- **`Updater.swift`** — `ChannelGatingDelegate.allowedChannels(for:)` now returns a union `Set<String>` based on both bools. Combine subscriber for `$devUpdates` matches the existing `$experimentalUpdates` one. Both subscribers also emit a `.notice` log line on each toggle change so the toggle-driven re-check is visible in the app's own log stream (Sparkle's internal background-check logs go to its own subsystem, not ours).
- **`.github/workflows/appcast-publish.yml`** — tag-suffix dispatch grew a `*-dev*) export CHANNEL=dev ;;` arm before the experimental one. Tag format: `vX.Y.Z-dev.N`.
- **`scripts/sign-appcast.sh`** — no edit needed; already accepts any `$CHANNEL` and emits `<sparkle:channel>$CHANNEL</sparkle:channel>`.
- **`CHANGELOG.md`** — dated entry covering the design + the known follow-up.

## Validated locally

- `swift build` clean, all 194 tests green.
- Toggle persistence verified across app restarts.
- Toggle changes emit the new log line.

## Known follow-up (not in this PR)

The pre-check intercept in `Updater.checkForUpdates()` uses `isExperimentalVersion(_:)` to detect a running experimental version and nudge the user. That heuristic infers channel from major/minor numbers, which broke after the 2026-05-05 graduation when channel-by-tag-suffix replaced channel-by-version. Adding "dev" doesn't make it more wrong; it's the same gap. The clean fix is to bake an `SUChannel` key into `Info.plist` at release time and have the intercept compare bundled vs. enabled channels. Flagged in the CHANGELOG entry.

## Test plan

- [ ] CI test workflow passes (`swift build` + `swift test`)
- [ ] On the next dev-channel release: stable users don't see it, dev-toggle users do

🤖 Generated with [Claude Code](https://claude.com/claude-code)