### PR TITLE
README: auto-updated "Release channels" block + correct /releases/latest

### DIFF
--- a/.github/workflows/appcast-publish.yml
+++ b/.github/workflows/appcast-publish.yml
@@ -159,7 +159,25 @@ jobs:
               -f scripts/upsert-appcast-item.awk \
               appcast.xml > appcast.xml.new
           mv appcast.xml.new appcast.xml
-          git add appcast.xml
+          # Refresh README's "Release channels" block for dev /
+          # experimental tags so the published tag-pinned URL is
+          # always current. Stable uses GitHub's /releases/latest
+          # redirect and never needs a rewrite — empty $CHANNEL passes
+          # through untouched. Tag-pattern matches what the appcast
+          # signing step already computed; both decisions share the
+          # same source of truth (the tag suffix).
+          case "$VERSION_TAG" in
+              *-dev*)          README_CHANNEL=dev ;;
+              *-experimental*) README_CHANNEL=experimental ;;
+              *)               README_CHANNEL= ;;
+          esac
+          awk \
+              -v channel="$README_CHANNEL" \
+              -v tag="$VERSION_TAG" \
+              -f scripts/update-readme-channel.awk \
+              README.md > README.md.new
+          mv README.md.new README.md
+          git add appcast.xml README.md
           git commit -m "appcast: publish $VERSION_TAG
 
           [skip ci]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,18 @@ jobs:
                   --generate-notes \
                   --title "$VERSION_TAG"
           fi
+          # Mark dev / experimental tags as prerelease so GitHub's
+          # `/releases/latest` redirect correctly returns the most
+          # recent STABLE release rather than the most recent dev tag.
+          # Same tag-pattern decision the appcast workflow uses to
+          # pick a Sparkle channel. Idempotent: re-running on the same
+          # tag is a no-op.
+          case "$VERSION_TAG" in
+              *-dev*|*-experimental*)
+                  gh release edit "$VERSION_TAG" --prerelease ;;
+              *)
+                  gh release edit "$VERSION_TAG" --prerelease=false ;;
+          esac
 
       # Appcast publishing happens in a separate workflow
       # (.github/workflows/appcast-publish.yml) triggered by

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,10 @@ jobs:
         # `<item>`. Without this, a future workflow tweak could
         # re-introduce the 2026-05-10 live-feed-broke bug.
         run: scripts/test-upsert-appcast.sh
+
+      - name: README channel-link updater regression
+        # Tiny shell-test harness for scripts/update-readme-channel.awk.
+        # Pins behavior of the README "Release channels" block updater
+        # so the appcast-publish workflow keeps producing a valid
+        # README on every release.
+        run: scripts/test-update-readme-channel.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,24 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### README "Release channels" block + correct `releases/latest` redirect (2026-05-11)
+
+The README's install step linked GitHub's `/releases/latest` for stable downloads, but every recent release was published without the `prerelease` flag set, so `/releases/latest` was returning whatever tag was newest (dev tags included). A user clicking "latest" today gets `v0.2.0.17-dev.4` instead of the most recent stable.
+
+Fix has two pieces. First, `release.yml` now sets `--prerelease` on `*-dev*` / `*-experimental*` tags and `--prerelease=false` on bare tags (same tag-pattern logic the appcast already uses to pick a Sparkle channel). `/releases/latest` now correctly returns the latest stable. Second, the README gets a new "Release channels" block:
+
+```html
+<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — _no current release_
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->
+```
+
+The Dev and Experimental rows get auto-rewritten by `appcast-publish.yml` on every release-published event: same workflow that already commits `appcast.xml` back to main now also runs `scripts/update-readme-channel.awk` against the README and folds the change into the same commit. Stable stays free via the `/releases/latest` redirect. No manual README maintenance on tag.
+
+`scripts/update-readme-channel.awk` is a 50-line awk script with start-of-line anchors on the BEGIN/END markers so it can't accidentally eat a lookalike bullet outside the block (same defensive style as `upsert-appcast-item.awk`). Five test cases in `scripts/test-update-readme-channel.sh` cover both channels, the no-op empty-channel case, lines outside the markers, and idempotency. Wired into `test.yml`.
+
 ### Trace `.debug` lines for `ProfileConfigWatcher` (2026-05-11)
 
 The watcher logged only on error paths. Matched the `IOKitUSBWatcher` convention from the 2026-05-09 verbose-logging release: six new `.debug` calls covering start (with bound fd numbers), stop, dir-source events, file-source events with mask, inode-staleness rebinds, and debounce arming. All under category `config-watcher`. Diagnostic only: `.debug` is off the persistence path, so this doesn't change Save Logs for Support exports. Stream via `log stream --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "config-watcher"' --level debug --style compact`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ The app updates itself in the background. To check manually, open **About → Ch
 
 To stop it: click the menu bar icon → **Quit**.
 
+### Release channels
+
+Most users want the stable channel. Dev and experimental are opt-in via **Settings → General → Updates** inside the app; once enabled, Sparkle auto-updates from that channel.
+
+<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — _no current release_
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->
+
 ---
 
 ## First-run setup

--- a/scripts/test-update-readme-channel.sh
+++ b/scripts/test-update-readme-channel.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Tiny shell-test harness for scripts/update-readme-channel.awk.
+# Exits non-zero on the first failure so test.yml fails loudly.
+#
+# Each case writes a tiny README fragment to a temp file, runs the
+# awk script with the case's `channel` and `tag` parameters, and
+# diffs the output against the expected fragment. Idempotency is
+# explicitly tested by running the same call twice and confirming
+# the second invocation is a no-op.
+
+set -euo pipefail
+
+# bash 3.2 on macOS — no associative arrays, no `mapfile`. Keep it
+# simple.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AWK_SCRIPT="$SCRIPT_DIR/update-readme-channel.awk"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+run_case() {
+    local name="$1"
+    local channel="$2"
+    local tag="$3"
+    local input="$4"
+    local expected="$5"
+
+    printf "%s\n" "$input" > "$TMP/in.md"
+    awk -v channel="$channel" -v tag="$tag" -f "$AWK_SCRIPT" "$TMP/in.md" > "$TMP/out.md"
+
+    if [ "$(cat "$TMP/out.md")" = "$expected" ]; then
+        printf '  ✓ %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf '  ✗ %s\n' "$name"
+        printf '    expected:\n'
+        printf '%s\n' "$expected" | sed 's/^/      /'
+        printf '    got:\n'
+        sed 's/^/      /' "$TMP/out.md"
+        fail=$((fail + 1))
+    fi
+}
+
+# Case 1: dev channel updates the dev line, stable + experimental untouched.
+run_case "dev tag rewrites only the Dev line" \
+    "dev" "v0.2.0.17-dev.5" \
+"# Hi
+<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — [v0.2.0.17-dev.4](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.4)
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->
+trailer" \
+"# Hi
+<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — [v0.2.0.17-dev.5](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.5)
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->
+trailer"
+
+# Case 2: experimental channel updates the experimental line.
+run_case "experimental tag rewrites only the Experimental line" \
+    "experimental" "v0.3.0-experimental.1" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — [v0.2.0.17-dev.4](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.4)
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — [v0.2.0.17-dev.4](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.4)
+- **Experimental** — [v0.3.0-experimental.1](https://github.com/superic/av-pain-reliever/releases/tag/v0.3.0-experimental.1)
+<!-- END CURRENT RELEASES -->"
+
+# Case 3: empty channel (the stable case) is a total no-op even on
+# matching lines. release.yml passes channel="" for bare tags.
+run_case "empty channel is a no-op" \
+    "" "v1.0.0" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->"
+
+# Case 4: lines OUTSIDE the markers are never modified, even if they
+# look like a Dev or Experimental bullet. Defends against accidental
+# global rewrites if a maintainer pastes the snippet into a doc.
+run_case "no rewrite outside the markers" \
+    "dev" "v9.9.9-dev.1" \
+"- **Dev** — outside the block, do not touch
+<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->
+- **Dev** — also outside, also untouched" \
+"- **Dev** — outside the block, do not touch
+<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — [v9.9.9-dev.1](https://github.com/superic/av-pain-reliever/releases/tag/v9.9.9-dev.1)
+<!-- END CURRENT RELEASES -->
+- **Dev** — also outside, also untouched"
+
+# Case 5: idempotency — running twice with the same inputs is the
+# same as running once. Catches a class of bug where a sub() pattern
+# accidentally re-eats its own output.
+INPUT="<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->"
+EXPECTED="<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — [v0.5-dev.1](https://github.com/superic/av-pain-reliever/releases/tag/v0.5-dev.1)
+<!-- END CURRENT RELEASES -->"
+printf "%s\n" "$INPUT" > "$TMP/in.md"
+awk -v channel="dev" -v tag="v0.5-dev.1" -f "$AWK_SCRIPT" "$TMP/in.md" > "$TMP/once.md"
+awk -v channel="dev" -v tag="v0.5-dev.1" -f "$AWK_SCRIPT" "$TMP/once.md" > "$TMP/twice.md"
+if [ "$(cat "$TMP/once.md")" = "$EXPECTED" ] && [ "$(cat "$TMP/twice.md")" = "$EXPECTED" ]; then
+    printf '  ✓ idempotent: second run leaves output unchanged\n'
+    pass=$((pass + 1))
+else
+    printf '  ✗ idempotent: second run changed output\n'
+    fail=$((fail + 1))
+fi
+
+echo
+echo "Passed: $pass"
+echo "Failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/update-readme-channel.awk
+++ b/scripts/update-readme-channel.awk
@@ -1,0 +1,59 @@
+# Update the dev or experimental release line inside a README's
+# "BEGIN CURRENT RELEASES" / "END CURRENT RELEASES" block. The stable
+# line is never modified by this script — it uses GitHub's
+# /releases/latest redirect, which is always correct without a tag
+# fix-up. Called from .github/workflows/appcast-publish.yml on every
+# release publish so the README always reflects the most recent
+# release per channel.
+#
+# Inputs (set via `awk -v`):
+#   channel  "dev" or "experimental" — which line to rewrite. If
+#            channel is anything else (e.g. empty for stable),
+#            every line passes through unchanged.
+#   tag      The new tag (e.g. "v0.2.0.17-dev.5"). The URL gets
+#            rewritten to point at /releases/tag/<tag>.
+#
+# Behavior:
+#   - Reads README from stdin.
+#   - Lines outside the BEGIN/END block pass through verbatim.
+#   - Inside the block, the line whose label matches `channel`
+#     ("Dev" or "Experimental") is replaced with a fresh markdown
+#     bullet pointing at /releases/tag/<tag>. Other lines (including
+#     the stable line) pass through.
+#   - Markers themselves pass through.
+#
+# Style mirrors `scripts/upsert-appcast-item.awk`: start-of-line
+# anchors on the markers, deliberate idempotency (running twice with
+# the same input is identical to running once).
+
+BEGIN {
+    in_block = 0
+    if (channel == "dev") {
+        label = "Dev"
+    } else if (channel == "experimental") {
+        label = "Experimental"
+    } else {
+        label = ""
+    }
+}
+
+/^[[:space:]]*<!-- BEGIN CURRENT RELEASES -->[[:space:]]*$/ {
+    in_block = 1
+    print
+    next
+}
+
+/^[[:space:]]*<!-- END CURRENT RELEASES -->[[:space:]]*$/ {
+    in_block = 0
+    print
+    next
+}
+
+{
+    if (in_block && label != "" && $0 ~ ("\\*\\*" label "\\*\\*")) {
+        printf("- **%s** — [%s](https://github.com/superic/av-pain-reliever/releases/tag/%s)\n",
+               label, tag, tag)
+    } else {
+        print
+    }
+}


### PR DESCRIPTION
## Summary

- `/releases/latest` was returning the most recent tag of any kind because dev/experimental releases shipped without the `prerelease` flag. `release.yml` now sets `--prerelease` on `*-dev*` / `*-experimental*` tags (matching the tag-pattern logic the appcast already uses to pick a Sparkle channel), so `/releases/latest` redirects to the most recent stable.
- README gains a "Release channels" block with Stable (uses `/releases/latest`), Dev, Experimental rows. `appcast-publish.yml` auto-rewrites Dev and Experimental on every release-published event and folds the change into the same commit as `appcast.xml`. Zero manual README maintenance on tag.
- `scripts/update-readme-channel.awk` (50 lines) + `scripts/test-update-readme-channel.sh` (5 test cases) mirror the existing `upsert-appcast-item.awk` pattern. Wired into `test.yml`.

## Test plan

These changes only run inside CI workflows; there's no `./dev/build` step to exercise.

1. **Local script test:** `scripts/test-update-readme-channel.sh` passes 5/5 (already verified). Covers both channels, empty-channel no-op, lines outside markers, idempotency.
2. **CI gating checks:**
   - `test` job runs the new script test alongside the existing appcast-upsert one.
   - `Analyze (actions)` validates the workflow YAML edits.
3. **End-to-end verification on next dev release.** When `v0.2.0.17-dev.5` (or whatever's next) gets cut:
   - The draft release is created with `--prerelease=true` (visible on the GitHub release page).
   - After publishing, `appcast-publish.yml` commits both `appcast.xml` and the rewritten README's Dev row.
   - `https://github.com/superic/av-pain-reliever/releases/latest` now redirects to the most recent stable, not the dev tag.

If you'd rather catch any prerelease-flag misbehavior before risking a real dev tag, we could cut a `dryrun` tag first (the appcast-publish workflow already has a `dryrun` skip path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)