### PR TITLE
feat(menu): "Not a Location" dismiss + clear stuck unknown-location state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,43 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### Slop-review follow-up on the dismiss-a-location feature (2026-05-17)
+
+Six mechanical fixes applied after `/code-quality:slop` on the dismiss-a-location diff:
+
+1. Dropped the dead pluralization branch in `IgnoredLocationRow.headline` (the `count == 1 ? "" : "s"` ternary was unreachable because the early-return handles count == 1).
+2. Replaced `Image(systemName: "cable.connector")` in `IgnoredLocationRow` with `Theme.Symbol.usbSection`. `Theme.swift` retired `cable.connector` for the stick-figure-at-small-sizes reason; the sibling `ProfileRow` was already on the replacement glyph. The row's own doc comment says "mirrors `ProfileRow`'s layout" — now it actually does.
+3. Bumped the `ignoredLocations` JSON encode-failure log line from `.debug` to `.error`. Silent data loss was logged at a level that's invisible in the support-log export.
+4. Factored `NamedUSBDevice.formatDisplayName(vendorName:name:)` as a shared static so `IgnoredLocation.Device.displayName` defers to the same fallback ladder. Removes a near-copy that had drifted on the `(nil, nil)` branch (was rendering "USB 05ac:12a8", now matches the wizard's "(unnamed device)" fallback).
+5. Extracted `AppDelegate.clearUnknownLocationState()`. The triple-clear pattern was open-coded in four sites with subtle drift — one site forgot `notifiedUnknownLocation`, another forgot `lastUnknownDevices`. One method now owns the reset; all four exit edges call it.
+6. Moved name capture from click-time (in `ignoreCurrentUnknownLocation`) to signal-time (in `handleUnknownLocation`). New private `lastUnknownDevicesNamed: [NamedUSBDevice]` is populated alongside `lastUnknownDevices` via a transient `IOKitUSBWatcher`; the dismiss button now reads the stored snapshot. Eliminates the race window where unplugging between signal and click would persist hex instead of names.
+
+All 273 tests still pass; no behavior change beyond the consistency fixes.
+
+### Dismiss-a-location: "Not a Location" + per-fingerprint ignore list (2026-05-17)
+
+Some unknown-location plug-ins aren't real places — a phone on the couch, a friend's USB stick, a random hub. The menu's "Set Up Location…" prompt was the only affordance for those, and there was no way to say "no, never ask about this combination again."
+
+Added a "Not a Location" item next to "Set Up Location…" (only visible when `atUnknownLocation` is true). Clicking it captures the canonical fingerprint of the currently-attached USB set + the device names IOKit reports for them, persists that as an entry in `SettingsStore.ignoredLocations`, and clears the in-memory unknown-location state so the menu hides the affordance immediately. Subsequent plug-ins of the same combination short-circuit in `handleUnknownLocation` — no toast, no menu prompt.
+
+Persistence model:
+
+- New struct `IgnoredLocation` (codable, `key + devices + dismissedAt`) and a `LocationFingerprint.canonical(for:)` helper that produces a stable pipe-joined `vid:pid[/serial]` string regardless of `Set<USBDevice>` enumeration order. Serials participate in the key so two physically-distinct units of the same model don't collide.
+- `SettingsStore` adds `ignoredLocations`, `isLocationIgnored(key:)`, `ignoreLocation(_:)`, `unignoreLocation(key:)`. Stored as JSON `Data` under the `ignoredLocations` UserDefaults key — the entries carry nested structs + a Date, so plist-of-dicts wasn't a clean fit. Empty list removes the key entirely, preserving the lazy-default-on-read pattern the other caches use.
+- Un-ignore path: a new "Ignored Locations" `Section` at the bottom of Settings → Profiles renders each entry with its device names + relative dismiss time and an `arrow.uturn.backward` button. `AppDelegate.unignoreLocation(key:)` removes the entry and calls `engine?.evaluate()` so a currently-attached set that just got un-ignored re-prompts without unplug/replug.
+
+Menu label also shortened from "Set Up This Location…" to "Set Up Location…". `MenuBarExtra(.menu)` sizes the underlying NSMenu on first render and doesn't widen when conditional items appear later — once the rest of the menu had been measured without the unknown-location row, the longer string ended up middle-truncated as "Set Up...ocation…". Dropping "This" keeps the label within the existing menu width.
+
+Tests: 6 new cases in `SettingsStoreTests` covering ignore round-trip, replacement on duplicate keys, un-ignore clears the UserDefaults key, fresh-store doesn't seed, and the canonical-fingerprint helper's order-independence + serial sensitivity.
+
+### Clear `atUnknownLocation` when the user unplugs back to the laptop (2026-05-17)
+
+`atUnknownLocation` is the flag behind the menu's "Set Up This Location…" affordance. The engine only fires the *entering* edge (`onUnknownLocation` when the fallback profile resolves with USB devices attached); the flag was cleared in `handleProfileApplied` only when a profile with a **non-empty fingerprint** resolved. The Laptop profile is the empty-fingerprint fallback, so the unplug-everything path (fallback + no devices) skipped the clear and the menu kept showing "Set Up This Location…" indefinitely.
+
+Repro: on Laptop with nothing attached, plug in any device that doesn't match a profile (a phone, a random USB stick), then unplug it. The "New location detected" toast fires correctly on plug-in, but "Set Up This Location…" stuck around after unplug.
+
+Fix in `engine.onDevicesEvaluated`: when the attached set is empty, clear `atUnknownLocation`, `lastUnknownDevices`, and re-arm `notifiedUnknownLocation`. `onDevicesEvaluated` fires before `onUnknownLocation` in the engine's evaluation pass, and `onUnknownLocation` requires a non-empty attached set to fire, so there's no ordering hazard — the clear sticks. The non-empty-fingerprint clear branch in `handleProfileApplied` still handles the other transition (user moves directly from unknown location to a known one without going through undocked).
+
 ### Stable release auto-clears the Dev/Experimental README rows (2026-05-13)
 
 Follow-on to #100. The README's "Release channels" block had three rows; Dev and Experimental were auto-filled on every dev/experimental release publish, but **when a stable release shipped, the obsolete prerelease rows kept pointing at their last tag.** Looked confusing: "Dev: v0.2.0.17-dev.5" sitting under "Stable: latest" once the stable is what `latest` resolves to anyway.

--- a/Sources/AVPainReliever/Engine/USBWatcher.swift
+++ b/Sources/AVPainReliever/Engine/USBWatcher.swift
@@ -33,6 +33,16 @@ public struct NamedUSBDevice: Hashable, Sendable, Identifiable {
     /// product name when both are available; falls back to whichever
     /// is set; falls back to `(unnamed device)` when neither is.
     public var displayName: String {
+        Self.formatDisplayName(vendorName: vendorName, name: name)
+    }
+
+    /// Shared label-formatting ladder for callers that hold the
+    /// vendor + product strings directly (e.g. the app's persisted
+    /// `IgnoredLocation.Device`, which can't carry a live
+    /// `NamedUSBDevice`). Keeps the wizard list and the Settings →
+    /// Profiles "Ignored Locations" list rendering names identically
+    /// for the same `(vendorName, name)` pair.
+    public static func formatDisplayName(vendorName: String?, name: String?) -> String {
         switch (vendorName, name) {
         case let (.some(v), .some(n)): return "\(v) — \(n)"
         case (.some(let v), .none):    return v

--- a/Sources/AVPainRelieverApp/App.swift
+++ b/Sources/AVPainRelieverApp/App.swift
@@ -195,12 +195,28 @@ private struct MenuContentView: View {
             // step. The wizard pre-selects all currently-attached
             // devices anyway, so the user just needs to pick a name
             // and hit Save.
+            //
+            // Label kept short ("Set Up Location…" not "Set Up THIS
+            // Location…") because SwiftUI's MenuBarExtra(.menu) sizes
+            // the underlying NSMenu on first render and doesn't widen
+            // when conditional items appear later — a longer string
+            // ended up middle-truncated as "Set Up...ocation…" once
+            // the rest of the menu had been measured without it.
             Button {
                 delegate.beginAddingProfile()
                 openWindow(id: addProfileWindowID)
                 NSApp.activate(ignoringOtherApps: true)
             } label: {
-                Label("Set Up This Location…", systemImage: "plus.circle.fill")
+                Label("Set Up Location…", systemImage: "plus.circle.fill")
+            }
+            // Escape hatch: this device combination isn't a real
+            // place (phone on the couch, random USB stick). Records
+            // the fingerprint so subsequent plug-ins don't re-prompt;
+            // un-ignore lives in Settings → Profiles.
+            Button {
+                delegate.ignoreCurrentUnknownLocation()
+            } label: {
+                Label("Not a Location", systemImage: "xmark.circle")
             }
             Divider()
         }

--- a/Sources/AVPainRelieverApp/AppDelegate.swift
+++ b/Sources/AVPainRelieverApp/AppDelegate.swift
@@ -75,6 +75,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// the menu lands in the form with the right devices selected.
     @Published var lastUnknownDevices: Set<USBDevice> = []
 
+    /// Named-device snapshot taken at unknown-location signal time.
+    /// Populated alongside `lastUnknownDevices` via a transient
+    /// `IOKitUSBWatcher.currentDevicesNamed()` call so the
+    /// "Not a Location" dismiss button can persist real product +
+    /// vendor names instead of re-enumerating at click time (which
+    /// would race against the user unplugging in the same instant).
+    private var lastUnknownDevicesNamed: [NamedUSBDevice] = []
+
     private var engine: Engine?
 
     /// Watches `profiles.toml` for out-of-band edits and triggers a
@@ -423,6 +431,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             // gates on `statsTrackingEnabled` internally — when the
             // user has tracking off, this is a no-op.
             self?.settings.recordDevicesSeen(devices)
+
+            // Leaving the unknown-location state when the user
+            // unplugs everything. The engine's `onUnknownLocation`
+            // only fires the entering edge; without this, the
+            // fallback profile + empty attached set keeps the flag
+            // stuck because `handleProfileApplied`'s clear branch
+            // only runs for non-empty-fingerprint profiles.
+            if devices.isEmpty {
+                self?.clearUnknownLocationState()
+            }
         }
         engine.start()
         self.engine = engine
@@ -508,18 +526,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         // the fallback path; getting back to a real-fingerprint
         // resolution means we're at a known place again.
         if !profile.fingerprint.isEmpty {
-            notifiedUnknownLocation = false
-            atUnknownLocation = false
-            lastUnknownDevices = []
+            clearUnknownLocationState()
         }
     }
 
     private func handleUnknownLocation(devices: Set<USBDevice>) {
+        // Honor the user's prior dismissal. Pre-existing entries on
+        // the ignored list short-circuit before we touch any UI
+        // state, so a known-uninteresting device set (phone on the
+        // couch, random USB stick) never resurrects the menu prompt
+        // or the toast on subsequent plug-ins.
+        let key = LocationFingerprint.canonical(for: devices)
+        if settings.isLocationIgnored(key: key) {
+            logger.debug("handleUnknownLocation: ignored fingerprint \(key) — suppressing UI")
+            clearUnknownLocationState()
+            return
+        }
+
         // Always update the status so the menu reflects the new
         // location even if we've already toasted about it. Setting
         // these every time is cheap and keeps the menu accurate.
         atUnknownLocation = true
         lastUnknownDevices = devices
+        // Capture names *now* so a later "Not a Location" click
+        // doesn't race with the user unplugging — see
+        // `lastUnknownDevicesNamed` doc comment. Filter to the
+        // engine-reported set so we don't accidentally persist
+        // names for devices that weren't part of the unknown
+        // fingerprint (the IOKit re-enumeration runs against the
+        // live system, which is a superset only on race conditions
+        // but cheap to guard against).
+        let nameWatcher = IOKitUSBWatcher(logger: ConsoleLogger(category: "unknown-location-watcher"))
+        lastUnknownDevicesNamed = nameWatcher.currentDevicesNamed().filter { devices.contains($0.device) }
 
         // One toast per "stretch of unknown-ness" — re-armed when the
         // user resolves to a specific profile. Avoids spamming when
@@ -711,6 +749,72 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             failure.icon = AppIcon.image
             failure.runModal()
         }
+    }
+
+    /// Dismiss the current "new location" suggestion. Persists the
+    /// fingerprint of the attached device set so subsequent plug-ins
+    /// of the same combination don't re-toast or re-show the
+    /// "Set Up Location…" menu item. Reachable from the menu when
+    /// `atUnknownLocation` is true.
+    ///
+    /// Reads names from `lastUnknownDevicesNamed`, populated at
+    /// signal time, so dismissing in the middle of an unplug doesn't
+    /// lose the names — same fingerprint key, names captured when
+    /// devices were still attached.
+    func ignoreCurrentUnknownLocation() {
+        let devices = lastUnknownDevices
+        guard !devices.isEmpty else { return }
+        let key = LocationFingerprint.canonical(for: devices)
+        logger.debug("ignoreCurrentUnknownLocation: key=\(key) devices=\(devices.count)")
+
+        let namesByDevice = Dictionary(uniqueKeysWithValues: lastUnknownDevicesNamed.map { ($0.device, $0) })
+        let entries: [IgnoredLocation.Device] = devices.map { device in
+            let lookup = namesByDevice[device]
+            return IgnoredLocation.Device(
+                vendorID: device.vendorID,
+                productID: device.productID,
+                serialNumber: device.serialNumber,
+                name: lookup?.name,
+                vendorName: lookup?.vendorName
+            )
+        }
+
+        settings.ignoreLocation(IgnoredLocation(
+            key: key,
+            devices: entries,
+            dismissedAt: Date()
+        ))
+
+        // Hide the affordance immediately without waiting for the
+        // next engine evaluation.
+        clearUnknownLocationState()
+    }
+
+    /// Reset every field that participates in the unknown-location
+    /// UI. Called from each exit edge (profile match resolves, all
+    /// devices unplugged, user dismisses, fingerprint is ignored)
+    /// so the four exit sites stay in lockstep — forgetting one
+    /// field at one site is how wedge states sneak in.
+    private func clearUnknownLocationState() {
+        atUnknownLocation = false
+        lastUnknownDevices = []
+        lastUnknownDevicesNamed = []
+        notifiedUnknownLocation = false
+    }
+
+    /// Remove a previously-dismissed fingerprint from the ignored
+    /// list. Wired to the "Un-ignore" button on each row of the
+    /// Settings → Profiles "Ignored locations" section. Subsequent
+    /// plug-ins of the matching device set will re-prompt as usual.
+    func unignoreLocation(key: String) {
+        logger.debug("unignoreLocation: key=\(key)")
+        settings.unignoreLocation(key: key)
+        // Force a fresh engine evaluation so a currently-attached
+        // device set that just got un-ignored re-triggers the
+        // unknown-location prompt without the user having to
+        // unplug/replug. `engine?.evaluate()` runs synchronously and
+        // bypasses the debounce window.
+        engine?.evaluate()
     }
 
     // MARK: - Bootstrap

--- a/Sources/AVPainRelieverApp/IgnoredLocation.swift
+++ b/Sources/AVPainRelieverApp/IgnoredLocation.swift
@@ -1,0 +1,77 @@
+import Foundation
+import AVPainReliever
+
+/// A dismissed "new location" suggestion. Persisted in `SettingsStore`
+/// under `ignoredLocations` so the engine stops surfacing the same
+/// fingerprint after the user marks it as not-a-real-location.
+///
+/// Keyed by the canonical fingerprint string of the attached USB set
+/// (see `LocationFingerprint.canonical`). `devices` is display-only —
+/// it carries the names captured at dismiss time so the Settings →
+/// Profiles "Ignored locations" list can render "iPhone" instead of
+/// raw vid:pid hex.
+struct IgnoredLocation: Codable, Hashable, Identifiable {
+    /// Canonical fingerprint string for the attached device set.
+    /// Stable across launches: same devices in the same combination
+    /// produce the same key.
+    let key: String
+
+    /// The devices that made up the dismissed location. Display-only;
+    /// matching uses `key`.
+    let devices: [Device]
+
+    /// When the user dismissed the location. Surfaced in the Settings
+    /// list as relative-time ("2h ago") to help the user remember
+    /// which one they intended to un-ignore.
+    let dismissedAt: Date
+
+    var id: String { key }
+
+    struct Device: Codable, Hashable {
+        let vendorID: Int
+        let productID: Int
+        let serialNumber: String?
+        /// USB Product Name as IOKit reported it. May be nil for
+        /// devices that don't expose one (cheap hubs, multi-function
+        /// device legs).
+        let name: String?
+        /// USB Vendor Name as IOKit reported it. Same nil semantics.
+        let vendorName: String?
+
+        /// Defers to `NamedUSBDevice.formatDisplayName` so the
+        /// Settings → Profiles "Ignored Locations" list and the
+        /// wizard's device picker render names identically for the
+        /// same `(vendorName, name)` pair. (none, none) falls back
+        /// to `"(unnamed device)"` — capturing devices via the
+        /// transient watcher at dismiss time means we almost always
+        /// have at least a vendor name.
+        var displayName: String {
+            NamedUSBDevice.formatDisplayName(vendorName: vendorName, name: name)
+        }
+    }
+}
+
+/// Canonical string fingerprint for an attached device set. The same
+/// `Set<USBDevice>` always produces the same string regardless of
+/// enumeration order; two different sets always produce different
+/// strings.
+///
+/// Format: pipe-joined `vid:pid[/serial]` entries, sorted by
+/// `(vid, pid, serial ?? "")`. Hex is lowercase 4-char so a casual
+/// `defaults read` is human-readable.
+enum LocationFingerprint {
+    static func canonical(for devices: Set<USBDevice>) -> String {
+        let sorted = devices.sorted { lhs, rhs in
+            if lhs.vendorID != rhs.vendorID { return lhs.vendorID < rhs.vendorID }
+            if lhs.productID != rhs.productID { return lhs.productID < rhs.productID }
+            return (lhs.serialNumber ?? "") < (rhs.serialNumber ?? "")
+        }
+        return sorted.map { device in
+            let base = String(format: "%04x:%04x", device.vendorID, device.productID)
+            if let serial = device.serialNumber, !serial.isEmpty {
+                return "\(base)/\(serial)"
+            }
+            return base
+        }.joined(separator: "|")
+    }
+}

--- a/Sources/AVPainRelieverApp/SettingsStore.swift
+++ b/Sources/AVPainRelieverApp/SettingsStore.swift
@@ -36,6 +36,7 @@ final class SettingsStore: ObservableObject {
         static let rememberedAudioInputs = "rememberedAudioInputs"
         static let rememberedAudioOutputs = "rememberedAudioOutputs"
         static let rememberedCameras = "rememberedCameras"
+        static let ignoredLocations = "ignoredLocations"
     }
 
     /// Toast on profile change?  Default on — the at-a-glance signal
@@ -264,6 +265,21 @@ final class SettingsStore: ObservableObject {
         didSet { write(rememberedCameras, forKey: Key.rememberedCameras) }
     }
 
+    /// Device fingerprints the user has dismissed as "not a location"
+    /// — e.g. plugging their phone into the laptop on the couch isn't
+    /// a real place to capture, just a passing thing. The menu's "Not
+    /// a location" button writes here; the engine consults
+    /// `isLocationIgnored` and suppresses both the toast and the
+    /// "Set Up Location…" affordance for any matching key.
+    ///
+    /// Persisted as a JSON blob (Codable→Data) because the entries
+    /// carry nested structs + a Date; the dict-of-plist approach the
+    /// other caches use would force the same fields through
+    /// stringly-typed indirection on every read.
+    @Published var ignoredLocations: [IgnoredLocation] {
+        didSet { writeIgnoredLocations(ignoredLocations) }
+    }
+
     /// True when any profile's remembered-device cache has at least
     /// one entry. Drives the Settings → General "Forget unused
     /// devices" affordance, which only renders when there's
@@ -357,6 +373,66 @@ final class SettingsStore: ObservableObject {
         self.rememberedAudioInputs = (defaults.object(forKey: Key.rememberedAudioInputs) as? [String: [String]]) ?? [:]
         self.rememberedAudioOutputs = (defaults.object(forKey: Key.rememberedAudioOutputs) as? [String: [String]]) ?? [:]
         self.rememberedCameras = (defaults.object(forKey: Key.rememberedCameras) as? [String: [String]]) ?? [:]
+        self.ignoredLocations = Self.readIgnoredLocations(from: defaults)
+    }
+
+    /// Look up whether a canonical location fingerprint is on the
+    /// ignored list. Returns false for the empty list, which is the
+    /// install-default state.
+    func isLocationIgnored(key: String) -> Bool {
+        ignoredLocations.contains(where: { $0.key == key })
+    }
+
+    /// Add `entry` to the ignored list. Replaces any existing entry
+    /// with the same key (re-ignoring an un-ignored location updates
+    /// the captured device names + dismiss time without leaving a
+    /// stale duplicate). No-op if `key` is empty.
+    func ignoreLocation(_ entry: IgnoredLocation) {
+        guard !entry.key.isEmpty else { return }
+        var updated = ignoredLocations.filter { $0.key != entry.key }
+        updated.append(entry)
+        ignoredLocations = updated
+    }
+
+    /// Remove the entry with the given canonical key. No-op if no
+    /// matching entry exists.
+    func unignoreLocation(key: String) {
+        let filtered = ignoredLocations.filter { $0.key != key }
+        guard filtered.count != ignoredLocations.count else { return }
+        ignoredLocations = filtered
+    }
+
+    /// JSON-decode the persisted blob. Returns an empty list when the
+    /// key is absent OR when decoding fails (which would mean a
+    /// schema migration ate the data — we'd rather drop ignores than
+    /// crash on launch).
+    private static func readIgnoredLocations(from defaults: UserDefaults) -> [IgnoredLocation] {
+        guard let data = defaults.data(forKey: Key.ignoredLocations) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (try? decoder.decode([IgnoredLocation].self, from: data)) ?? []
+    }
+
+    /// JSON-encode and write the list. Empty list clears the key
+    /// entirely so a fresh install sees no leftover ignores from a
+    /// prior re-installation under the same domain.
+    private func writeIgnoredLocations(_ list: [IgnoredLocation]) {
+        if list.isEmpty {
+            defaults.removeObject(forKey: Key.ignoredLocations)
+            Self.logger.debug("wrote key=\(Key.ignoredLocations) value=nil (cleared)")
+            return
+        }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(list) else {
+            // Silent data loss otherwise: the user's dismissals would
+            // disappear with no diagnostic trail at .debug. Surface
+            // it at .error so it appears in the support-log export.
+            Self.logger.error("encode failed for key=\(Key.ignoredLocations); \(list.count) ignored-location entries NOT persisted")
+            return
+        }
+        defaults.set(data, forKey: Key.ignoredLocations)
+        Self.logger.debug("wrote key=\(Key.ignoredLocations) value=<\(list.count) entries>")
     }
 
     /// Bump the lifetime switch counter that drives the easter-egg

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -38,7 +38,7 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.general)
 
-            ProfilesSettingsTab(delegate: delegate)
+            ProfilesSettingsTab(delegate: delegate, settings: settings)
                 .tabItem {
                     Label("Profiles", systemImage: "list.bullet.rectangle")
                 }
@@ -359,6 +359,7 @@ private struct GeneralSettingsTab: View {
 
 private struct ProfilesSettingsTab: View {
     @ObservedObject var delegate: AppDelegate
+    @ObservedObject var settings: SettingsStore
     @Environment(\.openWindow) private var openWindow
     // Native SwiftUI .alert() for delete confirmation — matches the
     // Stats tab's "Reset stats?" pattern. Was an NSAlert on
@@ -367,21 +368,48 @@ private struct ProfilesSettingsTab: View {
 
     var body: some View {
         Group {
-            if delegate.availableProfiles.isEmpty {
+            if delegate.availableProfiles.isEmpty && settings.ignoredLocations.isEmpty {
                 emptyState
             } else {
                 List {
-                    ForEach(delegate.availableProfiles, id: \.name) { profile in
-                        ProfileRow(
-                            profile: profile,
-                            isActive: profile.name == delegate.activeProfileSlug,
-                            onEdit: {
-                                delegate.beginEditingProfile(profile)
-                                openWindow(id: addProfileWindowID)
-                                NSApp.activate(ignoringOtherApps: true)
-                            },
-                            onDelete: { profilePendingDeletion = profile }
-                        )
+                    if !delegate.availableProfiles.isEmpty {
+                        Section {
+                            ForEach(delegate.availableProfiles, id: \.name) { profile in
+                                ProfileRow(
+                                    profile: profile,
+                                    isActive: profile.name == delegate.activeProfileSlug,
+                                    onEdit: {
+                                        delegate.beginEditingProfile(profile)
+                                        openWindow(id: addProfileWindowID)
+                                        NSApp.activate(ignoringOtherApps: true)
+                                    },
+                                    onDelete: { profilePendingDeletion = profile }
+                                )
+                            }
+                        }
+                    }
+                    if !settings.ignoredLocations.isEmpty {
+                        // Surface "Not a Location" dismissals so the
+                        // user can audit and undo them. Sorted by
+                        // most-recent first so a fresh dismissal is
+                        // visible at the top — matches the relative-
+                        // time copy ("Dismissed 5m ago").
+                        Section {
+                            ForEach(
+                                settings.ignoredLocations.sorted { $0.dismissedAt > $1.dismissedAt }
+                            ) { ignored in
+                                IgnoredLocationRow(
+                                    ignored: ignored,
+                                    onUnignore: { delegate.unignoreLocation(key: ignored.key) }
+                                )
+                            }
+                        } header: {
+                            Text("Ignored Locations")
+                        } footer: {
+                            Text("Device combinations you've dismissed as not a real place. Un-ignore one to re-enable the “Set Up Location…” prompt the next time it's attached.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 .listStyle(.inset)
@@ -572,6 +600,67 @@ private struct ProfileRow: View {
             rows.append(DeviceRow(icon: Theme.Symbol.usbSection, label: "\(count) USB device\(count == 1 ? "" : "s")"))
         }
         return rows
+    }
+}
+
+/// One row in the Profiles tab's "Ignored Locations" section.
+/// Mirrors `ProfileRow`'s leading-icon + vertical-device-list layout
+/// so the two lists visually relate — same row height, same
+/// secondary-text styling, same trailing icon-only action button.
+private struct IgnoredLocationRow: View {
+    let ignored: IgnoredLocation
+    let onUnignore: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "xmark.circle")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(headline)
+                    .font(.body.weight(.medium))
+                ForEach(ignored.devices, id: \.self) { device in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: Theme.Symbol.usbSection)
+                            .frame(width: 14, alignment: .center)
+                        Text(device.displayName)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                Text("Dismissed \(relativeDismissedAt)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            IconButton(
+                systemImage: "arrow.uturn.backward",
+                accessibilityLabel: "Un-ignore this location",
+                action: onUnignore
+            )
+        }
+        .padding(.vertical, 6)
+    }
+
+    /// Title line. Prefers the friendliest single device name available
+    /// when there's only one device in the fingerprint — e.g. "iPhone"
+    /// — so the user instantly recognises the row. Falls back to a
+    /// device-count summary for multi-device combinations.
+    private var headline: String {
+        if ignored.devices.count == 1, let only = ignored.devices.first {
+            return only.displayName
+        }
+        return "\(ignored.devices.count) devices"
+    }
+
+    private var relativeDismissedAt: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: ignored.dismissedAt, relativeTo: Date())
     }
 }
 

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -394,6 +394,12 @@ private struct ProfilesSettingsTab: View {
                         // most-recent first so a fresh dismissal is
                         // visible at the top — matches the relative-
                         // time copy ("Dismissed 5m ago").
+                        //
+                        // Helper text is rendered as the last row
+                        // inside the Section body, not in the
+                        // `footer:` slot — macOS 14's List footer
+                        // doesn't wrap, so a long string clips out
+                        // of the window (see `feedback_swiftui_form_footer`).
                         Section {
                             ForEach(
                                 settings.ignoredLocations.sorted { $0.dismissedAt > $1.dismissedAt }
@@ -403,12 +409,31 @@ private struct ProfilesSettingsTab: View {
                                     onUnignore: { delegate.unignoreLocation(key: ignored.key) }
                                 )
                             }
-                        } header: {
-                            Text("Ignored Locations")
-                        } footer: {
-                            Text("Device combinations you've dismissed as not a real place. Un-ignore one to re-enable the “Set Up Location…” prompt the next time it's attached.")
+                            Text("Device combinations you've dismissed as not a real place. Remove one to re-enable the “Set Up Location…” prompt the next time it's attached.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.vertical, 4)
+                        } header: {
+                            // `Form { Section { … } header: { Label(…) } }` in
+                            // the General tab gets a prominent bold-icon +
+                            // bold-text rendering out of the box, but
+                            // `List { Section { … } header: { Label(…) } }`
+                            // does not — SwiftUI defaults a List header to a
+                            // smaller, regular-weight style. Match the
+                            // General tab look by rendering Image + Text
+                            // separately so the icon can keep `.title3`
+                            // sizing while the text drops to `.headline`
+                            // (body-size semibold) — `Label` would scale
+                            // the icon to the text and shrink it.
+                            HStack(spacing: 6) {
+                                Image(systemName: "bell.slash")
+                                    .font(.title3.weight(.semibold))
+                                Text("Ignored Locations")
+                                    .font(.headline)
+                            }
+                            .foregroundStyle(.primary)
+                            .padding(.top, 4)
                         }
                     }
                 }
@@ -613,7 +638,14 @@ private struct IgnoredLocationRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
-            Image(systemName: "xmark.circle")
+            // questionmark.circle mirrors the menu-bar icon shown
+            // when the engine is *at* an unknown location — visual
+            // consistency between "we don't know this place" and
+            // "you told us not to ask about this place." `xmark.circle`
+            // here read as an actionable remove-button next to the
+            // text, which fought the actual remove control on the
+            // trailing edge.
+            Image(systemName: "questionmark.circle")
                 .font(.title3)
                 .foregroundStyle(.secondary)
                 .frame(width: 28)
@@ -637,9 +669,15 @@ private struct IgnoredLocationRow: View {
                     .foregroundStyle(.tertiary)
             }
             Spacer()
+            // Trash icon to match `ProfileRow`'s delete affordance —
+            // the user's mental model is "remove this entry from
+            // the ignored list." Not marked `.destructive` because
+            // the side-effect (re-enabling the prompt next time
+            // these devices are attached) is benign; red would
+            // overstate the consequence.
             IconButton(
-                systemImage: "arrow.uturn.backward",
-                accessibilityLabel: "Un-ignore this location",
+                systemImage: "trash",
+                accessibilityLabel: "Remove from ignored list",
                 action: onUnignore
             )
         }

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -880,6 +880,34 @@ struct SettingsStoreTests {
         #expect(defaults.object(forKey: SettingsStore.Key.ignoredLocations) == nil)
     }
 
+    @Test("garbage JSON in ignoredLocations is recovered to an empty list, not a crash")
+    func ignoredLocationsDecodeFailureRecovers() {
+        let defaults = makeSuite()
+        // Plant malformed bytes under the key — could happen after a
+        // future schema change, a UserDefaults corruption, or a buggy
+        // hand-edit via `defaults write`. Production says we'd rather
+        // drop the ignores than crash on launch.
+        defaults.set(Data("not valid json".utf8), forKey: SettingsStore.Key.ignoredLocations)
+
+        let store = SettingsStore(defaults: defaults)
+        #expect(store.ignoredLocations.isEmpty)
+        #expect(!store.isLocationIgnored(key: "any-key"))
+
+        // Subsequent writes must still work — a wedged read path must
+        // not poison the write path. Adding an entry should overwrite
+        // the malformed blob with a clean JSON document, and a fresh
+        // store opened against the same defaults should now see it.
+        let entry = IgnoredLocation(
+            key: "05ac:12a8",
+            devices: [],
+            dismissedAt: Date()
+        )
+        store.ignoreLocation(entry)
+        let reopened = SettingsStore(defaults: defaults)
+        #expect(reopened.ignoredLocations.count == 1)
+        #expect(reopened.isLocationIgnored(key: entry.key))
+    }
+
     @Test("LocationFingerprint.canonical is stable regardless of insertion order")
     func locationFingerprintIsOrderStable() {
         let a = USBDevice(vendorID: 0x05ac, productID: 0x12a8)

--- a/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
+++ b/Tests/AVPainRelieverAppTests/SettingsStoreTests.swift
@@ -798,6 +798,114 @@ struct SettingsStoreTests {
         #expect(defaults.object(forKey: SettingsStore.Key.rememberedCameras) == nil)
     }
 
+    @Test("ignoreLocation persists across reloads")
+    func ignoreLocationRoundTrip() {
+        let defaults = makeSuite()
+        let entry = IgnoredLocation(
+            key: "05ac:12a8",
+            devices: [
+                IgnoredLocation.Device(
+                    vendorID: 0x05ac,
+                    productID: 0x12a8,
+                    serialNumber: nil,
+                    name: "iPhone",
+                    vendorName: "Apple Inc."
+                )
+            ],
+            dismissedAt: Date()
+        )
+        do {
+            let store = SettingsStore(defaults: defaults)
+            #expect(store.ignoredLocations.isEmpty)
+            #expect(!store.isLocationIgnored(key: entry.key))
+            store.ignoreLocation(entry)
+            #expect(store.isLocationIgnored(key: entry.key))
+        }
+        let reopened = SettingsStore(defaults: defaults)
+        #expect(reopened.ignoredLocations.count == 1)
+        #expect(reopened.isLocationIgnored(key: entry.key))
+        #expect(reopened.ignoredLocations.first?.devices.first?.displayName == "Apple Inc. — iPhone")
+    }
+
+    @Test("ignoreLocation replaces an existing entry with the same key")
+    func ignoreLocationReplacesDuplicates() {
+        let store = SettingsStore(defaults: makeSuite())
+        let first = IgnoredLocation(
+            key: "05ac:12a8",
+            devices: [],
+            dismissedAt: Date(timeIntervalSince1970: 1)
+        )
+        let second = IgnoredLocation(
+            key: "05ac:12a8",
+            devices: [
+                IgnoredLocation.Device(
+                    vendorID: 0x05ac, productID: 0x12a8,
+                    serialNumber: nil, name: "iPhone", vendorName: "Apple"
+                )
+            ],
+            dismissedAt: Date(timeIntervalSince1970: 2)
+        )
+        store.ignoreLocation(first)
+        store.ignoreLocation(second)
+        #expect(store.ignoredLocations.count == 1)
+        // The second write wins (newer dismissedAt + populated device
+        // list) — so a user who un-ignores then re-ignores gets the
+        // fresher snapshot of names, not the stale one.
+        #expect(store.ignoredLocations.first?.devices.count == 1)
+        #expect(store.ignoredLocations.first?.dismissedAt.timeIntervalSince1970 == 2)
+    }
+
+    @Test("unignoreLocation removes the matching entry and clears storage when empty")
+    func unignoreLocationClears() {
+        let defaults = makeSuite()
+        let entry = IgnoredLocation(
+            key: "05ac:12a8",
+            devices: [],
+            dismissedAt: Date()
+        )
+        let store = SettingsStore(defaults: defaults)
+        store.ignoreLocation(entry)
+        #expect(defaults.data(forKey: SettingsStore.Key.ignoredLocations) != nil)
+        store.unignoreLocation(key: entry.key)
+        #expect(store.ignoredLocations.isEmpty)
+        // Empty list clears the key entirely so a re-installation
+        // under the same defaults domain doesn't see ghost entries.
+        #expect(defaults.object(forKey: SettingsStore.Key.ignoredLocations) == nil)
+    }
+
+    @Test("constructing a fresh SettingsStore does not seed ignoredLocations on disk")
+    func freshStoreDoesNotWriteIgnoredLocations() {
+        let defaults = makeSuite()
+        _ = SettingsStore(defaults: defaults)
+        #expect(defaults.object(forKey: SettingsStore.Key.ignoredLocations) == nil)
+    }
+
+    @Test("LocationFingerprint.canonical is stable regardless of insertion order")
+    func locationFingerprintIsOrderStable() {
+        let a = USBDevice(vendorID: 0x05ac, productID: 0x12a8)
+        let b = USBDevice(vendorID: 0x2188, productID: 0x6533)
+        let c = USBDevice(vendorID: 0x043e, productID: 0x9a68, serialNumber: "ABC123")
+        let s1: Set<USBDevice> = [a, b, c]
+        let s2: Set<USBDevice> = [c, a, b]
+        #expect(LocationFingerprint.canonical(for: s1) == LocationFingerprint.canonical(for: s2))
+        // Empty set produces empty string — handy for the AppDelegate
+        // short-circuit when no devices are attached.
+        #expect(LocationFingerprint.canonical(for: []) == "")
+    }
+
+    @Test("LocationFingerprint.canonical distinguishes different serials of the same vid/pid")
+    func locationFingerprintIncludesSerial() {
+        let withSerial = USBDevice(vendorID: 0x043e, productID: 0x9a68, serialNumber: "HOME")
+        let otherSerial = USBDevice(vendorID: 0x043e, productID: 0x9a68, serialNumber: "WORK")
+        let noSerial = USBDevice(vendorID: 0x043e, productID: 0x9a68, serialNumber: nil)
+        let k1 = LocationFingerprint.canonical(for: [withSerial])
+        let k2 = LocationFingerprint.canonical(for: [otherSerial])
+        let k3 = LocationFingerprint.canonical(for: [noSerial])
+        #expect(k1 != k2)
+        #expect(k1 != k3)
+        #expect(k2 != k3)
+    }
+
     @Test("stats fields persist across reloads")
     func statsFieldsRoundTrip() {
         let defaults = makeSuite()

--- a/Tests/AVPainRelieverTests/IOKitUSBWatcherTests.swift
+++ b/Tests/AVPainRelieverTests/IOKitUSBWatcherTests.swift
@@ -51,3 +51,68 @@ struct IOKitUSBWatcherTests {
         watcher.stop()
     }
 }
+
+/// Pure-function coverage for `NamedUSBDevice.formatDisplayName`, the
+/// shared label ladder both the wizard's device picker and the
+/// Settings → Profiles "Ignored Locations" list defer to. Worth
+/// pinning all four arms because the fallback case (neither vendor
+/// nor product name) is the one IOKit hits for cheap hubs and
+/// multi-function-device legs.
+@Suite("NamedUSBDevice.formatDisplayName")
+struct NamedUSBDeviceFormatDisplayNameTests {
+    @Test("vendor + product → 'Vendor — Product'")
+    func bothPresent() {
+        #expect(
+            NamedUSBDevice.formatDisplayName(
+                vendorName: "Apple Inc.",
+                name: "iPhone"
+            ) == "Apple Inc. — iPhone"
+        )
+    }
+
+    @Test("vendor only → vendor")
+    func vendorOnly() {
+        #expect(
+            NamedUSBDevice.formatDisplayName(
+                vendorName: "LG Electronics",
+                name: nil
+            ) == "LG Electronics"
+        )
+    }
+
+    @Test("product only → product")
+    func productOnly() {
+        #expect(
+            NamedUSBDevice.formatDisplayName(
+                vendorName: nil,
+                name: "CalDigit Thunderbolt 3 Audio"
+            ) == "CalDigit Thunderbolt 3 Audio"
+        )
+    }
+
+    @Test("neither → '(unnamed device)' sentinel")
+    func neitherPresent() {
+        // The sentinel is load-bearing for the wizard — without it
+        // the device row would render an empty label, which reads
+        // as a layout bug. Pin the exact string so a future
+        // copy-edit of NamedUSBDevice.displayName doesn't silently
+        // diverge from the call sites that rely on this fallback.
+        #expect(
+            NamedUSBDevice.formatDisplayName(vendorName: nil, name: nil)
+                == "(unnamed device)"
+        )
+    }
+
+    @Test("empty strings are treated as present (no implicit nil-folding)")
+    func emptyStringsArePresent() {
+        // Sanity check on Swift Optional semantics — `Optional("")`
+        // is `.some`, not `.none`. The formatter should pass empty
+        // strings through rather than fold them into the
+        // `(unnamed device)` sentinel. Production callers that want
+        // empty == absent must filter before calling.
+        #expect(
+            NamedUSBDevice.formatDisplayName(vendorName: "", name: "")
+                == " — "
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two things, one feature branch:

- **Bug fix:** "Set Up Location…" stayed in the menu after the user unplugged back to the laptop fallback. The engine's `onUnknownLocation` only fires the *entering* edge, and `handleProfileApplied`'s clear branch was gated on a non-empty fingerprint — so falling back to the laptop profile with no devices attached left `atUnknownLocation` stuck `true`. Cleared on `onDevicesEvaluated` when devices is empty.
- **Feature:** New "Not a Location" dismiss flow. Per-fingerprint ignore list persisted in `SettingsStore.ignoredLocations`. Menu shows the dismiss item alongside "Set Up Location…" while `atUnknownLocation` is true; click → fingerprint goes on the list, prompt + toast suppressed forever for that exact device combination. Settings → Profiles gains an "Ignored Locations" section that lists each entry with device names + relative dismiss time and a trash button to remove it; un-ignore forces `engine.evaluate()` so a currently-attached set re-prompts without unplug/replug.

Menu label also shortened from "Set Up This Location…" to "Set Up Location…" — SwiftUI's `MenuBarExtra(.menu)` sizes the underlying NSMenu on first render and doesn't widen for conditional items, so the longer string was middle-truncating as "Set Up...ocation…" once the rest of the menu had been measured without it.

Slop-review follow-up included: shared `NamedUSBDevice.formatDisplayName` helper so the wizard's device list and the Settings ignored-list render names identically; encode-failure now logs at `.error` instead of `.debug` (silent data loss otherwise); extracted `clearUnknownLocationState()` so the four exit edges stay in lockstep; name capture moved from click-time to signal-time to remove the unplug-during-click race window; section header rendered as Image + Text so the bell-slash icon stays at `.title3` while the text drops to `.headline`, matching General's prominent header style.

## Test plan

- [x] `swift test` — 279 tests pass (was 273, +6 new: `NamedUSBDevice.formatDisplayName` arms + `ignoredLocations` decode-failure resilience)
- [x] Local install via `./dev/build --full`, hands-on tested
- [x] Original bug: plug iPhone → "Not a Location" + "Set Up Location…" show; unplug → both disappear within 1.5s
- [x] Dismiss flow: click "Not a Location" → menu items hide immediately
- [x] Persistent ignore: unplug + replug iPhone → no toast, no prompt
- [x] Settings → Profiles → Ignored Locations: header matches General's bold-icon + bold-text style, helper text wraps inside window, left glyph is question-mark-circle (non-actionable), trailing trash button removes the entry
- [x] Un-ignore round-trip: click trash → next attach re-prompts without unplug
- [x] Menu width: "Set Up Location…" no longer middle-truncates

🤖 Generated with [Claude Code](https://claude.com/claude-code)