### PR TITLE
fix(tests): don't register swiftpm-testing-helper as a login item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ Final shape (in `WindowChrome.swift`):
 
 The `WindowCenteringView` logs decision points under a new `window-center` category so future regressions of this class are diagnosable in one `log stream` run. Diagnostic only: `.debug` is off the persistence path, so Save Logs for Support exports are unchanged.
 
+### Don't register `swiftpm-testing-helper` as a login item from tests (2026-05-12)
+
+`SettingsStoreTests.launchAtLoginPersists` toggled `store.launchAtLogin = true`, which fired the `@Published` `didSet` and called `LaunchAtLogin.apply(enabled: true)`. Under `swift test`, that resolves to `SMAppService.mainApp` from inside the `swiftpm-testing-helper` process, registering the **test runner** as a login item every time the suite ran. macOS Sequoia surfaces this as a "Login Item Added" banner ("`swiftpm-testing-helper` will open automatically when you log in"), which had silently accumulated across many test runs over the past week.
+
+Fix is a `LoginItemApplier` typealias and an injected applier closure on `SettingsStore.init`. Production passes the real `LaunchAtLogin.apply(enabled:)`; tests pass `{ _ in }`. The one test that mutates `launchAtLogin` now injects the no-op explicitly so `SMAppService` never gets called from the test helper. Existing tests that construct `SettingsStore` without mutating `launchAtLogin` are safe because Swift's `didSet` doesn't fire during initialization, so they continue using the default production applier without ever invoking it.
+
+Cleanup for users on the affected machine: open **System Settings → Login Items & Extensions** and remove `swiftpm-testing-helper` from **Open at Login**. After that, the bug is gone for good.
+
 ### Trace `.debug` lines for `ProfileConfigWatcher` (2026-05-11)
 
 The watcher logged only on error paths. Matched the `IOKitUSBWatcher` convention from the 2026-05-09 verbose-logging release: six new `.debug` calls covering start (with bound fd numbers), stop, dir-source events, file-source events with mask, inode-staleness rebinds, and debounce arming. All under category `config-watcher`. Diagnostic only: `.debug` is off the persistence path, so this doesn't change Save Logs for Support exports. Stream via `log stream --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "config-watcher"' --level debug --style compact`.

--- a/Sources/AVPainRelieverApp/LaunchAtLogin.swift
+++ b/Sources/AVPainRelieverApp/LaunchAtLogin.swift
@@ -2,6 +2,14 @@ import Foundation
 import ServiceManagement
 import OSLog
 
+/// Closure signature for "apply the login-item state for `enabled`."
+/// `SettingsStore` takes one of these so tests can inject a no-op
+/// instead of letting `SMAppService.mainApp.register()` run from
+/// inside `swiftpm-testing-helper` (which would register the test
+/// runner as a login item — see `LaunchAtLogin.swift`'s `apply` doc
+/// for the gory details).
+typealias LoginItemApplier = (Bool) -> Void
+
 /// Wraps `SMAppService.mainApp` so SettingsStore can flip the
 /// "launch at login" preference without taking a hard dependency on
 /// SMAppService throughout the codebase.
@@ -13,6 +21,12 @@ import OSLog
 ///     misregisters the launcher. This helper logs the failure but
 ///     never throws — the user sees the toggle flip back to off in
 ///     the next launch (since the registration didn't stick).
+///   - **Under `swift test`,** `SMAppService.mainApp` resolves to
+///     the SPM test runner (`swiftpm-testing-helper`), so calling
+///     `apply` from a test registers that binary as a system login
+///     item. `SettingsStore` injects this via `LoginItemApplier` so
+///     tests can pass a no-op closure; production always uses the
+///     real `apply` below.
 ///   - The signed `.app` bundle (when distribution lands) will
 ///     register cleanly. The same code path here will start
 ///     working with no app-side changes.

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -95,12 +95,15 @@ final class SettingsStore: ObservableObject {
 
     /// Whether the app should auto-launch at login. Default off so a
     /// fresh user has to opt in (per macOS background-task etiquette).
-    /// `LaunchAtLogin.apply(enabled:)` mirrors this state into the
-    /// system's launch services.
+    /// The injected `applyLoginItem` mirrors this state into the
+    /// system's launch services in production, and is a no-op in
+    /// tests (otherwise `SMAppService.mainApp.register()` would run
+    /// from `swiftpm-testing-helper` and register the test runner
+    /// itself as a login item — see `LaunchAtLogin.swift`).
     @Published var launchAtLogin: Bool {
         didSet {
             write(launchAtLogin, forKey: Key.launchAtLogin)
-            LaunchAtLogin.apply(enabled: launchAtLogin)
+            applyLoginItem(launchAtLogin)
         }
     }
 
@@ -309,8 +312,21 @@ final class SettingsStore: ObservableObject {
         Self.logger.debug("wrote key=\(key) value=\(rendered)")
     }
 
-    init(defaults: UserDefaults = .standard) {
+    /// Closure invoked from `launchAtLogin.didSet` to mirror the
+    /// toggle into `SMAppService.mainApp`. Production passes
+    /// `LaunchAtLogin.apply(enabled:)`; tests pass a no-op so
+    /// `swiftpm-testing-helper` never registers itself as a login
+    /// item. Held as an `@MainActor`-isolated property because the
+    /// enclosing class is `@MainActor` and the closure may touch
+    /// main-actor state.
+    private let applyLoginItem: LoginItemApplier
+
+    init(
+        defaults: UserDefaults = .standard,
+        applyLoginItem: @escaping LoginItemApplier = LaunchAtLogin.apply(enabled:)
+    ) {
         self.defaults = defaults
+        self.applyLoginItem = applyLoginItem
         // Default-on toggles use `object(forKey:) == nil` to distinguish
         // "never set" (use default) from "set to false" (respect
         // user's choice). `bool(forKey:)` returns false for missing

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -50,10 +50,15 @@ struct SettingsStoreTests {
     func launchAtLoginPersists() {
         let defaults = makeSuite()
         do {
-            let store = SettingsStore(defaults: defaults)
+            // Pass an explicit no-op `applyLoginItem` so the didSet
+            // doesn't reach `SMAppService.mainApp.register()`. Under
+            // `swift test` the main app resolves to
+            // `swiftpm-testing-helper`, and macOS would register the
+            // test runner as a login item every time this test ran.
+            let store = SettingsStore(defaults: defaults, applyLoginItem: { _ in })
             store.launchAtLogin = true
         }
-        let reopened = SettingsStore(defaults: defaults)
+        let reopened = SettingsStore(defaults: defaults, applyLoginItem: { _ in })
         #expect(reopened.launchAtLogin == true)
     }
 


### PR DESCRIPTION
## Summary

You got a macOS notification saying `swiftpm-testing-helper` had been added as a login item. That was me. Every time I ran `swift test` this week, `SettingsStoreTests.launchAtLoginPersists` toggled `store.launchAtLogin = true`, which fired the `@Published` `didSet` and called `LaunchAtLogin.apply(enabled: true)` → `SMAppService.mainApp.register()` — and from inside `swiftpm-testing-helper`, `mainApp` resolves to the test runner itself. macOS Sequoia escalated the silent registration into a banner notification, which is what you saw.

## What changed

- New `LoginItemApplier` typealias in `LaunchAtLogin.swift`.
- `SettingsStore.init` now takes `applyLoginItem: @escaping LoginItemApplier = LaunchAtLogin.apply(enabled:)`. Production uses the real applier; tests pass `{ _ in }`.
- `SettingsStoreTests.launchAtLoginPersists` injects the no-op so the side effect never reaches SMAppService.
- Other tests that construct `SettingsStore` without mutating `launchAtLogin` are untouched — Swift's `didSet` doesn't fire during init, so they continue using the default production applier safely.

## Verification

`log show --predicate 'category == "launch-at-login"' --last 30m` showed three `swiftpm-testing-helper: registered as login item` lines from test runs earlier today (pre-fix), and zero from the test run after this commit. The only post-fix registration is from `AVPainRelieverApp` itself (the actual installed app), which is correct production behavior.

## ⚠️ One-time cleanup required on your machine

The fix prevents *future* registrations but doesn't undo the rogue one already there. Open **System Settings → Login Items & Extensions**, find `swiftpm-testing-helper` in the **Open at Login** list, and remove it. Then it's gone for good.

## Test plan

Run the suite once:

```
swift test
```

In another terminal:

```
log show --predicate 'subsystem == "com.ericwillis.avpainreliever" AND category == "launch-at-login"' --info --last 5m
```

Expected: **no** `swiftpm-testing-helper` lines. If you see any, the fix isn't holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)