### PR TITLE
fix(appcast): repair comment-eaten parse error; harden upsert awk regex

### DIFF
--- a/.github/workflows/appcast-publish.yml
+++ b/.github/workflows/appcast-publish.yml
@@ -148,44 +148,16 @@ jobs:
           git checkout main
           git pull --ff-only origin main
           # Upsert: if an <item> block with <sparkle:version>$VERSION</sparkle:version>
-          # exists, replace it with the new signed item. Otherwise splice
-          # the new item before </channel>. awk buffers each <item>...</item>
-          # block so the version-match check operates on the full block,
-          # not a single line.
+          # exists, replace it with the new signed item. Otherwise
+          # splice the new item before </channel>. The awk logic
+          # lives in scripts/upsert-appcast-item.awk so it can be
+          # unit-tested independently (see
+          # scripts/test-upsert-appcast.sh, exercised in test.yml).
           awk \
               -v item_file="$ITEM_FILE" \
               -v target_version="$VERSION" \
-              '
-              BEGIN { in_item = 0; item_buf = ""; replaced = 0 }
-              /<item>/ {
-                  in_item = 1
-                  item_buf = $0
-                  next
-              }
-              in_item == 1 && /<\/item>/ {
-                  item_buf = item_buf "\n" $0
-                  marker = "<sparkle:version>" target_version "</sparkle:version>"
-                  if (index(item_buf, marker) > 0) {
-                      while ((getline line < item_file) > 0) print line
-                      close(item_file)
-                      replaced = 1
-                  } else {
-                      print item_buf
-                  }
-                  in_item = 0
-                  item_buf = ""
-                  next
-              }
-              in_item == 1 {
-                  item_buf = item_buf "\n" $0
-                  next
-              }
-              /<\/channel>/ && !replaced {
-                  while ((getline line < item_file) > 0) print line
-                  close(item_file)
-              }
-              { print }
-              ' appcast.xml > appcast.xml.new
+              -f scripts/upsert-appcast-item.awk \
+              appcast.xml > appcast.xml.new
           mv appcast.xml.new appcast.xml
           git add appcast.xml
           git commit -m "appcast: publish $VERSION_TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,11 @@ jobs:
 
       - name: Test
         run: swift test --parallel
+
+      - name: Appcast upsert regression
+        # Tiny shell-test harness for scripts/upsert-appcast-item.awk.
+        # Pins the start-of-line anchoring that prevents the awk
+        # script from eating XML comments whose prose mentions
+        # `<item>`. Without this, a future workflow tweak could
+        # re-introduce the 2026-05-10 live-feed-broke bug.
+        run: scripts/test-upsert-appcast.sh

--- a/appcast.xml
+++ b/appcast.xml
@@ -5,8 +5,6 @@
         <link>https://github.com/superic/av-pain-reliever</link>
         <description>AV Pain Reliever — release feed for the Sparkle auto-updater.</description>
         <language>en</language>
-        <!--
-            Stub feed. The .github/workflows/release.yml workflow
         <item>
             <title>Version 0.1.0</title>
             <pubDate>Sun, 03 May 2026 07:04:30 +0000</pubDate>

--- a/scripts/test-upsert-appcast.sh
+++ b/scripts/test-upsert-appcast.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/upsert-appcast-item.awk.
+#
+# Why these exist: a 2026-05-10 publish run (v0.2.0.17-dev.1)
+# corrupted appcast.xml by matching `<item>` inside a comment block,
+# entering item-buffer mode mid-comment, then overwriting the buffer
+# when the real `<item>` opened. The resulting unterminated `<!--`
+# made Sparkle's feed parser bail with "An error occurred while
+# parsing the update feed." These tests pin the hardened
+# start-of-line anchors so that regression class can't slip back in.
+#
+# Runs three fixture-driven checks:
+#   1. Comment with `<item>` in prose is preserved verbatim, new
+#      item is spliced before </channel> (the live-broken scenario).
+#   2. Existing item with matching <sparkle:version> is REPLACED
+#      with the new signed item, not duplicated.
+#   3. Output of every scenario passes xmllint.
+#
+# Bash 3.2 compatible (no associative arrays, no `${var,,}`,
+# nothing fancy), per the project's macOS-stock-bash rule.
+#
+# Usage: scripts/test-upsert-appcast.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AWK_SCRIPT="$ROOT/scripts/upsert-appcast-item.awk"
+
+if [ ! -f "$AWK_SCRIPT" ]; then
+    echo "FAIL: $AWK_SCRIPT not found" >&2
+    exit 2
+fi
+
+if ! command -v xmllint >/dev/null 2>&1; then
+    echo "FAIL: xmllint required but not on PATH" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# ----- helpers --------------------------------------------------------------
+
+# Reusable signed item the tests splice in.
+cat > "$WORK/new-item.xml" <<'EOF'
+        <item>
+            <title>Version 9.9.9-test</title>
+            <pubDate>Sun, 10 May 2026 22:00:00 +0000</pubDate>
+            <sparkle:channel>dev</sparkle:channel>
+            <sparkle:version>9.9.9-test</sparkle:version>
+            <sparkle:shortVersionString>9.9.9-test</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://example.invalid/x.zip"
+                       type="application/octet-stream"
+                       sparkle:edSignature="AAAA" length="100" />
+        </item>
+EOF
+
+# Run the awk script and capture stdout to $1; stdin is the fixture path.
+run_upsert() {
+    local out="$1"
+    local fixture="$2"
+    local version="$3"
+    awk \
+        -v item_file="$WORK/new-item.xml" \
+        -v target_version="$version" \
+        -f "$AWK_SCRIPT" \
+        "$fixture" > "$out"
+}
+
+assert_xml_valid() {
+    local file="$1"
+    local label="$2"
+    if xmllint --noout "$file" 2>/dev/null; then
+        echo "  PASS: $label parses as XML"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $label is not valid XML"
+        xmllint --noout "$file" 2>&1 | sed 's/^/    /'
+        fail=$((fail + 1))
+    fi
+}
+
+assert_grep() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    if grep -q "$pattern" "$file"; then
+        echo "  PASS: $label"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $label (pattern not found: $pattern)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_count() {
+    local file="$1"
+    local pattern="$2"
+    local expected="$3"
+    local label="$4"
+    local actual
+    actual=$(grep -c "$pattern" "$file" || true)
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS: $label (count=$actual)"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $label (expected count=$expected, got=$actual)"
+        fail=$((fail + 1))
+    fi
+}
+
+# ----- fixture 1: comment with <item> in prose preserved --------------------
+
+echo "Test 1: comment containing <item> in prose is preserved verbatim"
+
+cat > "$WORK/fixture-1.xml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Feed</title>
+        <!--
+            Stub feed. The workflow appends a new <item> here on
+            every signed-and-notarized release. Until the first tag
+            lands, an installed app fetching this feed correctly
+            resolves to "you're up to date."
+        -->
+        <item>
+            <title>Version 1.0.0</title>
+            <sparkle:version>1.0.0</sparkle:version>
+        </item>
+    </channel>
+</rss>
+EOF
+
+run_upsert "$WORK/out-1.xml" "$WORK/fixture-1.xml" "9.9.9-test"
+assert_xml_valid "$WORK/out-1.xml" "fixture 1 output"
+assert_grep "$WORK/out-1.xml" "appends a new <item> here" "comment middle survives"
+assert_grep "$WORK/out-1.xml" "    -->" "comment closer survives"
+assert_grep "$WORK/out-1.xml" "9.9.9-test" "new item spliced in"
+assert_count "$WORK/out-1.xml" "<sparkle:version>" 2 "exactly two items in output"
+
+# ----- fixture 2: replace existing item with same version -------------------
+
+echo "Test 2: existing item with matching version is REPLACED, not duplicated"
+
+cat > "$WORK/fixture-2.xml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Feed</title>
+        <item>
+            <title>Version 1.0.0</title>
+            <sparkle:version>1.0.0</sparkle:version>
+        </item>
+        <item>
+            <title>Version 9.9.9-test (OLD)</title>
+            <sparkle:version>9.9.9-test</sparkle:version>
+        </item>
+    </channel>
+</rss>
+EOF
+
+run_upsert "$WORK/out-2.xml" "$WORK/fixture-2.xml" "9.9.9-test"
+assert_xml_valid "$WORK/out-2.xml" "fixture 2 output"
+assert_count "$WORK/out-2.xml" "<sparkle:version>9.9.9-test</sparkle:version>" 1 \
+    "9.9.9-test appears exactly once (replaced, not appended)"
+assert_grep "$WORK/out-2.xml" "<sparkle:version>1.0.0</sparkle:version>" \
+    "untouched 1.0.0 item still present"
+# The replacement should carry the new signature, not the OLD title.
+if ! grep -q "OLD" "$WORK/out-2.xml"; then
+    echo "  PASS: stale 'OLD' marker dropped (replacement succeeded)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL: stale 'OLD' marker still in output"
+    fail=$((fail + 1))
+fi
+
+# ----- fixture 3: empty feed (no items yet) ---------------------------------
+
+echo "Test 3: empty feed (no existing items) splices new item before </channel>"
+
+cat > "$WORK/fixture-3.xml" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Feed</title>
+        <description>Empty feed.</description>
+    </channel>
+</rss>
+EOF
+
+run_upsert "$WORK/out-3.xml" "$WORK/fixture-3.xml" "9.9.9-test"
+assert_xml_valid "$WORK/out-3.xml" "fixture 3 output"
+assert_grep "$WORK/out-3.xml" "9.9.9-test" "new item appears in previously-empty feed"
+assert_count "$WORK/out-3.xml" "<sparkle:version>" 1 "exactly one item after splice"
+
+# ----- summary --------------------------------------------------------------
+
+echo
+echo "Results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/upsert-appcast-item.awk
+++ b/scripts/upsert-appcast-item.awk
@@ -1,0 +1,56 @@
+# Upsert a single Sparkle <item> block into an appcast.xml feed.
+#
+# Inputs (set via `awk -v`):
+#   item_file       Path to a file containing the fully-formed signed
+#                   <item>...</item> block to insert or replace.
+#   target_version  The <sparkle:version> string that identifies which
+#                   existing item to replace (e.g. "0.2.0.17-dev.1").
+#                   If no item with that version exists in the input
+#                   feed, the new item is spliced in before </channel>.
+#
+# Behavior:
+#   - Reads the input feed from stdin (or `awk -f ... appcast.xml`).
+#   - Buffers each <item>...</item> block, then either replaces it
+#     with the contents of item_file (if its <sparkle:version> marker
+#     matches target_version) or echoes it unchanged.
+#   - Lines outside any <item> block pass through verbatim — including
+#     XML comments that happen to mention "<item>" in their prose.
+#     The <item> / </item> matchers are anchored to start-of-line
+#     (after leading whitespace) precisely so they DON'T fire on
+#     comment text like "appends a new <item> here on release."
+#     A 2026-05-10 regression let the unanchored regex eat the docs
+#     comment and corrupt the live feed; the start-of-line anchors
+#     make that class of bug impossible.
+#   - If target_version is absent from the input, the new item is
+#     spliced in just before </channel> so it appears at the end of
+#     the feed.
+
+BEGIN { in_item = 0; item_buf = ""; replaced = 0 }
+/^[[:space:]]*<item>/ {
+    in_item = 1
+    item_buf = $0
+    next
+}
+in_item == 1 && /^[[:space:]]*<\/item>/ {
+    item_buf = item_buf "\n" $0
+    marker = "<sparkle:version>" target_version "</sparkle:version>"
+    if (index(item_buf, marker) > 0) {
+        while ((getline line < item_file) > 0) print line
+        close(item_file)
+        replaced = 1
+    } else {
+        print item_buf
+    }
+    in_item = 0
+    item_buf = ""
+    next
+}
+in_item == 1 {
+    item_buf = item_buf "\n" $0
+    next
+}
+/<\/channel>/ && !replaced {
+    while ((getline line < item_file) > 0) print line
+    close(item_file)
+}
+{ print }


### PR DESCRIPTION
## Summary

The v0.2.0.17-dev.1 publish run corrupted appcast.xml. Sparkle clients hitting Check for Updates were seeing a generic "An error occurred while parsing the update feed" alert.

**Root cause:** the inline awk in `appcast-publish.yml` matched `<item>` anywhere on a line. The docs comment near the top of appcast.xml contained the phrase _"appends a new \<item\> here on every signed-and-notarized release"_ which matched the regex. awk entered item-buffer mode mid-comment, ate the rest of the comment text into the buffer, then hit the real `<item>` opening of v0.1.0 — which overwrote the buffer with just `<item>` and lost the comment's middle. The output kept the opening `<!--` and one line of prose but dropped the rest, including `-->`, leaving an unterminated comment that swallowed everything below.

## Four changes

1. **appcast.xml** — drop the now-mangled comment block entirely. Inline docs, not load-bearing.
2. **scripts/upsert-appcast-item.awk** — extract the awk logic from the workflow YAML to a standalone, testable script. `<item>` / `</item>` matchers anchored to start-of-line so they only fire on real element openings, not prose mentions inside comments.
3. **`.github/workflows/appcast-publish.yml`** — replace the inline awk block with `awk -f scripts/upsert-appcast-item.awk`.
4. **scripts/test-upsert-appcast.sh** + new test.yml step — regression test harness with three fixture-driven scenarios:
   - Comment containing `<item>` in prose is preserved verbatim, new item is spliced before `</channel>` (the live-broken scenario).
   - Existing item with matching `<sparkle:version>` is REPLACED, not duplicated.
   - Empty feed (no items yet) splices the new item before `</channel>`.

   12 assertions pass locally. Bash 3.2 compatible per the project's macOS-stock-bash rule. Runs on every PR via test.yml so this regression class can't slip back in.

The v0.2.0.17-dev.1 release item itself is unchanged. Once this lands on main, raw.githubusercontent.com serves valid XML and Check for Updates resolves to "you're up to date" or the update-available state, not the parse error.

## Test plan

- [x] `xmllint --noout appcast.xml` exits 0 locally.
- [x] `scripts/test-upsert-appcast.sh` exits 0 locally — 12/12 PASS.
- [ ] After merge: `curl -s https://raw.githubusercontent.com/superic/av-pain-reliever/main/appcast.xml | xmllint --noout -` exits 0.
- [ ] After merge: open the app, click Check for Updates — should resolve to a normal "you're up to date" or "v0.2.0.17-dev.1 available" prompt, not the parse error.
- [ ] Future appcast-publish runs preserve any `<!-- ... <item> ... -->` comment intact (covered by the new fixture test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)