### PR TITLE
ui: tighten README voice (drop tagline, remove em dashes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1036,6 +1036,18 @@ The Scope creep candidates list grew by two entries to keep the canonical list c
 
 Doc-only PR; no code changes.
 
+### README tightening: drop tagline, remove em dashes, less polished voice (2026-05-10)
+
+The README read as slightly AI-shaped: heavy em-dash use for parenthetical asides, a too-tidy descriptive tagline under the hero image, polished but slightly hollow phrasings in the intro. User feedback on 2026-05-10: *"Make it sound less like AI wrote it. You're wonderful but I want more of a human touch here."*
+
+Three passes through the file:
+
+1. **Removed the descriptive blockquote tagline.** ("Auto-switch your microphone, speakers, and camera when you change desks.") The hero image's alt attribute and the body paragraph below it carry the same information without the duplication.
+2. **Removed every em dash.** Replaced with periods, commas, parens, or colons depending on the grammatical role each one was filling. Bullet definitions like `**Switch to** — manually apply…` became `**Switch to**: manually apply…`. Aside-style em dashes around lists (`Some apps — Zoom, Slack, Teams — keep…`) became parens. The hero image's alt text (`AV Pain Reliever — Your laptop knows where it is.`) became `AV Pain Reliever. Your laptop knows where it is.`
+3. **Loosened the intro paragraph.** Original: *"When you carry a MacBook between locations — your home office, a work desk, a conference room, a café — your audio defaults usually need fixing every time."* Now reads in shorter, choppier sentences with the location list broken into its own beat: *"You carry your MacBook to a few different desks during the week. Home office, work desk, conference room, café. Each one has a different microphone, different speakers, maybe a different camera. The audio is wrong until you fix it."* Same information, more conversational rhythm.
+
+Navigation arrows (`→`) were left alone. They're a different character and serve a different purpose (path separators, e.g., `Settings… → Camera`).
+
 ### README hero image replaces the H1 title (2026-05-10)
 
 The README opened with a plain `# AV Pain Reliever` H1. Now that the repo has a real social-preview card uploaded under Settings → General → Social preview (the "story" layout: USB → speaker → camera, white background, "Your laptop knows where it is."), the same image carries the title role at the top of the README too — visual continuity with what users see on GitHub unfurls.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 <p align="center">
-  <img src="docs/og-card.png" alt="AV Pain Reliever — Your laptop knows where it is." width="800">
+  <img src="docs/og-card.png" alt="AV Pain Reliever. Your laptop knows where it is." width="800">
 </p>
 
-> Auto-switch your microphone, speakers, and camera when you change desks.
-
-When you carry a MacBook between locations — your home office, a work desk, a conference room, a café — your audio defaults usually need fixing every time. Different microphone, different speakers, sometimes a different camera. **AV Pain Reliever** notices which dock you've connected to and automatically:
+You carry your MacBook to a few different desks during the week. Home office, work desk, conference room, café. Each one has a different microphone, different speakers, maybe a different camera. The audio is wrong until you fix it. **AV Pain Reliever** notices which dock you've connected to and handles it for you:
 
 - Sets your **system default microphone** for that location.
 - Sets your **system default speaker** for that location.
 - Sets your **system preferred camera** for that location.
 
-Configure your video apps (Zoom, Slack, Teams) once to follow the system, and after that the right setup is active the moment you plug in. Unplug and it returns to your laptop's built-in mic and speakers.
+Set your video apps (Zoom, Slack, Teams) once to follow the system default. After that, plug in and the right setup kicks in. Unplug, and you're back to the laptop's built-in mic and speakers.
 
-Some apps — Zoom, Slack, Teams — keep their own camera selection that ignores the system default. For those, AV Pain Reliever can also act as a **virtual camera** that always streams whatever camera the active profile names. See *Virtual camera* below.
+Some apps (Zoom, Slack, Teams) keep their own camera selection that ignores the system default. For those, AV Pain Reliever can also act as a **virtual camera** that streams whichever real camera the active profile names. See *Virtual camera* below.
 
-The app lives in your menu bar — no Dock icon, no windows in your way.
+The app lives in your menu bar. No Dock icon, no windows in your way.
 
 ---
 
@@ -41,7 +39,7 @@ To stop it: click the menu bar icon → **Quit**.
 
 The first time you launch, the welcome window walks you through capturing the dock you're at right now:
 
-1. **Name the location.** "Home Office", "Work Desk", "Studio", "Conference Room" — anything that makes sense to you.
+1. **Name the location.** Whatever makes sense to you: "Home Office", "Work Desk", "Studio", "Conference Room".
 2. **Pick which USB devices identify this location.** Untick anything that travels with you (keyboards, mice, phones).
 3. **Pick the audio and camera defaults.** Pre-filled with your current System Settings.
 4. **Save.**
@@ -56,10 +54,10 @@ When you connect to a new dock the app doesn't recognise, the menu bar shows **"
 
 Click the menu bar icon for:
 
-- **Switch to** — manually apply a different profile.
-- **Add Profile…** — capture the dock you're at right now (⌘N).
-- **Settings…** — notifications, menu bar appearance, profile management, Launch at Login (⌘,).
-- **About** — version and updates.
+- **Switch to**: manually apply a different profile.
+- **Add Profile…**: capture the dock you're at right now (⌘N).
+- **Settings…**: notifications, menu bar appearance, profile management, Launch at Login (⌘,).
+- **About**: version and updates.
 
 ---
 
@@ -67,7 +65,7 @@ Click the menu bar icon for:
 
 Zoom, Slack, and Teams remember the camera you pick *inside their own settings* and ignore the system default. So even after AV Pain Reliever changes your system camera, those apps keep using whatever you last chose in their picker.
 
-The virtual camera fixes that. Once turned on, **AV Pain Reliever** appears as a camera in any video app's picker. Pick it once and it then streams whichever real camera the active profile names — built-in, USB capture card, iPhone Continuity Camera, anything you can configure in a profile. When the profile changes, the picture follows.
+The virtual camera fixes that. Once turned on, **AV Pain Reliever** appears as a camera in any video app's picker. Pick it once and it streams whichever real camera the active profile names: built-in, USB capture card, iPhone Continuity Camera, anything you can configure in a profile. When the profile changes, the picture follows.
 
 To enable:
 
@@ -82,7 +80,7 @@ To turn it off, flip the toggle back. The "AV Pain Reliever" entry stops showing
 
 ## Privacy
 
-The app makes no network calls beyond checking for its own updates. No analytics, no telemetry, no third-party services. Your profiles are stored as a plain text file on your Mac (`~/Library/Application Support/AVPainReliever/profiles.toml`) — you can read it, back it up, or edit it by hand.
+The app makes no network calls beyond checking for its own updates. No analytics, no telemetry, no third-party services. Your profiles are stored as a plain text file on your Mac (`~/Library/Application Support/AVPainReliever/profiles.toml`). You can read it, back it up, or edit it by hand.
 
 ---
 
@@ -92,4 +90,4 @@ Questions or bug reports: [open an issue](https://github.com/superic/av-pain-rel
 
 ---
 
-For developers: see [CHANGELOG.md](CHANGELOG.md) for the project journal, [docs/](docs/) for architecture / decisions / virtual camera / release docs, and [CLAUDE.md](CLAUDE.md) for repo orientation. Licensed MIT — see [LICENSE](LICENSE).
+For developers: see [CHANGELOG.md](CHANGELOG.md) for the project journal, [docs/](docs/) for architecture / decisions / virtual camera / release docs, and [CLAUDE.md](CLAUDE.md) for repo orientation. MIT licensed. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

The README read slightly AI-shaped. User feedback on 2026-05-10: drop the descriptive blockquote tagline, strip every em dash, and loosen the intro into something more human.

Three passes through the file:

1. **Removed the blockquote tagline.** The hero image's `alt` and the body paragraph below already carry the same information.
2. **Removed every em dash.** Replaced with periods, commas, parens, or colons depending on the role each one was filling. Bullet definitions like `**Switch to** — manually apply…` became `**Switch to**: manually apply…`. Aside-style em dashes around lists (`Some apps — Zoom, Slack, Teams — keep…`) became parens. The hero image's alt text (`AV Pain Reliever — Your laptop knows where it is.`) became `AV Pain Reliever. Your laptop knows where it is.`.
3. **Loosened the intro paragraph** into shorter, choppier sentences. Original opened with a long em-dash-heavy sentence; now reads as four short beats with the location list broken out: *"You carry your MacBook to a few different desks during the week. Home office, work desk, conference room, café. Each one has a different microphone, different speakers, maybe a different camera. The audio is wrong until you fix it."*

Navigation arrows (`→`) were left alone. They're a different character and serve a different purpose (path separators in instructions like `Settings… → Camera`).

## Verification

```sh
$ grep -c "—" README.md
0
```

## Test plan

- [ ] CI test workflow passes (`swift build` + `swift test`)
- [ ] Diff on the "Files changed" tab reads naturally end-to-end
- [ ] No em dashes in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)