### PR TITLE
fix(ui): center windows synchronously to remove the open-then-jump flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ The Dev and Experimental rows get auto-rewritten by `appcast-publish.yml` on eve
 
 `scripts/update-readme-channel.awk` is a 50-line awk script with start-of-line anchors on the BEGIN/END markers so it can't accidentally eat a lookalike bullet outside the block (same defensive style as `upsert-appcast-item.awk`). Five test cases in `scripts/test-update-readme-channel.sh` cover both channels, the no-op empty-channel case, lines outside the markers, and idempotency. Wired into `test.yml`.
 
+### Window centering no longer flashes (2026-05-12)
+
+Settings, About, Welcome, and Add Profile windows would sometimes open at their last-known position, then visibly snap to center a moment later. The original `WindowCenterer` in `WindowChrome.swift` deferred `window.center()` through a `DispatchQueue.main.async` hop, which fired *after* AppKit ordered the window front — the user saw both the pre-center frame and the snap.
+
+Rewrote the helper as a custom `NSView` subclass that overrides `viewDidMoveToWindow()`. That callback fires while the view is being attached to its window but before the window is shown, so the centering lands before any pixels paint. A `hasCentered` latch prevents re-centering on view re-hosting (theme change, scene restoration), so a user-moved window isn't yanked back.
+
+While in there, switched from `NSWindow.center()` (which uses the screen the window's saved frame is on, or main if none) to centering on the screen with the mouse cursor. For a menu-bar app the user may click the menu bar on one monitor while the saved frame is on another; the cursor's screen is the screen they're looking at. The y-axis placement matches AppKit's `center()` heuristic (about a third from the top), so the windows still feel like macOS-native utility windows rather than dead-center-on-screen modals.
+
 ### Trace `.debug` lines for `ProfileConfigWatcher` (2026-05-11)
 
 The watcher logged only on error paths. Matched the `IOKitUSBWatcher` convention from the 2026-05-09 verbose-logging release: six new `.debug` calls covering start (with bound fd numbers), stop, dir-source events, file-source events with mask, inode-staleness rebinds, and debounce arming. All under category `config-watcher`. Diagnostic only: `.debug` is off the persistence path, so this doesn't change Save Logs for Support exports. Stream via `log stream --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "config-watcher"' --level debug --style compact`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,11 @@ The Dev and Experimental rows get auto-rewritten by `appcast-publish.yml` on eve
 
 Settings, About, Welcome, and Add Profile windows would sometimes open at their last-known position, then visibly snap to center a moment later. The original `WindowCenterer` in `WindowChrome.swift` deferred `window.center()` through a `DispatchQueue.main.async` hop, which fired *after* AppKit ordered the window front — the user saw both the pre-center frame and the snap.
 
-Rewrote the helper as a custom `NSView` subclass that overrides `viewDidMoveToWindow()`. That callback fires while the view is being attached to its window but before the window is shown, so the centering lands before any pixels paint. A `hasCentered` latch prevents re-centering on view re-hosting (theme change, scene restoration), so a user-moved window isn't yanked back.
+Rewrote the helper as a custom `NSView` subclass that overrides `viewDidMoveToWindow()`. That callback fires while the view is being attached to its window but before the window is shown, so the centering lands before any pixels paint.
+
+First attempt at this used a single `hasCentered` latch that only released on view re-hosting (theme change, scene restoration). That worked for the initial open but missed the close-and-reopen case: SwiftUI's `Settings` scene keeps the view hierarchy alive across close (the window is hidden, not destroyed), so `viewDidMoveToWindow` only fires the first time. Closing and reopening left the window at its last-moved position.
+
+Fix uses two `NSWindow` notifications to coordinate the latch: `willCloseNotification` resets it; `didBecomeKeyNotification` re-centers iff the latch is clear. Net behavior: every real close/reopen cycle re-centers. Click-away-and-click-back doesn't fire `willClose`, so the latch stays set and the window keeps its user-moved position.
 
 While in there, switched from `NSWindow.center()` (which uses the screen the window's saved frame is on, or main if none) to centering on the screen with the mouse cursor. For a menu-bar app the user may click the menu bar on one monitor while the saved frame is on another; the cursor's screen is the screen they're looking at. The y-axis placement matches AppKit's `center()` heuristic (about a third from the top), so the windows still feel like macOS-native utility windows rather than dead-center-on-screen modals.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,17 +75,20 @@ The Dev and Experimental rows get auto-rewritten by `appcast-publish.yml` on eve
 
 `scripts/update-readme-channel.awk` is a 50-line awk script with start-of-line anchors on the BEGIN/END markers so it can't accidentally eat a lookalike bullet outside the block (same defensive style as `upsert-appcast-item.awk`). Five test cases in `scripts/test-update-readme-channel.sh` cover both channels, the no-op empty-channel case, lines outside the markers, and idempotency. Wired into `test.yml`.
 
-### Window centering no longer flashes (2026-05-12)
+### Settings, About, Welcome, and Add Profile windows now center on every open (2026-05-12)
 
-Settings, About, Welcome, and Add Profile windows would sometimes open at their last-known position, then visibly snap to center a moment later. The original `WindowCenterer` in `WindowChrome.swift` deferred `window.center()` through a `DispatchQueue.main.async` hop, which fired *after* AppKit ordered the window front — the user saw both the pre-center frame and the snap.
+The four utility windows sometimes opened off-center on the wrong monitor, sometimes briefly at their last-known position before snapping to center. Root cause turned out to be a sequence of races between the helper's centering, AppKit's `frameAutosaveName` restoration, and SwiftUI's `Settings`-scene state restoration. Diagnostic logging across four iterations was the only way to see it clearly.
 
-Rewrote the helper as a custom `NSView` subclass that overrides `viewDidMoveToWindow()`. That callback fires while the view is being attached to its window but before the window is shown, so the centering lands before any pixels paint.
+Final shape (in `WindowChrome.swift`):
 
-First attempt at this used a single `hasCentered` latch that only released on view re-hosting (theme change, scene restoration). That worked for the initial open but missed the close-and-reopen case: SwiftUI's `Settings` scene keeps the view hierarchy alive across close (the window is hidden, not destroyed), so `viewDidMoveToWindow` only fires the first time. Closing and reopening left the window at its last-moved position.
+- A custom `NSView` subclass (`WindowCenteringView`) attaches `NSWindow.willCloseNotification` and `NSWindow.didBecomeKeyNotification` observers in `viewDidMoveToWindow`.
+- `didBecomeKeyNotification` is the **single source of truth** for centering. On every become-key with a cleared `hasCentered` latch, the window re-centers on the cursor's screen. `willCloseNotification` clears the latch so the next open re-centers.
+- Centering is intentionally NOT done in `viewDidMoveToWindow`. The diagnostic logs showed SwiftUI's `Settings` scene restoring its last-session frame between `viewDidMoveToWindow` and `didBecomeKey` (~30 ms gap), which would clobber any pre-show centering. `didBecomeKey` fires after that restoration, so it's the only reliable hook.
+- `frameAutosaveName` is cleared if SwiftUI assigns one, as belt-and-suspenders against AppKit's restoration on top of SwiftUI's.
+- Centering uses the screen with the mouse cursor, not `NSWindow.center()`'s "screen the saved frame is on" default. For a menu-bar app, the cursor's monitor is the one the user is looking at; the saved-frame's monitor may have been from a different session. Y-axis placement matches AppKit's `center()` heuristic (about a third from the top) so the windows still feel like macOS-native utility windows.
+- Focus-return (user clicks another app then back to the window) does NOT fire `willClose`, so the latch stays set and the window keeps its user-moved position.
 
-Fix uses two `NSWindow` notifications to coordinate the latch: `willCloseNotification` resets it; `didBecomeKeyNotification` re-centers iff the latch is clear. Net behavior: every real close/reopen cycle re-centers. Click-away-and-click-back doesn't fire `willClose`, so the latch stays set and the window keeps its user-moved position.
-
-While in there, switched from `NSWindow.center()` (which uses the screen the window's saved frame is on, or main if none) to centering on the screen with the mouse cursor. For a menu-bar app the user may click the menu bar on one monitor while the saved frame is on another; the cursor's screen is the screen they're looking at. The y-axis placement matches AppKit's `center()` heuristic (about a third from the top), so the windows still feel like macOS-native utility windows rather than dead-center-on-screen modals.
+The `WindowCenteringView` logs decision points under a new `window-center` category so future regressions of this class are diagnosable in one `log stream` run. Diagnostic only: `.debug` is off the persistence path, so Save Logs for Support exports are unchanged.
 
 ### Trace `.debug` lines for `ProfileConfigWatcher` (2026-05-11)
 

--- a/Sources/AVPainRelieverApp/WindowChrome.swift
+++ b/Sources/AVPainRelieverApp/WindowChrome.swift
@@ -69,11 +69,17 @@ private struct WindowChromeAccessor: NSViewRepresentable {
 
 // MARK: - centeredOnScreen
 
-/// SwiftUI view modifier that recenters the hosting `NSWindow` on the
-/// active screen every time the window appears. Without this, macOS
-/// remembers each window's last position and reopens it there, which
-/// produces the surprising "settings window opened in some random
-/// corner of the second monitor" experience for utility windows.
+/// SwiftUI view modifier that centers the hosting `NSWindow` on the
+/// screen with the mouse cursor when the window first appears. Without
+/// this, macOS remembers each window's last position and reopens it
+/// there, producing the surprising "settings window opened in some
+/// random corner of the second monitor" experience for utility windows.
+///
+/// Centers **synchronously** in `viewDidMoveToWindow`, before AppKit
+/// orders the window front. An earlier implementation used a
+/// `DispatchQueue.main.async` hop, which deferred the centering past
+/// the show, producing a visible flash where the window appeared at
+/// its saved position and then snapped to center one runloop later.
 struct CenteredOnScreen: ViewModifier {
     func body(content: Content) -> some View {
         content.background(WindowCenterer())
@@ -81,8 +87,9 @@ struct CenteredOnScreen: ViewModifier {
 }
 
 extension View {
-    /// Center the hosting window on the active screen on every open.
-    /// Idempotent — safe to combine with `dialogWindowChrome()`.
+    /// Center the hosting window on the active screen on first open.
+    /// Idempotent across re-hosting; the window is only centered once
+    /// per view instance so a user-moved window isn't yanked back.
     func centeredOnScreen() -> some View {
         modifier(CenteredOnScreen())
     }
@@ -90,16 +97,54 @@ extension View {
 
 private struct WindowCenterer: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
-        DispatchQueue.main.async { [weak view] in
-            view?.window?.center()
-        }
-        return view
+        WindowCenteringView()
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
         // No-op on update. Centering on every state change would
-        // fight the user if they manually move the window mid-
-        // session. We only center on open.
+        // fight the user if they manually moved the window mid-
+        // session.
+    }
+}
+
+/// Centers its hosting window the first time the view is attached.
+/// `viewDidMoveToWindow` runs after the window exists but before it
+/// is ordered front, so the center call lands before the user sees
+/// anything. The `hasCentered` latch guards against SwiftUI re-hosting
+/// the view later (theme change, scene restoration), which would
+/// otherwise re-center and clobber a user-moved window.
+private final class WindowCenteringView: NSView {
+    private var hasCentered = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard !hasCentered, let window = window else { return }
+        hasCentered = true
+        centerOnCursorScreen(window)
+    }
+
+    /// Center on the screen currently containing the mouse cursor.
+    /// For a menu-bar app the user may click the menu bar on monitor
+    /// A while the saved frame is on monitor B; the cursor's screen
+    /// is the screen they're looking at. Falls back to `NSWindow.center()`
+    /// (main screen) when no screen contains the cursor — typically
+    /// only happens during screen-reconfiguration races.
+    private func centerOnCursorScreen(_ window: NSWindow) {
+        let cursor = NSEvent.mouseLocation
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(cursor) })
+            ?? NSScreen.main
+        else {
+            window.center()
+            return
+        }
+        let visible = screen.visibleFrame
+        var frame = window.frame
+        frame.origin.x = visible.origin.x + (visible.width - frame.width) / 2
+        // Match AppKit's `NSWindow.center()` heuristic: place the
+        // window above geometric center (about a third from the top
+        // of the screen), which reads as "primary attention" for a
+        // utility window rather than "bottom-of-the-stack."
+        frame.origin.y = visible.origin.y + (visible.height - frame.height) * 2 / 3
+        window.setFrame(frame, display: true)
     }
 }

--- a/Sources/AVPainRelieverApp/WindowChrome.swift
+++ b/Sources/AVPainRelieverApp/WindowChrome.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import OSLog
 
 /// SwiftUI view modifier that locks the hosting `NSWindow` to a fixed,
 /// dialog-style chrome: title bar + close button only. The yellow
@@ -126,6 +127,10 @@ private struct WindowCenterer: NSViewRepresentable {
 ///     doesn't fire `willClose`, so the latch stays true and the
 ///     window stays where the user left it.
 private final class WindowCenteringView: NSView {
+    private static let logger = Logger(
+        subsystem: "com.ericwillis.avpainreliever",
+        category: "window-center"
+    )
     private var hasCentered = false
     private var willCloseObserver: NSObjectProtocol?
     private var didBecomeKeyObserver: NSObjectProtocol?
@@ -133,9 +138,23 @@ private final class WindowCenteringView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         teardownObservers()
-        guard let window = window else { return }
+        guard let window = window else {
+            Self.logger.debug("viewDidMoveToWindow: window=nil; nothing to do")
+            return
+        }
+        // Defuse macOS's frame autosave so SwiftUI/AppKit doesn't
+        // restore the previous frame AFTER our centering and clobber
+        // it. Setting the name to empty string disables autosaving
+        // on the window. Must run BEFORE the first center so the
+        // restore (if any) happens before, not after.
+        if !window.frameAutosaveName.isEmpty {
+            Self.logger.debug("viewDidMoveToWindow: clearing frameAutosaveName=\(window.frameAutosaveName, privacy: .public)")
+            window.setFrameAutosaveName("")
+        }
         if !hasCentered {
+            Self.logger.debug("viewDidMoveToWindow: centering, current frame=\(NSStringFromRect(window.frame), privacy: .public)")
             centerOnCursorScreen(window)
+            Self.logger.debug("viewDidMoveToWindow: centered, new frame=\(NSStringFromRect(window.frame), privacy: .public)")
             hasCentered = true
         }
         attachObservers(to: window)
@@ -148,8 +167,7 @@ private final class WindowCenteringView: NSView {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            // Window is about to be hidden. Clear the latch so the
-            // next time it becomes key, we re-center.
+            Self.logger.debug("willClose: clearing latch")
             self?.hasCentered = false
         }
         didBecomeKeyObserver = center.addObserver(
@@ -157,8 +175,14 @@ private final class WindowCenteringView: NSView {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            guard let self, !self.hasCentered, let window = self.window else { return }
+            guard let self, let window = self.window else { return }
+            if self.hasCentered {
+                Self.logger.debug("didBecomeKey: latched, leaving frame=\(NSStringFromRect(window.frame), privacy: .public)")
+                return
+            }
+            Self.logger.debug("didBecomeKey: centering, current frame=\(NSStringFromRect(window.frame), privacy: .public)")
             self.centerOnCursorScreen(window)
+            Self.logger.debug("didBecomeKey: centered, new frame=\(NSStringFromRect(window.frame), privacy: .public)")
             self.hasCentered = true
         }
     }

--- a/Sources/AVPainRelieverApp/WindowChrome.swift
+++ b/Sources/AVPainRelieverApp/WindowChrome.swift
@@ -87,9 +87,10 @@ struct CenteredOnScreen: ViewModifier {
 }
 
 extension View {
-    /// Center the hosting window on the active screen on first open.
-    /// Idempotent across re-hosting; the window is only centered once
-    /// per view instance so a user-moved window isn't yanked back.
+    /// Center the hosting window on the cursor's screen on every
+    /// open, including reopens after the user closes the window. A
+    /// click-away-and-back focus return doesn't recenter — only a
+    /// real close/reopen cycle does.
     func centeredOnScreen() -> some View {
         modifier(CenteredOnScreen())
     }
@@ -107,20 +108,71 @@ private struct WindowCenterer: NSViewRepresentable {
     }
 }
 
-/// Centers its hosting window the first time the view is attached.
-/// `viewDidMoveToWindow` runs after the window exists but before it
-/// is ordered front, so the center call lands before the user sees
-/// anything. The `hasCentered` latch guards against SwiftUI re-hosting
-/// the view later (theme change, scene restoration), which would
-/// otherwise re-center and clobber a user-moved window.
+/// Centers its hosting window on first attach AND on every reopen
+/// after a close.
+///
+/// SwiftUI's `Settings` scene keeps the view hierarchy alive across
+/// the window's close/reopen cycle (the window is hidden, not
+/// destroyed), so `viewDidMoveToWindow` only fires the first time the
+/// window is ever opened. Relying on it alone leaves the window at
+/// its user-moved position on the second open, which feels broken.
+///
+/// Two `NSWindow` notifications coordinate a "re-center on next open
+/// but never on focus-return" semantic:
+///   - `willCloseNotification` resets `hasCentered = false` so the
+///     next `didBecomeKey` re-centers.
+///   - `didBecomeKeyNotification` centers iff `!hasCentered`, then
+///     re-sets the latch. Clicking away from the window and back
+///     doesn't fire `willClose`, so the latch stays true and the
+///     window stays where the user left it.
 private final class WindowCenteringView: NSView {
     private var hasCentered = false
+    private var willCloseObserver: NSObjectProtocol?
+    private var didBecomeKeyObserver: NSObjectProtocol?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard !hasCentered, let window = window else { return }
-        hasCentered = true
-        centerOnCursorScreen(window)
+        teardownObservers()
+        guard let window = window else { return }
+        if !hasCentered {
+            centerOnCursorScreen(window)
+            hasCentered = true
+        }
+        attachObservers(to: window)
+    }
+
+    private func attachObservers(to window: NSWindow) {
+        let center = NotificationCenter.default
+        willCloseObserver = center.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            // Window is about to be hidden. Clear the latch so the
+            // next time it becomes key, we re-center.
+            self?.hasCentered = false
+        }
+        didBecomeKeyObserver = center.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, !self.hasCentered, let window = self.window else { return }
+            self.centerOnCursorScreen(window)
+            self.hasCentered = true
+        }
+    }
+
+    private func teardownObservers() {
+        let center = NotificationCenter.default
+        if let willCloseObserver { center.removeObserver(willCloseObserver) }
+        if let didBecomeKeyObserver { center.removeObserver(didBecomeKeyObserver) }
+        willCloseObserver = nil
+        didBecomeKeyObserver = nil
+    }
+
+    deinit {
+        teardownObservers()
     }
 
     /// Center on the screen currently containing the mouse cursor.

--- a/Sources/AVPainRelieverApp/WindowChrome.swift
+++ b/Sources/AVPainRelieverApp/WindowChrome.swift
@@ -142,22 +142,17 @@ private final class WindowCenteringView: NSView {
             Self.logger.debug("viewDidMoveToWindow: window=nil; nothing to do")
             return
         }
-        // Defuse macOS's frame autosave so SwiftUI/AppKit doesn't
-        // restore the previous frame AFTER our centering and clobber
-        // it. Setting the name to empty string disables autosaving
-        // on the window. Must run BEFORE the first center so the
-        // restore (if any) happens before, not after.
+        // Defuse AppKit's frame autosave (if any) so a saved frame
+        // can't be restored. SwiftUI's Settings scene has its own
+        // state-restoration mechanism on top of this that fires
+        // BETWEEN viewDidMoveToWindow and didBecomeKey, which is why
+        // we don't try to center here — see the didBecomeKey handler.
         if !window.frameAutosaveName.isEmpty {
             Self.logger.debug("viewDidMoveToWindow: clearing frameAutosaveName=\(window.frameAutosaveName, privacy: .public)")
             window.setFrameAutosaveName("")
         }
-        if !hasCentered {
-            Self.logger.debug("viewDidMoveToWindow: centering, current frame=\(NSStringFromRect(window.frame), privacy: .public)")
-            centerOnCursorScreen(window)
-            Self.logger.debug("viewDidMoveToWindow: centered, new frame=\(NSStringFromRect(window.frame), privacy: .public)")
-            hasCentered = true
-        }
         attachObservers(to: window)
+        Self.logger.debug("viewDidMoveToWindow: observers attached, current frame=\(NSStringFromRect(window.frame), privacy: .public)")
     }
 
     private func attachObservers(to window: NSWindow) {


### PR DESCRIPTION
## Summary

Settings, About, Welcome, and Add Profile windows sometimes opened off-center, sometimes flashed through a saved position before snapping. Root cause: a sequence of races between the helper's centering, AppKit's `frameAutosaveName` restoration, and SwiftUI's `Settings`-scene state restoration. Diagnostic logging across iterations was the only way to see it cleanly.

**Final design (in `WindowChrome.swift`):**

- Custom `NSView` subclass (`WindowCenteringView`) attaches `NSWindow.willCloseNotification` and `NSWindow.didBecomeKeyNotification` observers in `viewDidMoveToWindow`.
- `didBecomeKey` is the **single source of truth** for centering. Centers on the cursor's screen iff a `hasCentered` latch is clear; sets the latch. `willClose` clears the latch.
- Centering is intentionally NOT done in `viewDidMoveToWindow`. Diagnostic logs showed SwiftUI's `Settings` scene restoring its last-session frame between `viewDidMoveToWindow` and `didBecomeKey` (~30 ms gap), clobbering any pre-show centering. `didBecomeKey` fires after that restoration, so it's the only reliable hook.
- `frameAutosaveName` is cleared if SwiftUI assigns one — belt-and-suspenders against AppKit's restoration layered on top of SwiftUI's.
- Centering uses the screen with the mouse cursor, not `NSWindow.center()`'s "screen the saved frame is on" default. Right behavior for a menu-bar app where the cursor's monitor and the saved-frame's monitor may disagree.
- Focus-return (user clicks another app then back) does NOT fire `willClose`, so the latch stays set and the window keeps its user-moved position.
- Decision points are logged under a new `window-center` category (`.debug` level, off the persistence path) so future regressions are one `log stream` away.

## Verification

The reporter (you) ran the full matrix:

- Settings: first open centered ✓ | close → reopen centered ✓ | move → close → reopen centered ✓
- About: first open centered ✓ | move → close → reopen centered ✓
- Add Profile: centered ✓

## Test plan

```
./dev/build --full
```

Smoke test: open each of Settings, About, Add Profile a couple times each. Move them. Close and reopen. Click away and back (latch should not yank). Multi-monitor: drag the window to one monitor, close, move cursor to the other, reopen — should center on the cursor's monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)