### PR TITLE
ui(settings): Profiles tab adopts the grouped-Form chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ universal format support. v0.1.x will keep getting patch releases
 in parallel for anyone who doesn't need any of this. **Money.**
 ```
 
+### Profiles tab adopts the grouped-Form chrome (2026-05-18)
+
+The Profiles tab in Settings was the last surface still using `List` with `.listStyle(.inset)` — General, Camera, and Stats all render `Form(.grouped)` with rounded-card section chrome and prominent bold-icon + bold-text Section headers. Switched Profiles over to match. Apple's own System Settings renders list-style content (Login Items, Wi-Fi, Extensions) inside the same grouped-Form chrome, so the tab now reads as part of the same settings surface instead of drifting into List's sidebar aesthetic.
+
+Mechanical: `List { Section { ForEach … } }` → `Form { Section { ForEach … } header: { Label(…) } }.groupedFormChrome()`. The "Ignored Locations" header dropped its manual `HStack(Image + Text)` workaround (we'd built that because List headers default to a smaller, regular-weight style) — Form gives both sections the prominent rendering for free. Added a sibling "Profiles" header (`Label("Profiles", systemImage: "list.bullet.rectangle")`) for parity. Empty state, delete-confirmation alert, and `.safeAreaInset(.bottom)` `+` button bar untouched. Net diff: −29 / +18 lines.
+
+`GroupedFormChrome`'s doc comment claimed the Profiles tab was "intentionally bespoke" and didn't use the modifier. Stale — fixed.
+
 ### Slop-review follow-up on the dismiss-a-location feature (2026-05-17)
 
 Six mechanical fixes applied after `/code-quality:slop` on the dismiss-a-location diff:

--- a/Sources/AVPainRelieverApp/GroupedFormChrome.swift
+++ b/Sources/AVPainRelieverApp/GroupedFormChrome.swift
@@ -11,8 +11,7 @@ extension View {
     /// One place to change the convention. If we ever bump the
     /// padding, swap to a different formStyle, or add other shared
     /// chrome (background, frame, etc.), edit it here and every
-    /// caller follows. The Profiles Settings tab is intentionally
-    /// bespoke (no Form, different layout) and doesn't use this.
+    /// caller follows.
     ///
     /// **Don't wrap the Form in a container that adds horizontal
     /// padding.** e.g. avoid:

--- a/Sources/AVPainRelieverApp/SettingsView.swift
+++ b/Sources/AVPainRelieverApp/SettingsView.swift
@@ -371,7 +371,16 @@ private struct ProfilesSettingsTab: View {
             if delegate.availableProfiles.isEmpty && settings.ignoredLocations.isEmpty {
                 emptyState
             } else {
-                List {
+                // Form(.grouped) instead of List: matches the General /
+                // Stats tab's rounded-card chrome, prominent
+                // bold-icon + bold-text Section headers, and consistent
+                // row metrics. Apple's own System Settings renders
+                // list-style content (Login Items, Wi-Fi networks,
+                // Extensions) inside the same grouped-Form chrome, so
+                // the Profiles tab now reads as part of the same
+                // settings surface instead of drifting into List's
+                // sidebar-style aesthetic.
+                Form {
                     if !delegate.availableProfiles.isEmpty {
                         Section {
                             ForEach(delegate.availableProfiles, id: \.name) { profile in
@@ -386,20 +395,19 @@ private struct ProfilesSettingsTab: View {
                                     onDelete: { profilePendingDeletion = profile }
                                 )
                             }
+                        } header: {
+                            Label("Profiles", systemImage: "list.bullet.rectangle")
                         }
                     }
                     if !settings.ignoredLocations.isEmpty {
                         // Surface "Not a Location" dismissals so the
                         // user can audit and undo them. Sorted by
                         // most-recent first so a fresh dismissal is
-                        // visible at the top — matches the relative-
-                        // time copy ("Dismissed 5m ago").
+                        // visible at the top.
                         //
-                        // Helper text is rendered as the last row
-                        // inside the Section body, not in the
-                        // `footer:` slot — macOS 14's List footer
-                        // doesn't wrap, so a long string clips out
-                        // of the window (see `feedback_swiftui_form_footer`).
+                        // Helper text rendered as the last row inside
+                        // the Section body (not in `footer:`) per the
+                        // macOS 14 Form-footer-doesn't-wrap workaround.
                         Section {
                             ForEach(
                                 settings.ignoredLocations.sorted { $0.dismissedAt > $1.dismissedAt }
@@ -413,31 +421,12 @@ private struct ProfilesSettingsTab: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
-                                .padding(.vertical, 4)
                         } header: {
-                            // `Form { Section { … } header: { Label(…) } }` in
-                            // the General tab gets a prominent bold-icon +
-                            // bold-text rendering out of the box, but
-                            // `List { Section { … } header: { Label(…) } }`
-                            // does not — SwiftUI defaults a List header to a
-                            // smaller, regular-weight style. Match the
-                            // General tab look by rendering Image + Text
-                            // separately so the icon can keep `.title3`
-                            // sizing while the text drops to `.headline`
-                            // (body-size semibold) — `Label` would scale
-                            // the icon to the text and shrink it.
-                            HStack(spacing: 6) {
-                                Image(systemName: "bell.slash")
-                                    .font(.title3.weight(.semibold))
-                                Text("Ignored Locations")
-                                    .font(.headline)
-                            }
-                            .foregroundStyle(.primary)
-                            .padding(.top, 4)
+                            Label("Ignored Locations", systemImage: "bell.slash")
                         }
                     }
                 }
-                .listStyle(.inset)
+                .groupedFormChrome()
             }
         }
         .alert(


### PR DESCRIPTION
## Summary

The Profiles tab was the last Settings surface still using `List` with `.listStyle(.inset)`. Every other tab (General, Camera, Stats) renders `Form { ... }.groupedFormChrome()` for the rounded-card section chrome and prominent bold-icon + bold-text Section headers. Apple's own System Settings renders list-style content (Login Items, Wi-Fi networks, Extensions) inside that same grouped-Form chrome, so this brings the Profiles tab into visual parity with the rest of the settings surface.

- `List { ... }.listStyle(.inset)` → `Form { ... }.groupedFormChrome()`
- Added a sibling `Profiles` section header so the profile rows now live under a header matching the new "Ignored Locations" one
- Dropped the manual `HStack(Image + Text)` workaround on the "Ignored Locations" header (we built that to fight List's smaller-weight default; Form gives the prominent style for free, so a plain `Label` suffices)
- Stale `GroupedFormChrome` doc comment that claimed Profiles was "intentionally bespoke" fixed

Net diff: 3 files changed, +27 / −31 lines. No logic change, no test churn.

## Test plan

- [x] `swift test` — 279 green
- [x] Local install via `./dev/build --full`, hands-on tested
- [x] Profiles tab visually matches General tab: same rounded card chrome, same bold-icon + bold-text section header style, same 8pt margins
- [x] Profiles section + Ignored Locations section render side by side correctly
- [x] Empty state (no profiles + no ignored locations) still shows the hero
- [x] Bottom `+` button bar still pinned via `.safeAreaInset(.bottom)`
- [x] Edit + delete affordances on each profile row still work
- [x] Trash button on each ignored row still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)