### PR TITLE
chore(ci): stable release auto-clears obsolete Dev/Experimental README rows

### DIFF
--- a/.github/workflows/appcast-publish.yml
+++ b/.github/workflows/appcast-publish.yml
@@ -159,24 +159,78 @@ jobs:
               -f scripts/upsert-appcast-item.awk \
               appcast.xml > appcast.xml.new
           mv appcast.xml.new appcast.xml
-          # Refresh README's "Release channels" block for dev /
-          # experimental tags so the published tag-pinned URL is
-          # always current. Stable uses GitHub's /releases/latest
-          # redirect and never needs a rewrite — empty $CHANNEL passes
-          # through untouched. Tag-pattern matches what the appcast
-          # signing step already computed; both decisions share the
-          # same source of truth (the tag suffix).
+          # Refresh README's "Release channels" block. Three cases:
+          #
+          #   1. *-dev*           → rewrite the Dev row to the new tag.
+          #   2. *-experimental*  → rewrite the Experimental row.
+          #   3. bare stable tag  → reset Dev and Experimental rows to
+          #                         "no current release" IF their
+          #                         current tag is a prerelease of the
+          #                         SAME stable version we're shipping
+          #                         (e.g. dev row says v0.2.0.17-dev.5
+          #                         and we ship v0.2.0.17). A newer
+          #                         prerelease on a different major/
+          #                         minor/patch (e.g. experimental
+          #                         v0.3.0-experimental.1 while we
+          #                         ship stable v0.2.0.17) is left
+          #                         alone.
+          #
+          # Note: macOS / GNU `sort -V` is NOT a semver comparator. It
+          # places `v0.2.0.17` BEFORE `v0.2.0.17-dev.5`, opposite of
+          # semver. So instead of version-comparing, we use a simpler
+          # rule that captures the actual intent: strip the prerelease
+          # suffix from both tags and compare for equality.
+          #
+          # Helpers are inline so the workflow stays self-contained.
+          # Bash 3.2 compatible.
+          readme_row_tag() {
+              # Extract the tag from a "**$1** — [<tag>](...)" row, or
+              # echo empty if the row reads "_no current release_".
+              grep -oE "\*\*$1\*\* — \[[^]]+\]" README.md \
+                  | sed -E 's/.*\[(.+)\]/\1/' || true
+          }
+          strip_prerelease() {
+              # v0.2.0.17-dev.5 → v0.2.0.17; v0.2.0.17 → v0.2.0.17.
+              echo "$1" | sed -E 's/-.*$//'
+          }
+          reset_row_if_obsolete() {
+              # $1 = display label ("Dev"/"Experimental"), $2 = channel arg.
+              local current
+              current=$(readme_row_tag "$1")
+              if [ -z "$current" ]; then
+                  return  # already reset
+              fi
+              if [ "$(strip_prerelease "$current")" = "$(strip_prerelease "$VERSION_TAG")" ]; then
+                  awk \
+                      -v channel="$2" \
+                      -v tag="" \
+                      -f scripts/update-readme-channel.awk \
+                      README.md > README.md.new
+                  mv README.md.new README.md
+              fi
+          }
           case "$VERSION_TAG" in
-              *-dev*)          README_CHANNEL=dev ;;
-              *-experimental*) README_CHANNEL=experimental ;;
-              *)               README_CHANNEL= ;;
+              *-dev*)
+                  awk \
+                      -v channel=dev \
+                      -v tag="$VERSION_TAG" \
+                      -f scripts/update-readme-channel.awk \
+                      README.md > README.md.new
+                  mv README.md.new README.md
+                  ;;
+              *-experimental*)
+                  awk \
+                      -v channel=experimental \
+                      -v tag="$VERSION_TAG" \
+                      -f scripts/update-readme-channel.awk \
+                      README.md > README.md.new
+                  mv README.md.new README.md
+                  ;;
+              *)
+                  reset_row_if_obsolete Dev dev
+                  reset_row_if_obsolete Experimental experimental
+                  ;;
           esac
-          awk \
-              -v channel="$README_CHANNEL" \
-              -v tag="$VERSION_TAG" \
-              -f scripts/update-readme-channel.awk \
-              README.md > README.md.new
-          mv README.md.new README.md
           git add appcast.xml README.md
           git commit -m "appcast: publish $VERSION_TAG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### Stable release auto-clears the Dev/Experimental README rows (2026-05-13)
+
+Follow-on to #100. The README's "Release channels" block had three rows; Dev and Experimental were auto-filled on every dev/experimental release publish, but **when a stable release shipped, the obsolete prerelease rows kept pointing at their last tag.** Looked confusing: "Dev: v0.2.0.17-dev.5" sitting under "Stable: latest" once the stable is what `latest` resolves to anyway.
+
+`scripts/update-readme-channel.awk` gains an empty-tag semantic: pass `tag=""` and the addressed row gets reset to `_no current release_` instead of rewritten with a new link.
+
+`appcast-publish.yml` grows a three-way `case` on `$VERSION_TAG`:
+
+- `*-dev*` → rewrite the Dev row to the new tag (unchanged).
+- `*-experimental*` → rewrite the Experimental row (unchanged).
+- bare stable tag → for each of Dev and Experimental, if the row's current tag is a prerelease of the **same** stable version (`strip-prerelease(current) == strip-prerelease(new_stable)`), reset it.
+
+The strip-and-compare rule beats version-comparison via `sort -V` because that's not a real semver comparator — `sort -V` places `v0.2.0.17` BEFORE `v0.2.0.17-dev.5`, opposite of semver. Strip-and-compare captures the actual intent: "this row is showing a prerelease of the version I'm now shipping as stable, clear it." Prerelease tags pointing at a future major/minor (e.g. experimental `v0.3.0-experimental.1` while we ship stable `v0.2.0.17`) are left alone.
+
+Tests: 3 new cases in `scripts/test-update-readme-channel.sh` (empty-tag-resets-dev, empty-tag-resets-experimental, reset-is-idempotent-on-already-reset). 8 total in the harness.
+
 ### README "Release channels" block + correct `releases/latest` redirect (2026-05-11)
 
 The README's install step linked GitHub's `/releases/latest` for stable downloads, but every recent release was published without the `prerelease` flag set, so `/releases/latest` was returning whatever tag was newest (dev tags included). A user clicking "latest" today gets `v0.2.0.17-dev.4` instead of the most recent stable.

--- a/scripts/test-update-readme-channel.sh
+++ b/scripts/test-update-readme-channel.sh
@@ -104,7 +104,44 @@ run_case "no rewrite outside the markers" \
 <!-- END CURRENT RELEASES -->
 - **Dev** — also outside, also untouched"
 
-# Case 5: idempotency — running twice with the same inputs is the
+# Case 5: empty tag for dev resets the row to "no current release".
+# Used when a stable release ships and dev no longer has anything
+# newer than stable; the workflow calls with tag="" to clear the row.
+run_case "dev with empty tag resets to 'no current release'" \
+    "dev" "" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — [v0.2.0.17-dev.5](https://github.com/superic/av-pain-reliever/releases/tag/v0.2.0.17-dev.5)
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Stable** — [latest](https://github.com/superic/av-pain-reliever/releases/latest)
+- **Dev** — _no current release_
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->"
+
+# Case 6: same reset behavior for experimental.
+run_case "experimental with empty tag resets to 'no current release'" \
+    "experimental" "" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Experimental** — [v0.3.0-experimental.1](https://github.com/superic/av-pain-reliever/releases/tag/v0.3.0-experimental.1)
+<!-- END CURRENT RELEASES -->" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Experimental** — _no current release_
+<!-- END CURRENT RELEASES -->"
+
+# Case 7: reset is idempotent — calling reset on an already-reset
+# row is a no-op.
+run_case "reset on an already-reset row is a no-op" \
+    "dev" "" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->" \
+"<!-- BEGIN CURRENT RELEASES -->
+- **Dev** — _no current release_
+<!-- END CURRENT RELEASES -->"
+
+# Case 8: idempotency — running twice with the same inputs is the
 # same as running once. Catches a class of bug where a sub() pattern
 # accidentally re-eats its own output.
 INPUT="<!-- BEGIN CURRENT RELEASES -->

--- a/scripts/update-readme-channel.awk
+++ b/scripts/update-readme-channel.awk
@@ -11,15 +11,19 @@
 #            channel is anything else (e.g. empty for stable),
 #            every line passes through unchanged.
 #   tag      The new tag (e.g. "v0.2.0.17-dev.5"). The URL gets
-#            rewritten to point at /releases/tag/<tag>.
+#            rewritten to point at /releases/tag/<tag>. An EMPTY
+#            tag resets the row to "_no current release_" — used
+#            when a stable release ships and the channel no longer
+#            has anything newer than stable.
 #
 # Behavior:
 #   - Reads README from stdin.
 #   - Lines outside the BEGIN/END block pass through verbatim.
 #   - Inside the block, the line whose label matches `channel`
-#     ("Dev" or "Experimental") is replaced with a fresh markdown
-#     bullet pointing at /releases/tag/<tag>. Other lines (including
-#     the stable line) pass through.
+#     ("Dev" or "Experimental") is replaced with either a fresh
+#     markdown bullet pointing at /releases/tag/<tag>, OR (when
+#     tag is empty) the "_no current release_" placeholder. Other
+#     lines (including the stable line) pass through.
 #   - Markers themselves pass through.
 #
 # Style mirrors `scripts/upsert-appcast-item.awk`: start-of-line
@@ -51,8 +55,12 @@ BEGIN {
 
 {
     if (in_block && label != "" && $0 ~ ("\\*\\*" label "\\*\\*")) {
-        printf("- **%s** — [%s](https://github.com/superic/av-pain-reliever/releases/tag/%s)\n",
-               label, tag, tag)
+        if (tag == "") {
+            printf("- **%s** — _no current release_\n", label)
+        } else {
+            printf("- **%s** — [%s](https://github.com/superic/av-pain-reliever/releases/tag/%s)\n",
+                   label, tag, tag)
+        }
     } else {
         print
     }


### PR DESCRIPTION
## Summary

Follow-on to #100. Today, when a stable release ships, the README's Dev and Experimental rows keep pointing at their last prerelease tag — confusing once \`Stable: latest\` and \`Dev: v0.2.0.17-dev.5\` resolve to the same content.

- \`scripts/update-readme-channel.awk\` gains an empty-tag semantic: pass \`tag=\"\"\` and the row gets reset to \`_no current release_\` (same shape as the existing placeholder).
- \`appcast-publish.yml\` grows a three-way case on \`\$VERSION_TAG\`: dev/experimental tags rewrite their own rows (unchanged); a bare stable tag walks Dev and Experimental and resets each row IF its current tag is a prerelease of the same stable version we're shipping.
- The reset rule uses **strip-prerelease equality** (\`v0.2.0.17-dev.5\` and \`v0.2.0.17\` both strip to \`v0.2.0.17\` → reset) rather than \`sort -V\`, because GNU/macOS \`sort -V\` is not a semver comparator — it puts \`v0.2.0.17\` BEFORE \`v0.2.0.17-dev.5\`, opposite of semver semantics. Strip-and-compare captures the actual intent.
- A prerelease pointing at a different version (e.g. \`v0.3.0-experimental.1\` while we ship stable \`v0.2.0.17\`) is left alone.

## Test plan

Local tests pass:

\`\`\`
./scripts/test-update-readme-channel.sh
\`\`\`

8/8 cases, including 3 new ones for the empty-tag reset behavior and the already-reset idempotent case.

CI gating:
- \`test\` (now includes the expanded \`test-update-readme-channel.sh\` harness).
- \`Analyze (actions)\` (workflow edit lint).

End-to-end verification will happen when \`v0.2.0.17\` stable ships next: after that release publishes, \`appcast-publish.yml\` should commit a README diff that reads \`Dev: _no current release_\`. Experimental row was already empty so it'll stay empty (no diff).

If anything went wrong, the failure mode is benign: README rows stay pointing at stale tags. The maintainer can edit them by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)