### PR TITLE
fix: quarantine corrupt profiles.toml in place instead of overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,29 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### Quarantine corrupt profiles.toml to the Trash instead of silently overwriting (2026-05-10)
+
+A latent bug in `ProfileBootstrapper.loadOrBootstrap` came up while we were thinking about resilience: if `profiles.toml` failed to parse (syntax error, schema violation), the bootstrapper logged a warning and then unconditionally called `writeStarterConfig`, which atomically replaced the user's file with the 1-profile starter. Every custom profile, fingerprint, audio + camera selection: gone, silently. Triggered on every `bootEngine` call (launch, wizard save), and trivially reachable now that the auto-reload watcher fires on any out-of-band edit.
+
+Fix is a `LoadOutcome` enum that splits the recovery path from the first-launch path:
+
+```swift
+public enum LoadOutcome {
+    case loaded([Profile])
+    case bootstrapped([Profile])
+    case quarantinedAndReset([Profile], quarantinedAs: URL)
+    case unrecoverable
+}
+```
+
+On parse failure, the bootstrapper now moves the corrupt file to the user's **Trash** via `FileManager.trashItem` (with a `QuarantineOp` closure seam so tests don't pollute the real Trash). macOS handles collision naming and provides the standard right-click "Put Back" recovery affordance, which is far more discoverable than a sibling file in the hidden Application Support directory. If `trashItem` throws (read-only volume, etc.) the bootstrapper returns `.unrecoverable` and the original file is left untouched.
+
+AppDelegate switches on the outcome after `bootEngine` and posts a UNUserNotification on the `.quarantinedAndReset` or `.unrecoverable` branches. The `notificationsEnabled` toggle does NOT gate this notification (that toggle is for friendly per-switch toasts; corruption is operational and the user needs to know regardless). The corrupt-config toast carries a **Show in Finder** action button that reveals the trashed file with one click. To support that, `Notifier` grew a `NotificationAction` enum so callers can pick from pre-registered button labels (currently `openWizard` and `showInFinder`), since `UNUserNotificationCenter` requires categories up-front.
+
+Order of operations in `bootEngine`: `configReloadGate.stamp(configMTime())` happens immediately after `loadOrBootstrap` returns, before any user-visible work. The quarantine + starter-write path produces several filesystem events the watcher will see; stamping early ensures its debounced callback finds the new mtime and treats it as an echo rather than firing a redundant second `bootEngine`.
+
+Tests cover the bootstrap matrix with the closure seam: valid load, missing-file bootstrap, malformed TOML quarantine, schema-violation quarantine, URL propagation through the outcome, `.unrecoverable` when the quarantine op throws, and the `LoadOutcome.profiles` accessor. Each runs against a fresh scratch dir; the production `trashCorruptFile` is exercised indirectly via integration.
+
 ### M2 lessons (gotchas the architecture or first attempts hit)
 
 1. **`AVCaptureVideoDataOutput.sessionPreset` ≠ output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
-### Quarantine corrupt profiles.toml to the Trash instead of silently overwriting (2026-05-10)
+### Quarantine corrupt profiles.toml in place instead of silently overwriting (2026-05-10)
 
 A latent bug in `ProfileBootstrapper.loadOrBootstrap` came up while we were thinking about resilience: if `profiles.toml` failed to parse (syntax error, schema violation), the bootstrapper logged a warning and then unconditionally called `writeStarterConfig`, which atomically replaced the user's file with the 1-profile starter. Every custom profile, fingerprint, audio + camera selection: gone, silently. Triggered on every `bootEngine` call (launch, wizard save), and trivially reachable now that the auto-reload watcher fires on any out-of-band edit.
 
@@ -72,13 +72,15 @@ public enum LoadOutcome {
 }
 ```
 
-On parse failure, the bootstrapper now moves the corrupt file to the user's **Trash** via `FileManager.trashItem` (with a `QuarantineOp` closure seam so tests don't pollute the real Trash). macOS handles collision naming and provides the standard right-click "Put Back" recovery affordance, which is far more discoverable than a sibling file in the hidden Application Support directory. If `trashItem` throws (read-only volume, etc.) the bootstrapper returns `.unrecoverable` and the original file is left untouched.
+On parse failure, the bootstrapper renames the corrupt file in place to a timestamped sibling: `profiles.corrupted-{YYYY-MM-DD-HHMMSS-mmm}.toml`. The broken copy stays right next to the active config in Application Support so the user finds both when they navigate there. Considered the user's Trash (via `FileManager.trashItem`) and rejected it as too aggressive: Trash gets auto-emptied on some users' machines, "moved to Trash" sounds like deletion in user-facing copy, and the file ends up mixed with unrelated deleted items. A sibling rename keeps the data right where it belongs, indefinitely.
 
-AppDelegate switches on the outcome after `bootEngine` and posts a UNUserNotification on the `.quarantinedAndReset` or `.unrecoverable` branches. The `notificationsEnabled` toggle does NOT gate this notification (that toggle is for friendly per-switch toasts; corruption is operational and the user needs to know regardless). The corrupt-config toast carries a **Show in Finder** action button that reveals the trashed file with one click. To support that, `Notifier` grew a `NotificationAction` enum so callers can pick from pre-registered button labels (currently `openWizard` and `showInFinder`), since `UNUserNotificationCenter` requires categories up-front.
+A `QuarantineOp` closure seam keeps tests deterministic (they pass their own renamer instead of touching the real user filesystem). If the rename itself fails (read-only parent, etc.) the bootstrapper returns `.unrecoverable` and the original file is left untouched.
+
+AppDelegate switches on the outcome after `bootEngine` and posts a UNUserNotification on the `.quarantinedAndReset` or `.unrecoverable` branches. The `notificationsEnabled` toggle does NOT gate this notification (that toggle is for friendly per-switch toasts; corruption is operational and the user needs to know regardless). The corrupt-config toast carries a **Show in Finder** action button that reveals the renamed file with one click. The body also names the renamed file inline so a user who dismisses the toast still has a filename to grep. To support per-action button labels, `Notifier` grew a `NotificationAction` enum so callers pick from pre-registered category labels (currently `openWizard` and `showInFinder`), since `UNUserNotificationCenter` requires categories up-front.
 
 Order of operations in `bootEngine`: `configReloadGate.stamp(configMTime())` happens immediately after `loadOrBootstrap` returns, before any user-visible work. The quarantine + starter-write path produces several filesystem events the watcher will see; stamping early ensures its debounced callback finds the new mtime and treats it as an echo rather than firing a redundant second `bootEngine`.
 
-Tests cover the bootstrap matrix with the closure seam: valid load, missing-file bootstrap, malformed TOML quarantine, schema-violation quarantine, URL propagation through the outcome, `.unrecoverable` when the quarantine op throws, and the `LoadOutcome.profiles` accessor. Each runs against a fresh scratch dir; the production `trashCorruptFile` is exercised indirectly via integration.
+Tests cover the bootstrap matrix with the closure seam plus one test that exercises the real default rename: valid load, missing-file bootstrap, malformed TOML quarantine, schema-violation quarantine, URL propagation through the outcome, `.unrecoverable` when the quarantine op throws, the `LoadOutcome.profiles` accessor, and the default `renameCorruptFileInPlace` filename shape. Each runs against a fresh scratch dir.
 
 ### M2 lessons (gotchas the architecture or first attempts hit)
 

--- a/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
+++ b/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
@@ -21,10 +21,10 @@ public enum LoadOutcome {
 }
 
 /// Closure that moves a corrupt config file out of the way and returns
-/// its new URL. The default implementation moves the file to the
-/// user's Trash so recovery uses the standard Finder affordance
-/// (right-click, Put Back). Tests inject a sibling-rename closure to
-/// keep their scratch directories self-contained.
+/// its new URL. The default implementation renames it in place to a
+/// timestamped sibling so the broken copy stays right next to the
+/// active config and isn't subject to Trash auto-empty. Tests inject
+/// their own closure to keep their scratch directories deterministic.
 public typealias QuarantineOp = (URL) throws -> URL
 
 /// Discovers an existing profiles config or bootstraps a new one.
@@ -58,12 +58,12 @@ public struct ProfileBootstrapper {
     }
 
     /// URL-parameterized loader. Tests pass a scratch directory and a
-    /// sibling-rename `quarantine` closure so they don't reach into
-    /// the user's real Trash. Production uses the default Trash op.
+    /// deterministic `quarantine` closure. Production uses the
+    /// default in-place rename.
     public func loadOrBootstrap(
         from tomlURL: URL,
         logger: ApplierLogger,
-        quarantine: QuarantineOp = ProfileBootstrapper.trashCorruptFile
+        quarantine: QuarantineOp = ProfileBootstrapper.renameCorruptFileInPlace
     ) -> LoadOutcome {
         if FileManager.default.fileExists(atPath: tomlURL.path) {
             do {
@@ -104,18 +104,30 @@ public struct ProfileBootstrapper {
         }
     }
 
-    /// Default quarantine op: move the corrupt file to the user's
-    /// Trash. macOS handles collision naming (adds a numeric suffix if
-    /// the Trash already holds `profiles.toml`). Returns the resulting
-    /// URL inside the Trash so the host can offer a reveal-in-Finder
-    /// action. Throws if `trashItem` fails (read-only volume, etc.).
-    public static func trashCorruptFile(_ tomlURL: URL) throws -> URL {
-        var resultingURL: NSURL?
-        try FileManager.default.trashItem(at: tomlURL, resultingItemURL: &resultingURL)
-        guard let url = resultingURL as URL? else {
-            throw CocoaError(.fileWriteUnknown)
-        }
-        return url
+    /// Default quarantine op: rename the corrupt file in place to a
+    /// timestamped sibling. The broken copy stays in the Application
+    /// Support directory next to the active config, so the user finds
+    /// both when they open the folder. Filename pattern:
+    /// `profiles.corrupted-{YYYY-MM-DD-HHMMSS-mmm}.toml`. Millisecond
+    /// suffix prevents back-to-back corrupt saves from colliding.
+    /// Throws if the move fails (read-only parent, etc.) so the
+    /// caller can fall back to `.unrecoverable`.
+    public static func renameCorruptFileInPlace(_ tomlURL: URL) throws -> URL {
+        let timestamp = quarantineTimestamp(from: Date())
+        let parent = tomlURL.deletingLastPathComponent()
+        let destination = parent.appendingPathComponent("profiles.corrupted-\(timestamp).toml")
+        try FileManager.default.moveItem(at: tomlURL, to: destination)
+        return destination
+    }
+
+    /// Filename-safe timestamp: `YYYY-MM-DD-HHMMSS-mmm` in UTC. Used
+    /// only by the default quarantine op; not part of the public API.
+    private static func quarantineTimestamp(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss-SSS"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: date)
     }
 
     /// Default `profiles.toml` content, written on first launch when

--- a/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
+++ b/Sources/AVPainReliever/Config/ProfileBootstrapper.swift
@@ -1,18 +1,44 @@
 import Foundation
 
-/// Discovers an existing profiles config or bootstraps a new one for
-/// fresh installs. Wraps the read / seed dance the host's first
-/// launch performs:
+/// Outcome of a `ProfileBootstrapper.loadOrBootstrap` call. Carries
+/// the resolved profile list and, when corruption was recovered from,
+/// the URL of the moved-aside copy so the host can show the user
+/// where to find their data.
+public enum LoadOutcome {
+    case loaded([Profile])
+    case bootstrapped([Profile])
+    case quarantinedAndReset([Profile], quarantinedAs: URL)
+    case unrecoverable
+
+    public var profiles: [Profile] {
+        switch self {
+        case .loaded(let p), .bootstrapped(let p), .quarantinedAndReset(let p, _):
+            return p
+        case .unrecoverable:
+            return []
+        }
+    }
+}
+
+/// Closure that moves a corrupt config file out of the way and returns
+/// its new URL. The default implementation moves the file to the
+/// user's Trash so recovery uses the standard Finder affordance
+/// (right-click, Put Back). Tests inject a sibling-rename closure to
+/// keep their scratch directories self-contained.
+public typealias QuarantineOp = (URL) throws -> URL
+
+/// Discovers an existing profiles config or bootstraps a new one.
+/// Three branches:
 ///
-///   1. `~/Library/Application Support/AVPainReliever/profiles.toml` —
-///      the canonical Swift-app config; load it directly.
-///   2. The file doesn't exist — write a starter `profiles.toml` so
-///      the engine has a working "laptop" fallback to apply on first
-///      launch instead of running idle.
-///
-/// Lives in the engine library so the host AppDelegate can stay a
-/// thin caller and the bootstrap behavior is testable without the
-/// app target.
+///   1. File parses cleanly: load and return.
+///   2. File doesn't exist: write the starter so the engine has a
+///      "laptop" fallback to apply.
+///   3. File exists but won't parse (typo, schema violation): move
+///      the corrupt copy out of the way before writing a starter, and
+///      surface its new location in `LoadOutcome` so the host can
+///      tell the user. Without this branch, a single bad save (a typo
+///      caught by the auto-reload watcher) would silently overwrite
+///      every custom profile.
 public struct ProfileBootstrapper {
     public init() {}
 
@@ -25,22 +51,41 @@ public struct ProfileBootstrapper {
                 "Library/Application Support/AVPainReliever/profiles.toml"
             )
 
-    /// Load profiles from the canonical TOML, falling through to a
-    /// starter-config write if the file doesn't exist. Logs each
-    /// branch via `ApplierLogger` so the host's console pipeline gets
-    /// a uniform audit trail. Returns an empty array only when every
-    /// fallback failed; the engine then runs idle until the user
-    /// creates a config.
-    public func loadOrBootstrap(logger: ApplierLogger) -> [Profile] {
-        let tomlURL = Self.canonicalTOMLURL
+    /// Load profiles from the canonical TOML. Production entry point;
+    /// delegates to the URL-taking overload for test reach.
+    public func loadOrBootstrap(logger: ApplierLogger) -> LoadOutcome {
+        loadOrBootstrap(from: Self.canonicalTOMLURL, logger: logger)
+    }
 
+    /// URL-parameterized loader. Tests pass a scratch directory and a
+    /// sibling-rename `quarantine` closure so they don't reach into
+    /// the user's real Trash. Production uses the default Trash op.
+    public func loadOrBootstrap(
+        from tomlURL: URL,
+        logger: ApplierLogger,
+        quarantine: QuarantineOp = ProfileBootstrapper.trashCorruptFile
+    ) -> LoadOutcome {
         if FileManager.default.fileExists(atPath: tomlURL.path) {
             do {
                 let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
                 logger.info("loaded \(profiles.count) profiles from \(tomlURL.path)")
-                return profiles
+                return .loaded(profiles)
             } catch {
-                logger.warn("failed to load \(tomlURL.path): \(error)")
+                logger.warn("failed to parse \(tomlURL.path): \(error)")
+                // Move the corrupt file aside before any write. If the
+                // quarantine op fails, the user's broken-but-recoverable
+                // file stays in place; the destructive overwrite that
+                // used to happen on this path is gone.
+                do {
+                    let quarantineURL = try quarantine(tomlURL)
+                    try writeStarterConfig(at: tomlURL)
+                    let starterProfiles = try ConfigLoader().loadProfiles(from: tomlURL)
+                    logger.info("moved corrupt config to \(quarantineURL.path); wrote fresh starter")
+                    return .quarantinedAndReset(starterProfiles, quarantinedAs: quarantineURL)
+                } catch {
+                    logger.warn("could not recover from corrupt config: \(error). Leaving file in place, engine runs idle.")
+                    return .unrecoverable
+                }
             }
         }
 
@@ -51,12 +96,26 @@ public struct ProfileBootstrapper {
         do {
             try writeStarterConfig(at: tomlURL)
             let profiles = try ConfigLoader().loadProfiles(from: tomlURL)
-            logger.info("first launch — wrote a starter config to \(tomlURL.path) (\(profiles.count) profile)")
-            return profiles
+            logger.info("first launch: wrote a starter config to \(tomlURL.path) (\(profiles.count) profile)")
+            return .bootstrapped(profiles)
         } catch {
-            logger.warn("failed to write starter config to \(tomlURL.path): \(error) — engine will run idle until a config is created")
-            return []
+            logger.warn("failed to write starter config to \(tomlURL.path): \(error). Engine will run idle until a config is created.")
+            return .unrecoverable
         }
+    }
+
+    /// Default quarantine op: move the corrupt file to the user's
+    /// Trash. macOS handles collision naming (adds a numeric suffix if
+    /// the Trash already holds `profiles.toml`). Returns the resulting
+    /// URL inside the Trash so the host can offer a reveal-in-Finder
+    /// action. Throws if `trashItem` fails (read-only volume, etc.).
+    public static func trashCorruptFile(_ tomlURL: URL) throws -> URL {
+        var resultingURL: NSURL?
+        try FileManager.default.trashItem(at: tomlURL, resultingItemURL: &resultingURL)
+        guard let url = resultingURL as URL? else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return url
     }
 
     /// Default `profiles.toml` content, written on first launch when

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -393,12 +393,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         engine?.stop()
 
         let logger = ConsoleLogger()
-        let profiles = ProfileBootstrapper().loadOrBootstrap(logger: logger)
-        availableProfiles = ProfileDisplayOrder.displayOrder(profiles)
-        // Stamp the file's mtime so the config-watcher can recognize
-        // this load as the source of truth and skip a redundant
-        // reload if its debounced callback fires for the same write.
+        let loadOutcome = ProfileBootstrapper().loadOrBootstrap(logger: logger)
+        let profiles = loadOutcome.profiles
+        // Stamp the mtime as the first thing after bootstrap returns,
+        // before any user-visible work. The quarantine + starter-write
+        // path produces several FS events that the watcher will see;
+        // stamping early ensures its debounced callback finds the new
+        // mtime and treats it as an echo.
         configReloadGate.stamp(configMTime())
+        availableProfiles = ProfileDisplayOrder.displayOrder(profiles)
+        notifyOfLoadOutcome(loadOutcome)
         // Self-heal stats orphaned by anything that bypassed
         // `forgetProfile` (hand-edits to profiles.toml, or migration
         // from a build that predates the delete-time hook).
@@ -422,6 +426,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
         engine.start()
         self.engine = engine
+    }
+
+    /// Surface bootstrap outcomes that need user attention. Clean
+    /// loads are silent; corruption and unrecoverable cases always
+    /// fire (the `notificationsEnabled` toggle gates the friendly
+    /// per-switch toast, not operational data-loss alerts). The
+    /// corruption toast carries an action that reveals the moved-
+    /// aside file in Finder so recovery is one click.
+    private func notifyOfLoadOutcome(_ outcome: LoadOutcome) {
+        switch outcome {
+        case .loaded, .bootstrapped:
+            return
+        case .quarantinedAndReset(_, let quarantinedAs):
+            notifier.notify(
+                title: NotificationCopy.configCorruptedTitle,
+                body: NotificationCopy.configCorruptedBody,
+                iconSymbol: Theme.Symbol.warning,
+                action: .showInFinder,
+                onAction: {
+                    NSWorkspace.shared.activateFileViewerSelecting([quarantinedAs])
+                }
+            )
+        case .unrecoverable:
+            notifier.notify(
+                title: NotificationCopy.configUnrecoverableTitle,
+                body: NotificationCopy.configUnrecoverableBody,
+                iconSymbol: Theme.Symbol.warning
+            )
+        }
     }
 
     private func handleProfileApplied(_ profile: Profile) {
@@ -497,6 +530,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             title: "New location detected",
             body: NotificationCopy.unknownLocationBody(deviceCount: devices.count),
             iconSymbol: "questionmark.circle",
+            action: .openWizard,
             onAction: { [weak self] in
                 // UN delivers the action callback on the main queue
                 // already, so no extra hop is needed. Toggle the

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -441,7 +441,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         case .quarantinedAndReset(_, let quarantinedAs):
             notifier.notify(
                 title: NotificationCopy.configCorruptedTitle,
-                body: NotificationCopy.configCorruptedBody,
+                body: NotificationCopy.configCorruptedBody(
+                    filename: quarantinedAs.lastPathComponent
+                ),
                 iconSymbol: Theme.Symbol.warning,
                 action: .showInFinder,
                 onAction: {

--- a/Sources/AVPainRelieverApp/NotificationCopy.swift
+++ b/Sources/AVPainRelieverApp/NotificationCopy.swift
@@ -33,6 +33,25 @@ enum NotificationCopy {
         return title(forSlug: slug, dayOfYear: day)
     }
 
+    /// Title for the "your profiles.toml was corrupt; we moved it to
+    /// the Trash" toast. Operational, not playful: the user needs to
+    /// know what happened so they can recover.
+    static let configCorruptedTitle = "Couldn't read profiles.toml"
+
+    /// Body for the same toast. The Show in Finder action button
+    /// reveals the file in the Trash; the body explains the rest.
+    static let configCorruptedBody = "Moved the broken copy to the Trash. Started fresh from defaults."
+
+    /// Title for the worst-case branch: parse failed AND we couldn't
+    /// move the file aside (filesystem error, read-only parent).
+    /// Engine runs with an empty profile list until the user resolves
+    /// it.
+    static let configUnrecoverableTitle = "Couldn't recover profiles.toml"
+
+    /// Body for the worst-case branch. Points at the Advanced menu's
+    /// Save Logs for Support entry.
+    static let configUnrecoverableBody = "Use Advanced > Save Logs for Support and send us the log."
+
     /// Body text for the "new location detected" toast — warmer than
     /// the bare "N USB devices attached" version, while still telling
     /// the user the next concrete action they can take.

--- a/Sources/AVPainRelieverApp/NotificationCopy.swift
+++ b/Sources/AVPainRelieverApp/NotificationCopy.swift
@@ -33,14 +33,17 @@ enum NotificationCopy {
         return title(forSlug: slug, dayOfYear: day)
     }
 
-    /// Title for the "your profiles.toml was corrupt; we moved it to
-    /// the Trash" toast. Operational, not playful: the user needs to
-    /// know what happened so they can recover.
+    /// Title for the "your profiles.toml was corrupt; we renamed it"
+    /// toast. Operational, not playful: the user needs to know what
+    /// happened so they can recover.
     static let configCorruptedTitle = "Couldn't read profiles.toml"
 
-    /// Body for the same toast. The Show in Finder action button
-    /// reveals the file in the Trash; the body explains the rest.
-    static let configCorruptedBody = "Moved the broken copy to the Trash. Started fresh from defaults."
+    /// Body for the same toast. Names the renamed copy so a user who
+    /// dismisses the toast before clicking Show in Finder still has a
+    /// filename to grep for.
+    static func configCorruptedBody(filename: String) -> String {
+        "Saved the broken copy as \(filename) right next to it. Started fresh from defaults."
+    }
 
     /// Title for the worst-case branch: parse failed AND we couldn't
     /// move the file aside (filesystem error, read-only parent).

--- a/Sources/AVPainRelieverApp/Notifiers.swift
+++ b/Sources/AVPainRelieverApp/Notifiers.swift
@@ -2,6 +2,19 @@ import Foundation
 import AppKit
 import UserNotifications
 
+/// Identifies which action-button label to attach to a notification.
+/// UN's action API requires categories registered up-front (you can't
+/// set a button title per-call), so callers pick one of the pre-
+/// registered cases instead of passing free text.
+public enum NotificationAction {
+    /// "Open Wizard" - jumps into the Add Profile flow. Used by the
+    /// unknown-location toast.
+    case openWizard
+    /// "Show in Finder" - reveals a URL in Finder. Used by the
+    /// config-corrupted toast to surface the moved-aside file.
+    case showInFinder
+}
+
 /// Surface a transient banner-style notification to the user. The
 /// engine never instantiates a notifier; the app target picks the
 /// bundled vs unbundled backend, and tests inject a recording mock.
@@ -14,31 +27,29 @@ public protocol Notifier {
     /// attached to the notification. Backends that can't surface a
     /// thumbnail simply post the title + body unchanged.
     ///
-    /// `onAction` fires when the user clicks the inline button (NOT
-    /// when they click the body). Best-effort: backends that can't
-    /// render an action button drop the handler and it never fires.
-    /// The button label is owned by the backend (the UN backend
-    /// registers a single category up front so all action toasts
-    /// share the same label) — callers don't pass it per-call.
+    /// `action` and `onAction` are paired. `action` picks the button
+    /// label from the pre-registered set; `onAction` fires when the
+    /// user clicks the button. Backends that can't render action
+    /// buttons (AppleScript fallback) drop both. Pass `nil` for both
+    /// to post a plain toast.
     func notify(
         title: String,
         body: String?,
         iconSymbol: String?,
+        action: NotificationAction?,
         onAction: (() -> Void)?
     )
 }
 
 extension Notifier {
-    /// Convenience for action-less, icon-less notifications. Forwards
-    /// to the full method so backends only have to implement one
-    /// signature.
+    /// Convenience for action-less, icon-less notifications.
     public func notify(title: String, body: String?) {
-        notify(title: title, body: body, iconSymbol: nil, onAction: nil)
+        notify(title: title, body: body, iconSymbol: nil, action: nil, onAction: nil)
     }
 
     /// Convenience for a notification with just an icon thumbnail.
     public func notify(title: String, body: String?, iconSymbol: String?) {
-        notify(title: title, body: body, iconSymbol: iconSymbol, onAction: nil)
+        notify(title: title, body: body, iconSymbol: iconSymbol, action: nil, onAction: nil)
     }
 }
 
@@ -54,11 +65,13 @@ extension Notifier {
 /// `Settings → Send notifications` toggle still gates whether we
 /// even *try* to post — denying both layers is intentional.
 public final class UserNotificationsNotifier: NSObject, Notifier, UNUserNotificationCenterDelegate {
-    /// Identifier for the lone category we register at startup. It
-    /// carries a single "Open Wizard" action so the unknown-location
-    /// toast can offer a one-click jump into Add Profile.
-    private static let actionCategoryID = "av-pain-reliever.action"
-    private static let actionID = "av-pain-reliever.openWizard"
+    /// Pre-registered action categories. UN requires categories
+    /// up-front; you can't set a button title per-call. Each case in
+    /// `NotificationAction` maps to one of these category IDs.
+    private static let openWizardCategoryID = "av-pain-reliever.openWizard"
+    private static let showInFinderCategoryID = "av-pain-reliever.showInFinder"
+    private static let openWizardActionID = "av-pain-reliever.action.openWizard"
+    private static let showInFinderActionID = "av-pain-reliever.action.showInFinder"
 
     /// Open-action handler keyed by request UUID. We hold each
     /// closure until the corresponding notification is dismissed or
@@ -79,32 +92,37 @@ public final class UserNotificationsNotifier: NSObject, Notifier, UNUserNotifica
             // than logged. The system's own Notification Center
             // settings UI is the place to fix this.
         }
-        // Register one category with one action. Per Apple's API,
-        // categories must be set up-front; you can't attach arbitrary
-        // buttons per-notification. So the action button label is
-        // fixed at the category level instead of taken per-call from
-        // the protocol — see the `notify(...)` signature, which
-        // intentionally drops the `actionTitle` parameter for that
-        // reason. If we ever need a second action type, register
-        // another category here and gate on it inside `notify`.
-        let openAction = UNNotificationAction(
-            identifier: Self.actionID,
-            title: "Open Wizard",
-            options: [.foreground]
-        )
-        let category = UNNotificationCategory(
-            identifier: Self.actionCategoryID,
-            actions: [openAction],
+        // Register one category per `NotificationAction` case. UN
+        // requires categories up-front and won't accept per-call
+        // button titles; the call site picks a category by enum case.
+        let openWizard = UNNotificationCategory(
+            identifier: Self.openWizardCategoryID,
+            actions: [UNNotificationAction(
+                identifier: Self.openWizardActionID,
+                title: "Open Wizard",
+                options: [.foreground]
+            )],
             intentIdentifiers: [],
             options: []
         )
-        center.setNotificationCategories([category])
+        let showInFinder = UNNotificationCategory(
+            identifier: Self.showInFinderCategoryID,
+            actions: [UNNotificationAction(
+                identifier: Self.showInFinderActionID,
+                title: "Show in Finder",
+                options: [.foreground]
+            )],
+            intentIdentifiers: [],
+            options: []
+        )
+        center.setNotificationCategories([openWizard, showInFinder])
     }
 
     public func notify(
         title: String,
         body: String?,
         iconSymbol: String?,
+        action: NotificationAction?,
         onAction: (() -> Void)?
     ) {
         let content = UNMutableNotificationContent()
@@ -112,12 +130,15 @@ public final class UserNotificationsNotifier: NSObject, Notifier, UNUserNotifica
         if let body { content.body = body }
         content.sound = .default
 
-        // Attach the action category when the caller provided a
-        // handler. The button label is the category's pre-registered
-        // "Open Wizard" — UN doesn't take per-notification button
-        // labels, so the protocol surface drops the param entirely.
-        if onAction != nil {
-            content.categoryIdentifier = Self.actionCategoryID
+        // Pick the pre-registered category matching the requested
+        // action. UN doesn't accept per-call button labels.
+        if let action {
+            switch action {
+            case .openWizard:
+                content.categoryIdentifier = Self.openWizardCategoryID
+            case .showInFinder:
+                content.categoryIdentifier = Self.showInFinderCategoryID
+            }
         }
 
         // When the caller supplied an SF Symbol name, render it to a
@@ -244,9 +265,11 @@ public final class UserNotificationsNotifier: NSObject, Notifier, UNUserNotifica
     ) {
         let identifier = response.notification.request.identifier
         let handler = handlersQueue.sync { actionHandlers.removeValue(forKey: identifier) }
-        if response.actionIdentifier == Self.actionID, let handler {
-            // Hop to main since the handler typically opens a SwiftUI
-            // window. UN delivers on a private queue.
+        let isActionTap = response.actionIdentifier == Self.openWizardActionID
+            || response.actionIdentifier == Self.showInFinderActionID
+        if isActionTap, let handler {
+            // Hop to main since handlers typically touch SwiftUI or
+            // NSWorkspace. UN delivers on a private queue.
             DispatchQueue.main.async {
                 handler()
             }
@@ -279,15 +302,12 @@ public struct AppleScriptNotifier: Notifier {
         title: String,
         body: String?,
         iconSymbol: String?,
+        action: NotificationAction?,
         onAction: (() -> Void)?
     ) {
         // osascript notifications can't render an action button or a
-        // custom thumbnail — ignore `iconSymbol` and `onAction` and
-        // post a plain toast. Dev users see the message; the
-        // equivalent action is also reachable from the menu's
-        // "Set Up This Location…" button when in unknown-location
-        // state.
-        _ = (iconSymbol, onAction)
+        // custom thumbnail. Ignore all extras and post a plain toast.
+        _ = (iconSymbol, action, onAction)
         notifyPlain(title: title, body: body)
     }
 

--- a/Sources/AVPainRelieverApp/Theme.swift
+++ b/Sources/AVPainRelieverApp/Theme.swift
@@ -42,6 +42,10 @@ enum Theme {
         static let usbSection = "externaldrive.connected.to.line.below"
         static let audioSection = "speaker.wave.2.fill"
         static let cameraSection = "camera.fill"
+
+        /// Warning thumbnail for operational notifications (config
+        /// corruption, unrecoverable load failures).
+        static let warning = "exclamationmark.triangle"
     }
 
     enum Copy {

--- a/Tests/AVPainRelieverTests/ProfileBootstrapperTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileBootstrapperTests.swift
@@ -151,6 +151,31 @@ struct ProfileBootstrapperTests {
         }
     }
 
+    @Test("default in-place rename produces a profiles.corrupted-{timestamp}.toml sibling")
+    func defaultQuarantineRenamesInPlace() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        let corrupt = "[profiles.foo\nbroken"
+        try corrupt.write(to: url, atomically: true, encoding: .utf8)
+
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger()
+        )
+
+        guard case .quarantinedAndReset(_, let movedURL) = outcome else {
+            Issue.record("expected .quarantinedAndReset, got \(outcome)")
+            return
+        }
+        let name = movedURL.lastPathComponent
+        #expect(name.hasPrefix("profiles.corrupted-"))
+        #expect(name.hasSuffix(".toml"))
+        #expect(movedURL.deletingLastPathComponent().path == dir.path)
+        let preserved = try String(contentsOf: movedURL, encoding: .utf8)
+        #expect(preserved == corrupt)
+    }
+
     @Test("LoadOutcome.profiles returns [] for .unrecoverable and the inner array otherwise")
     func loadOutcomeProfilesAccessor() {
         let p: [Profile] = []

--- a/Tests/AVPainRelieverTests/ProfileBootstrapperTests.swift
+++ b/Tests/AVPainRelieverTests/ProfileBootstrapperTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+@testable import AVPainReliever
+
+/// Coverage for the bootstrap pipeline. Each test runs against a
+/// fresh scratch directory AND injects a sibling-rename `quarantine`
+/// closure so the production Trash op is never reached.
+@Suite("ProfileBootstrapper")
+struct ProfileBootstrapperTests {
+    @Test("valid TOML loads to .loaded([profiles]) without touching the file")
+    func validConfigLoads() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        let original = "[profiles.foo]\naudioInput = \"Mic\"\n"
+        try original.write(to: url, atomically: true, encoding: .utf8)
+
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: rejectQuarantine
+        )
+
+        guard case .loaded(let profiles) = outcome else {
+            Issue.record("expected .loaded, got \(outcome)")
+            return
+        }
+        #expect(profiles.count == 1)
+        #expect(profiles.first?.name == "foo")
+        let onDisk = try String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == original)
+    }
+
+    @Test("missing file triggers .bootstrapped([starter])")
+    func missingConfigBootstraps() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: rejectQuarantine
+        )
+
+        guard case .bootstrapped(let profiles) = outcome else {
+            Issue.record("expected .bootstrapped, got \(outcome)")
+            return
+        }
+        #expect(profiles.count >= 1)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("malformed TOML moves the file aside and writes a fresh starter")
+    func malformedQuarantines() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        let corrupt = "[profiles.foo\nbroken"
+        try corrupt.write(to: url, atomically: true, encoding: .utf8)
+
+        let quarantineDest = dir.appendingPathComponent("aside.toml")
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: siblingRename(to: quarantineDest)
+        )
+
+        guard case .quarantinedAndReset(let profiles, let movedURL) = outcome else {
+            Issue.record("expected .quarantinedAndReset, got \(outcome)")
+            return
+        }
+        #expect(profiles.count >= 1)
+        #expect(movedURL == quarantineDest)
+        let movedContent = try String(contentsOf: movedURL, encoding: .utf8)
+        #expect(movedContent == corrupt)
+        let replaced = try String(contentsOf: url, encoding: .utf8)
+        #expect(replaced != corrupt)
+    }
+
+    @Test("schema violation (wrong type) also moves the file aside")
+    func schemaViolationQuarantines() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        try "[profiles.foo]\naudioInput = 42\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let quarantineDest = dir.appendingPathComponent("aside.toml")
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: siblingRename(to: quarantineDest)
+        )
+
+        guard case .quarantinedAndReset(_, let movedURL) = outcome else {
+            Issue.record("expected .quarantinedAndReset, got \(outcome)")
+            return
+        }
+        #expect(movedURL == quarantineDest)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("LoadOutcome carries the resulting URL from the injected quarantine op")
+    func quarantineUrlIsPropagated() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        try "[broken".write(to: url, atomically: true, encoding: .utf8)
+
+        let fakeTrashURL = dir.appendingPathComponent("FakeTrash/profiles.toml")
+        try FileManager.default.createDirectory(
+            at: fakeTrashURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: siblingRename(to: fakeTrashURL)
+        )
+
+        guard case .quarantinedAndReset(_, let movedURL) = outcome else {
+            Issue.record("expected .quarantinedAndReset, got \(outcome)")
+            return
+        }
+        #expect(movedURL == fakeTrashURL)
+    }
+
+    @Test("unrecoverable when the quarantine op throws")
+    func unrecoverableWhenQuarantineThrows() throws {
+        let dir = try makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("profiles.toml")
+        let corrupt = "[profiles.foo\n"
+        try corrupt.write(to: url, atomically: true, encoding: .utf8)
+
+        let outcome = ProfileBootstrapper().loadOrBootstrap(
+            from: url,
+            logger: SilentLogger(),
+            quarantine: rejectQuarantine
+        )
+
+        if case .unrecoverable = outcome {
+            // Corrupt file stays in place: the production code would
+            // leave a sibling-rename failure visible to the user the
+            // same way.
+            let onDisk = try String(contentsOf: url, encoding: .utf8)
+            #expect(onDisk == corrupt)
+        } else {
+            Issue.record("expected .unrecoverable, got \(outcome)")
+        }
+    }
+
+    @Test("LoadOutcome.profiles returns [] for .unrecoverable and the inner array otherwise")
+    func loadOutcomeProfilesAccessor() {
+        let p: [Profile] = []
+        #expect(LoadOutcome.loaded(p).profiles.isEmpty)
+        #expect(LoadOutcome.bootstrapped(p).profiles.isEmpty)
+        #expect(LoadOutcome.quarantinedAndReset(p, quarantinedAs: URL(fileURLWithPath: "/tmp/x")).profiles.isEmpty)
+        #expect(LoadOutcome.unrecoverable.profiles.isEmpty)
+    }
+
+    private func makeScratchDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bootstrap-\(UUID())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Test seam: rename to a known destination instead of the real
+    /// Trash. Returns the destination URL the bootstrapper expects.
+    private func siblingRename(to dest: URL) -> QuarantineOp {
+        { source in
+            try FileManager.default.moveItem(at: source, to: dest)
+            return dest
+        }
+    }
+
+    /// Test seam: always throw, simulating a filesystem failure.
+    /// Production behavior mirrors this when `trashItem` throws.
+    private let rejectQuarantine: QuarantineOp = { _ in
+        throw CocoaError(.fileWriteNoPermission)
+    }
+}
+
+/// Minimal ApplierLogger conformance for tests: drops every call.
+/// Tests assert on filesystem state and `LoadOutcome` shape, not on
+/// log lines, so a silent logger is sufficient.
+private struct SilentLogger: ApplierLogger {
+    func debug(_ message: String) {}
+    func info(_ message: String) {}
+    func warn(_ message: String) {}
+    func error(_ message: String) {}
+}


### PR DESCRIPTION
## Summary

- Closes a latent data-loss bug: a parse failure in `profiles.toml` used to silently overwrite the user's file with the 1-profile starter. With the auto-reload watcher we just shipped, that destructive path is trivially reachable from a typo'd hand edit.
- New `LoadOutcome` enum + an in-place rename: the corrupt file is moved to `profiles.corrupted-{YYYY-MM-DD-HHMMSS-mmm}.toml` right next to the active config. No Trash move (auto-empty risk; sounds like deletion).
- Notification toast with **Show in Finder** action button reveals the renamed file. Body names the file inline so a user who dismisses the toast still has something to grep.
- `Notifier` grew a `NotificationAction` enum so callers can pick between pre-registered button labels (`openWizard`, `showInFinder`).
- `configReloadGate.stamp` moved earlier in `bootEngine` so the watcher's debounced callback treats the quarantine + starter-write FS events as an echo.

## Test plan

Build:
```
./dev/build --full
```

Then in the running app:

1. **App launches.** Menu bar icon appears, profile pill resolves to current location.
2. **Corrupt save triggers rename + toast.** Open `~/Library/Application Support/AVPainReliever/profiles.toml` in VS Code. Add a syntax error (e.g. delete the closing bracket on a section header: `[profiles.laptop`). Save with Cmd-S. Within ~250 ms a notification banner appears titled "Couldn't read profiles.toml" with body "Saved the broken copy as profiles.corrupted-{timestamp}.toml right next to it. Started fresh from defaults."
3. **Action button reveals in Finder.** Click "Show in Finder" on the notification. Finder opens `~/Library/Application Support/AVPainReliever/` with the corrupted file selected. Active `profiles.toml` is right next to it.
4. **`profiles.toml` got replaced cleanly.** Confirm the file in Application Support now contains the starter content (single `[profiles.laptop]` section). The engine is running with that profile.
5. **Auto-reload still works post-quarantine.** Edit the freshly-installed `profiles.toml` in VS Code (rename `[profiles.laptop]` → `[profiles.laptop-test]`). Save. Within ~250 ms a normal profile-applied notification fires.
6. **Wizard force-apply isn't undone.** Open Add Profile → save a new profile targeting current fingerprint. New profile sticks; no spurious quarantine event.
7. **Quit + relaunch.** Clean restart. No `config-watcher inactive` log line.

### Optional log verification

After step 2:
```
log show --predicate 'subsystem == \"com.ericwillis.avpainreliever\"' --info --debug --last 1m | grep config
```
Expect: `moved corrupt config to .../profiles.corrupted-{ts}.toml; wrote fresh starter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)