### PR TITLE
chore(logging): trace .debug lines in ProfileConfigWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### Trace `.debug` lines for `ProfileConfigWatcher` (2026-05-11)
+
+The watcher logged only on error paths. Matched the `IOKitUSBWatcher` convention from the 2026-05-09 verbose-logging release: six new `.debug` calls covering start (with bound fd numbers), stop, dir-source events, file-source events with mask, inode-staleness rebinds, and debounce arming. All under category `config-watcher`. Diagnostic only: `.debug` is off the persistence path, so this doesn't change Save Logs for Support exports. Stream via `log stream --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "config-watcher"' --level debug --style compact`.
+
 ### Quarantine corrupt profiles.toml in place instead of silently overwriting (2026-05-10)
 
 A latent bug in `ProfileBootstrapper.loadOrBootstrap` came up while we were thinking about resilience: if `profiles.toml` failed to parse (syntax error, schema violation), the bootstrapper logged a warning and then unconditionally called `writeStarterConfig`, which atomically replaced the user's file with the 1-profile starter. Every custom profile, fingerprint, audio + camera selection: gone, silently. Triggered on every `bootEngine` call (launch, wizard save), and trivially reachable now that the auto-reload watcher fires on any out-of-band edit.

--- a/Sources/AVPainRelieverApp/ProfileConfigWatcher.swift
+++ b/Sources/AVPainRelieverApp/ProfileConfigWatcher.swift
@@ -62,6 +62,7 @@ final class ProfileConfigWatcher {
         stop()
         bindDir()
         bindFileIfPresent()
+        Self.logger.debug("config-watcher: started (dirFD=\(dirFD), fileFD=\(fileFD))")
     }
 
     /// Tear down both watches. Idempotent.
@@ -80,6 +81,7 @@ final class ProfileConfigWatcher {
             close(fileFD)
             fileFD = -1
         }
+        Self.logger.debug("config-watcher: stopped")
     }
 
     private func bindDir() {
@@ -97,6 +99,7 @@ final class ProfileConfigWatcher {
         )
         src.setEventHandler { [weak self] in
             guard let self else { return }
+            Self.logger.debug("config-watcher: dir event")
             self.scheduleReload()
             self.refreshFileBindingIfStale()
         }
@@ -114,7 +117,9 @@ final class ProfileConfigWatcher {
             queue: .main
         )
         src.setEventHandler { [weak self] in
-            self?.scheduleReload()
+            guard let self else { return }
+            Self.logger.debug("config-watcher: file event mask=\(src.data.rawValue)")
+            self.scheduleReload()
             // Don't try to rebind from this handler. The dir-source
             // sees the same rename/delete as an entry-list change and
             // owns the rebind via `refreshFileBindingIfStale`.
@@ -133,6 +138,7 @@ final class ProfileConfigWatcher {
         let pathInode = inodeAtPath(url.path)
         let fdInode = inodeForFD(fileFD)
         guard pathInode != fdInode else { return }
+        Self.logger.debug("config-watcher: file inode changed (\(fdInode as Any) → \(pathInode as Any)), rebinding")
         fileSource?.cancel()
         fileSource = nil
         if fileFD >= 0 {
@@ -154,6 +160,7 @@ final class ProfileConfigWatcher {
     }
 
     private func scheduleReload() {
+        Self.logger.debug("config-watcher: debounce armed")
         debounceTimer?.cancel()
         let t = DispatchSource.makeTimerSource(queue: .main)
         t.schedule(deadline: .now() + debounceInterval)


### PR DESCRIPTION
## Summary

- Six new `.debug` calls in `ProfileConfigWatcher` covering start, stop, dir-source events, file-source events with mask, inode-staleness rebinds, and debounce arming.
- Matches the `IOKitUSBWatcher` convention from the 2026-05-09 verbose-logging release.
- All under category `config-watcher`. Diagnostic only: `.debug` is off the persistence path so Save Logs exports are unchanged.

## Test plan

Build:
```
./dev/build --full
```

Then in Terminal:
```
log stream --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "config-watcher"' --level debug --style compact
```

1. **At app launch**, expect: `config-watcher: started (dirFD=N, fileFD=M)`.
2. **Save `profiles.toml` in VS Code** (in-place save). Expect, in order: `config-watcher: file event mask=...`, `config-watcher: debounce armed`. About 250 ms later the engine reloads.
3. **Atomic-rename save** (TextEdit, or `cp profiles.toml profiles.toml.new && mv profiles.toml.new profiles.toml`). Expect: `config-watcher: dir event`, `config-watcher: debounce armed`, `config-watcher: file inode changed (... → ...), rebinding`, `config-watcher: file event mask=...`, possibly another debounce arm.
4. **Quit the app**. Expect: `config-watcher: stopped`.

If none of the new lines appear under the filter above, the live `.debug` stream isn't being consumed — check that `--level debug` is on the `log stream` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)