### PR TITLE
docs: record "no Mac App Store" decision

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -56,6 +56,19 @@ These are settled and validated by the shipped Swift implementation:
   integrate with app-specific audio APIs (no aggregate device hacks, no
   per-app `defaults` plist editing). Engine only ever
   touches system default input/output. Confirmed by user 2026-04-30.
+- **No Mac App Store distribution.** Confirmed 2026-05-10 after weighing
+  the costs: the app runs unsandboxed today (IOKit USB watching, CMIO
+  camera-extension installation, CoreAudio default-device switching all
+  rely on direct entitlements), and we've invested heavily in Sparkle +
+  dev/stable channels + the `dev/build` sign-notarize-staple flow.
+  Moving to the App Store means a sandbox rework (real risk of App Review
+  pushback on a virtual-camera-plus-audio-switcher) and throwing out the
+  release infrastructure. Wins (discoverability, payment infrastructure,
+  trust signal beyond notarization) don't justify the cost at current
+  user-base scale. Direct distribution via notarized Developer-ID
+  binaries on GitHub stays the path. Revisit if a real distribution
+  ceiling emerges, monetization becomes interesting, or a reviewer
+  roundup gates on App Store presence.
 
 ---
 


### PR DESCRIPTION
## Summary

- One-paragraph addition to `docs/decisions.md` under "Validated design decisions" recording the 2026-05-10 decision not to pursue Mac App Store distribution.
- Captures the rationale (sandbox rework cost, Sparkle / dev-channel investment, App Review risk on virtual-camera-plus-audio-switcher) and the trigger conditions for revisiting (distribution ceiling, monetization, reviewer roundups).

## Test plan

Docs-only change; no build or runtime impact. Smoke test:

1. Confirm the new bullet renders cleanly in `docs/decisions.md` and the surrounding bullets still flow.
2. `swift build` still works (it doesn't touch docs but worth a sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)