### PR TITLE
docs: backfill README "Dev" row to v0.2.0.17-dev.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Most users want the stable channel. Dev and experimental are opt-in via **Settin
 
 <!-- BEGIN CURRENT RELEASES -->
 - **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
-- **Dev** — _no current release_
+- **Dev** — [v0.2.0.17-dev.4](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.4)
 - **Experimental** — _no current release_
 <!-- END CURRENT RELEASES -->
 


### PR DESCRIPTION
## Summary

One-line README change. PR #100 shipped the auto-update plumbing but left the placeholder `_no current release_` in the Dev row. This commit runs the same awk script the workflow will run on every future release to backfill the current state.

Generated by:
```
awk -v channel=dev -v tag=v0.2.0.17-dev.4 \\
    -f scripts/update-readme-channel.awk README.md
```

Diff is one line: Dev row goes from `_no current release_` to the markdown link.

Note: existing dev releases on GitHub are still flagged `isPrerelease: false`, so `/releases/latest` still returns `v0.2.0.17-dev.4` (not the actual latest stable, `v0.2.0.16`). I'll surface that as a separate ask — fixable via four `gh release edit --prerelease` calls, no code change.

## Test plan

Docs-only. Smoke test: confirm the README diff is one line in the expected place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)